### PR TITLE
chore: publish as scoped package @nemus-cli/nemus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Validate package.json
         run: |
           node -e "const p=require('./package.json');
-            if (p.name !== 'nemus') throw new Error('package name must be nemus');
+            if (p.name !== '@nemus-cli/nemus') throw new Error('package name must be @nemus-cli/nemus');
             if (/melio/i.test(JSON.stringify(p))) throw new Error('package.json must not reference Melio');
             if (!p.version) throw new Error('missing version');
             if (!p.bin || !p.bin.nemus) throw new Error('missing nemus bin');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: release
-      url: https://www.npmjs.com/package/nemus
+      url: https://www.npmjs.com/package/@nemus-cli/nemus
     permissions:
       contents: write   # create tag + GitHub Release
       id-token: write   # npm provenance
@@ -105,7 +105,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.detect.outputs.version }}
         run: |
-          NOTES=$(printf '## Nemus v%s\n\n```bash\nnpm install -g nemus@%s\n```\n\nSee the [CHANGELOG](https://github.com/%s/blob/main/CHANGELOG.md) for details.\n' "$VERSION" "$VERSION" "$GITHUB_REPOSITORY")
+          NOTES=$(printf '## Nemus v%s\n\n```bash\nnpm install -g @nemus-cli/nemus@%s\n```\n\nSee the [CHANGELOG](https://github.com/%s/blob/main/CHANGELOG.md) for details.\n' "$VERSION" "$VERSION" "$GITHUB_REPOSITORY")
           if gh release view "v$VERSION" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh release edit "v$VERSION" --repo "$GITHUB_REPOSITORY" \
               --title "Nemus v$VERSION" --notes "$NOTES" --draft=false --prerelease=false

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="https://github.com/me-public/nemus/actions/workflows/ci.yml"><img src="https://github.com/me-public/nemus/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
-  <a href="https://www.npmjs.com/package/nemus"><img src="https://img.shields.io/npm/v/nemus.svg" alt="npm" /></a>
+  <a href="https://www.npmjs.com/package/@nemus-cli/nemus"><img src="https://img.shields.io/npm/v/@nemus-cli/nemus.svg" alt="npm" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT" /></a>
   <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen.svg" alt="Node >= 22" />
 </p>
@@ -72,7 +72,7 @@ different problem of *many* repos in *many* independent workspaces.
 
 ```bash
 # Install globally
-npm install -g nemus
+npm install -g @nemus-cli/nemus
 
 # One-time setup (choose your GitHub org, agent, clone protocol…)
 nemus configure
@@ -93,7 +93,7 @@ After creation you're dropped into the workspace directory with all repos cloned
 ### From npm (recommended)
 
 ```bash
-npm install -g nemus
+npm install -g @nemus-cli/nemus
 ```
 
 The postinstall step sets up optional shell integration (auto-cd into new

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-Nemus is distributed on npm as [`nemus`](https://www.npmjs.com/package/nemus).
+Nemus is distributed on npm as [`@nemus-cli/nemus`](https://www.npmjs.com/package/@nemus-cli/nemus).
 Security fixes are released against the **latest** published version. Please
 upgrade to the latest release before reporting an issue.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,6 +1,6 @@
 # Releasing Nemus
 
-Nemus publishes to npm as [`nemus`](https://www.npmjs.com/package/nemus).
+Nemus publishes to npm as [`@nemus-cli/nemus`](https://www.npmjs.com/package/@nemus-cli/nemus).
 Releases are **automated but gated by a manual approval**, so nothing reaches npm
 without a maintainer's explicit sign-off.
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nemus",
+  "name": "@nemus-cli/nemus",
   "version": "0.2.1",
   "description": "Nemus — a CLI for managing multi-repository workspaces. Create, sync, and operate across dozens of repos with a single command, and wire them up to your favorite coding agent.",
   "keywords": [

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * postinstall.js — runs after `npm install -g nemus`
+ * postinstall.js — runs after `npm install -g @nemus-cli/nemus`
  *
  * Installs the shell integration (nemus/nem shell functions) so that the
  * shell can auto-CD into a workspace after create / list / go commands.

--- a/src/utils/version-check.ts
+++ b/src/utils/version-check.ts
@@ -44,7 +44,7 @@ async function saveCache(cache: VersionCheckCache): Promise<void> {
 
 async function fetchLatestVersion(): Promise<string | null> {
   try {
-    const { stdout } = await execFileAsync('npm', ['view', 'nemus', 'version'], {
+    const { stdout } = await execFileAsync('npm', ['view', '@nemus-cli/nemus', 'version'], {
       timeout: 5000,
     });
     return stdout.trim();
@@ -92,5 +92,5 @@ export async function checkForUpdate(): Promise<string | null> {
 }
 
 function formatUpdateMessage(current: string, latest: string): string {
-  return `\x1b[33m[nemus] Update available: ${current} -> ${latest}. Run: npm install -g nemus@latest\x1b[0m`;
+  return `\x1b[33m[nemus] Update available: ${current} -> ${latest}. Run: npm install -g @nemus-cli/nemus@latest\x1b[0m`;
 }


### PR DESCRIPTION
npm's typosquat/similarity guard **rejects the bare name `nemus`** (403 — "too similar to existing package memfs"), so the first publish failed at the registry step. Publish under the **`nemus-cli` npm org** instead.

**Only the npm package name changes** (`nemus` → `@nemus-cli/nemus`); the `nemus`/`nem` CLI commands are unchanged. Install becomes `npm i -g @nemus-cli/nemus`.

Updated: `package.json` name, README badge/links/install, SECURITY.md, docs/releasing.md, release.yml (env url + release notes), version-check (`npm view` + update message), postinstall comment. Build + typecheck + 428 tests green.