### PR TITLE
feat: namespace cache/config under ~/.nemus with auto-migration (0.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-08-25
+
+### Changed
+
+- **Namespaced all cache/config/state under `~/.nemus`** (was
+  `~/.workspace-manager-cache`). This avoids collisions with other tools that
+  used the old generic path — which could, for example, make the update check
+  report a wrong "latest" version.
+- Environment overrides are now **`NEMUS_DIR`** and **`NEMUS_CACHE_DIR`**; the
+  legacy `WORKSPACE_MANAGER_DIR` / `WORKSPACE_MANAGER_CACHE_DIR` names still work
+  as fallbacks.
+- On first run, existing state is **migrated automatically** from
+  `~/.workspace-manager-cache` to `~/.nemus` (a non-destructive copy — the old
+  directory is left intact).
+- Published as the scoped package **`@nemus-cli/nemus`** (npm's similarity guard
+  blocks the bare name `nemus`). The `nemus` / `nem` CLI commands are unchanged.
+
 ## [0.2.1] - 2026-08-24
 
 ### Security
@@ -80,7 +97,8 @@ Initial open-source release of **Nemus**.
 - Automatic retries with backoff on flaky network operations.
 - Optional shell integration (auto-cd on create + quick-navigate helper).
 
-[Unreleased]: https://github.com/me-public/nemus/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/me-public/nemus/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/me-public/nemus/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/me-public/nemus/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/me-public/nemus/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/me-public/nemus/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -225,13 +225,17 @@ Run `nemus --help` for the full command reference.
 
 ## Configuration
 
-`nemus configure` writes `~/.workspace-manager-cache/config.json`. Environment
+`nemus configure` writes `~/.nemus/config.json`. Environment
 variables override it:
 
 ```bash
-export WORKSPACE_MANAGER_DIR="$HOME/my-workspaces"      # default: ~/workspaces
-export WORKSPACE_MANAGER_CACHE_DIR="$HOME/.cache/nemus" # default: ~/.workspace-manager-cache
+export NEMUS_DIR="$HOME/my-workspaces"        # default: ~/workspaces
+export NEMUS_CACHE_DIR="$HOME/.cache/nemus"   # default: ~/.nemus
 ```
+
+(The legacy `WORKSPACE_MANAGER_DIR` / `WORKSPACE_MANAGER_CACHE_DIR` names still
+work as fallbacks. On first run, state from the old `~/.workspace-manager-cache`
+location is migrated to `~/.nemus` automatically.)
 
 Key settings: `githubOrg` (which org's repos to list — leave empty to list your
 own), `cloneProtocol` (`ssh`|`https`), `aiAgent`, `primaryAgent`, `installMcp`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,7 +29,7 @@ Notable commands: `create`, `list`, `update`, `delete`, `sync`, `status`, `diff`
 
 The shared engine. Highlights:
 
-- **`config.ts`** — user config (`~/.workspace-manager-cache/config.json`) +
+- **`config.ts`** — user config (`~/.nemus/config.json`) +
   environment overrides, and the agent-type unions.
 - **`agent-config.ts`** — the **agent registry**. Each supported agent (Claude
   Code, pi, OpenCode, Codex, Gemini) is an `AgentPaths` entry describing its

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Nemus — a CLI for managing multi-repository workspaces. Create, sync, and operate across dozens of repos with a single command, and wire them up to your favorite coding agent.",
   "keywords": [
     "workspace",

--- a/skills/workspace-manager/references/configure.md
+++ b/skills/workspace-manager/references/configure.md
@@ -32,4 +32,4 @@ w cfg
 
 ## Success Criteria
 
-- User's settings are saved to `~/.workspace-manager-cache/config.json`.
+- User's settings are saved to `~/.nemus/config.json`.

--- a/src/commands/cache/manager.ts
+++ b/src/commands/cache/manager.ts
@@ -16,7 +16,7 @@ export async function cacheInfo() {
     console.log(`  Repositories: ${colorize(String(stats.repoCount), 'cyan')}`);
     console.log(`  Last updated: ${stats.age}`);
     console.log(`  Cache size: ${colorize(String(Math.round((stats.size || 0) / 1024)) + ' KB', 'yellow')}`);
-    console.log(`  Location: ${colorize('~/.workspace-manager-cache/repos-cache.json', 'gray')}`);
+    console.log(`  Location: ${colorize('~/.nemus/repos-cache.json', 'gray')}`);
   } else {
     console.log('\n' + colorize('Cache Status:', 'yellow'));
     console.log('  No cache found. Cache will be created on next repository fetch.\n');

--- a/src/pi-extensions/review-reminder.ts.template
+++ b/src/pi-extensions/review-reminder.ts.template
@@ -10,7 +10,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 
-const CACHE_DIR = path.join(os.homedir(), ".workspace-manager-cache");
+const CACHE_DIR = path.join(os.homedir(), ".nemus");
 const REVIEW_FILE = path.join(CACHE_DIR, "last-permission-review");
 const REMINDER_FILE = path.join(CACHE_DIR, "last-permission-reminder");
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;

--- a/src/scripts/workspace-table.py
+++ b/src/scripts/workspace-table.py
@@ -27,7 +27,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 # ─── Cache ───────────────────────────────────────────────────────────────────
-CACHE_FILE = Path.home() / ".workspace-manager-cache" / "pr-status.json"
+CACHE_FILE = Path.home() / ".nemus" / "pr-status.json"
 CACHE_TTL = 300  # seconds
 
 # ─── ANSI helpers ─────────────────────────────────────────────────────────────

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -200,4 +200,50 @@ describe('config', () => {
       expect(getUserConfig().aiAgent).toBe('auto');
     });
   });
+
+  describe('cache dir location + legacy migration', () => {
+    it('defaults CACHE_DIR to ~/.nemus when no env override is set', async () => {
+      delete process.env.NEMUS_CACHE_DIR;
+      delete process.env.WORKSPACE_MANAGER_CACHE_DIR;
+      vi.resetModules();
+      const { CACHE_DIR } = await loadModule();
+      expect(CACHE_DIR).toBe(path.join(tempDir, '.nemus'));
+    });
+
+    it('prefers NEMUS_CACHE_DIR, then legacy WORKSPACE_MANAGER_CACHE_DIR', async () => {
+      const nemusCache = path.join(tempDir, 'custom-nemus-cache');
+      process.env.NEMUS_CACHE_DIR = nemusCache;
+      vi.resetModules();
+      expect((await loadModule()).CACHE_DIR).toBe(nemusCache);
+
+      delete process.env.NEMUS_CACHE_DIR;
+      process.env.WORKSPACE_MANAGER_CACHE_DIR = path.join(tempDir, '.workspace-manager-cache');
+      vi.resetModules();
+      expect((await loadModule()).CACHE_DIR).toBe(path.join(tempDir, '.workspace-manager-cache'));
+    });
+
+    it('migrates state from ~/.workspace-manager-cache to ~/.nemus on first run', async () => {
+      delete process.env.NEMUS_CACHE_DIR;
+      delete process.env.WORKSPACE_MANAGER_CACHE_DIR;
+      // legacy dir (created by beforeEach) holds prior state; new dir absent
+      fs.writeFileSync(path.join(tempDir, '.workspace-manager-cache', 'suites.json'), '{"x":1}');
+      expect(fs.existsSync(path.join(tempDir, '.nemus'))).toBe(false);
+      vi.resetModules();
+      const { CACHE_DIR } = await loadModule();
+      expect(CACHE_DIR).toBe(path.join(tempDir, '.nemus'));
+      // copied, not moved: file exists in the new dir AND the legacy dir survives
+      expect(fs.readFileSync(path.join(tempDir, '.nemus', 'suites.json'), 'utf-8')).toBe('{"x":1}');
+      expect(fs.existsSync(path.join(tempDir, '.workspace-manager-cache', 'suites.json'))).toBe(true);
+    });
+
+    it('does not migrate when the new dir already exists', async () => {
+      delete process.env.NEMUS_CACHE_DIR;
+      delete process.env.WORKSPACE_MANAGER_CACHE_DIR;
+      fs.mkdirSync(path.join(tempDir, '.nemus'), { recursive: true });
+      fs.writeFileSync(path.join(tempDir, '.workspace-manager-cache', 'suites.json'), '{"x":1}');
+      vi.resetModules();
+      await loadModule();
+      expect(fs.existsSync(path.join(tempDir, '.nemus', 'suites.json'))).toBe(false);
+    });
+  });
 });

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -4,8 +4,35 @@ import * as fs from 'fs';
 
 const HOME_DIR = os.homedir();
 
-// Config file lives outside CACHE_DIR so we can read it to determine CACHE_DIR
-const CONFIG_FILE = path.join(HOME_DIR, '.workspace-manager-cache', 'config.json');
+// Cache/config/state directory. Prefer the branded NEMUS_* env vars; fall back
+// to the legacy WORKSPACE_MANAGER_* names for backward compatibility; else the
+// default ~/.nemus home.
+const DEFAULT_CACHE_DIR = path.join(HOME_DIR, '.nemus');
+const LEGACY_CACHE_DIR = path.join(HOME_DIR, '.workspace-manager-cache');
+
+/**
+ * One-time, best-effort migration of state from the pre-0.2.2 cache location
+ * (~/.workspace-manager-cache) to ~/.nemus. Runs only when using the default
+ * location (no env override) and the new dir doesn't exist yet. Copies rather
+ * than moves, so any other tool that happened to share the old path is left
+ * untouched; a failure is harmless because a fresh dir is created on first write.
+ */
+function migrateLegacyCacheDir(targetDir: string): void {
+  try {
+    if (targetDir === DEFAULT_CACHE_DIR && !fs.existsSync(targetDir) && fs.existsSync(LEGACY_CACHE_DIR)) {
+      fs.cpSync(LEGACY_CACHE_DIR, targetDir, { recursive: true });
+    }
+  } catch {
+    // best-effort — ignore and let the dir be created lazily
+  }
+}
+
+const CACHE_DIR_RESOLVED =
+  process.env.NEMUS_CACHE_DIR || process.env.WORKSPACE_MANAGER_CACHE_DIR || DEFAULT_CACHE_DIR;
+migrateLegacyCacheDir(CACHE_DIR_RESOLVED);
+
+// Config file lives inside the cache dir.
+const CONFIG_FILE = path.join(CACHE_DIR_RESOLVED, 'config.json');
 
 /** Coding-agent CLIs Nemus can integrate with. */
 export type ConcreteAgentType = 'claude' | 'pi' | 'opencode' | 'codex' | 'gemini';
@@ -78,8 +105,9 @@ export function getUserConfig(): UserConfig {
 // Bootstrap constants from initial config read (env vars take precedence)
 const initialConfig = getUserConfig();
 
-export const WORKSPACES_DIR = process.env.WORKSPACE_MANAGER_DIR || initialConfig.workspacesDir;
-export const CACHE_DIR = process.env.WORKSPACE_MANAGER_CACHE_DIR || path.join(HOME_DIR, '.workspace-manager-cache');
+export const WORKSPACES_DIR =
+  process.env.NEMUS_DIR || process.env.WORKSPACE_MANAGER_DIR || initialConfig.workspacesDir;
+export const CACHE_DIR = CACHE_DIR_RESOLVED;
 export const HISTORY_FILE = path.join(CACHE_DIR, 'history.jsonl');
 export const SUITES_FILE = path.join(CACHE_DIR, 'suites.json');
 export const META_FILENAME = '.workspace-meta.json';

--- a/src/utils/history.ts
+++ b/src/utils/history.ts
@@ -1,8 +1,7 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import * as os from 'os';
+import { CACHE_DIR } from './config';
 
-const CACHE_DIR = path.join(os.homedir(), '.workspace-manager-cache');
 const HISTORY_FILE = path.join(CACHE_DIR, 'history.jsonl');
 
 export interface OperationRecord {

--- a/src/utils/pi-extensions.test.ts
+++ b/src/utils/pi-extensions.test.ts
@@ -62,7 +62,7 @@ describe('Pi extensions', () => {
         path.join(extensionsDir, 'ws-review-reminder.ts'),
         'utf-8'
       );
-      expect(content).toContain('.workspace-manager-cache');
+      expect(content).toContain('.nemus');
       expect(content).toContain('last-permission-review');
     });
 


### PR DESCRIPTION
## Why
The old `~/.workspace-manager-cache` path is generic and **collided with other tools**. On a machine that also ran the internal `@melio/workspace-manager` (v4.x), Nemus read that tool's stale `last-version-check.json` and showed a bogus `0.2.1 -> 4.22.8` update notice. Surfaced during `nemus` post-publish sanity.

## What
- Default cache/config/state dir → **`~/.nemus`**.
- Env overrides **`NEMUS_DIR`** / **`NEMUS_CACHE_DIR`** (legacy `WORKSPACE_MANAGER_*` still work as fallbacks).
- **One-time, non-destructive migration**: copies `~/.workspace-manager-cache` → `~/.nemus` on first run (default location only); old dir left intact.
- `history.ts` shares config's `CACHE_DIR` instead of redefining it; status-line helpers + docs updated.
- New tests: cache-dir resolution + migration (copy-not-move; no-op when new dir exists).

Only paths change; CLI commands `nemus`/`nem` unchanged. Bumps **0.2.2**. Build + typecheck + **432 tests** green.