### PR TITLE
fix: don't migrate last-version-check.json to ~/.nemus (0.2.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-08-25
+
+### Fixed
+
+- The one-time `~/.workspace-manager-cache` → `~/.nemus` migration no longer
+  copies `last-version-check.json`. If the old (shared) path held another tool's
+  update-check cache, inheriting it could make nemus report a wrong "latest"
+  version until the entry expired; skipping it forces one fresh lookup instead.
+
 ## [0.2.2] - 2026-08-25
 
 ### Changed
@@ -97,7 +106,8 @@ Initial open-source release of **Nemus**.
 - Automatic retries with backoff on flaky network operations.
 - Optional shell integration (auto-cd on create + quick-navigate helper).
 
-[Unreleased]: https://github.com/me-public/nemus/compare/v0.2.2...HEAD
+[Unreleased]: https://github.com/me-public/nemus/compare/v0.2.3...HEAD
+[0.2.3]: https://github.com/me-public/nemus/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/me-public/nemus/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/me-public/nemus/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/me-public/nemus/compare/v0.1.0...v0.2.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Nemus — a CLI for managing multi-repository workspaces. Create, sync, and operate across dozens of repos with a single command, and wire them up to your favorite coding agent.",
   "keywords": [
     "workspace",

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -236,6 +236,19 @@ describe('config', () => {
       expect(fs.existsSync(path.join(tempDir, '.workspace-manager-cache', 'suites.json'))).toBe(true);
     });
 
+    it('does not migrate last-version-check.json (avoids inheriting a foreign latest)', async () => {
+      delete process.env.NEMUS_CACHE_DIR;
+      delete process.env.WORKSPACE_MANAGER_CACHE_DIR;
+      const legacy = path.join(tempDir, '.workspace-manager-cache');
+      fs.writeFileSync(path.join(legacy, 'suites.json'), '{"x":1}');
+      fs.writeFileSync(path.join(legacy, 'last-version-check.json'), '{"latestVersion":"99.0.0"}');
+      vi.resetModules();
+      await loadModule();
+      // other state migrates, but the version-check cache is left behind
+      expect(fs.existsSync(path.join(tempDir, '.nemus', 'suites.json'))).toBe(true);
+      expect(fs.existsSync(path.join(tempDir, '.nemus', 'last-version-check.json'))).toBe(false);
+    });
+
     it('does not migrate when the new dir already exists', async () => {
       delete process.env.NEMUS_CACHE_DIR;
       delete process.env.WORKSPACE_MANAGER_CACHE_DIR;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -16,11 +16,20 @@ const LEGACY_CACHE_DIR = path.join(HOME_DIR, '.workspace-manager-cache');
  * location (no env override) and the new dir doesn't exist yet. Copies rather
  * than moves, so any other tool that happened to share the old path is left
  * untouched; a failure is harmless because a fresh dir is created on first write.
+ *
+ * `last-version-check.json` is deliberately NOT migrated: the old path could be
+ * shared by another tool whose "latest version" is unrelated to nemus, and
+ * copying it would make the update check report a wrong version until the entry
+ * expires. Skipping it just forces one fresh lookup.
  */
+const MIGRATION_SKIP = new Set(['last-version-check.json']);
 function migrateLegacyCacheDir(targetDir: string): void {
   try {
     if (targetDir === DEFAULT_CACHE_DIR && !fs.existsSync(targetDir) && fs.existsSync(LEGACY_CACHE_DIR)) {
-      fs.cpSync(LEGACY_CACHE_DIR, targetDir, { recursive: true });
+      fs.cpSync(LEGACY_CACHE_DIR, targetDir, {
+        recursive: true,
+        filter: (src) => !MIGRATION_SKIP.has(path.basename(src)),
+      });
     }
   } catch {
     // best-effort — ignore and let the dir be created lazily


### PR DESCRIPTION
Follow-up to 0.2.2. The one-time `~/.workspace-manager-cache` → `~/.nemus` migration copied the whole dir, including `last-version-check.json`. If the old (generic) path was shared with another tool, nemus could inherit that tool's "latest version" and show a wrong update notice until the 24h TTL expired.

**Fix:** exclude `last-version-check.json` from the migration (`cpSync` filter); a fresh lookup runs instead. Adds a regression test. 433 tests green.