### PR TITLE
docs(readme): explicit npm package link + downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,12 @@
   <a href="https://github.com/me-public/nemus/actions/workflows/ci.yml"><img src="https://github.com/me-public/nemus/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="https://www.npmjs.com/package/@nemus-cli/nemus"><img src="https://img.shields.io/npm/v/@nemus-cli/nemus.svg" alt="npm" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT" /></a>
+  <a href="https://www.npmjs.com/package/@nemus-cli/nemus"><img src="https://img.shields.io/npm/dm/@nemus-cli/nemus.svg" alt="npm downloads" /></a>
   <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen.svg" alt="Node >= 22" />
+</p>
+
+<p align="center">
+  📦 <b><a href="https://www.npmjs.com/package/@nemus-cli/nemus">@nemus-cli/nemus</a></b> on npm &nbsp;—&nbsp; <code>npm install -g @nemus-cli/nemus</code>
 </p>
 
 ---


### PR DESCRIPTION
Makes the npm home obvious beyond the easy-to-miss version badge: adds a plain **[`@nemus-cli/nemus`](https://www.npmjs.com/package/@nemus-cli/nemus) on npm — `npm install -g @nemus-cli/nemus`** line under the tagline, plus an npm-downloads badge. Docs-only.