### PR TITLE
chore(deps): remove unused ink-select-input + ink-spinner (0.2.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.7] - 2026-08-25
+
+### Changed
+
+- Removed two **unused** runtime dependencies (`ink-select-input`, `ink-spinner`)
+  — they were only referenced in an ambient type-declaration file, never
+  imported or rendered. Trims the production dependency tree (322 → 314
+  packages), reducing supply-chain surface. No user-facing change.
+
 ## [0.2.6] - 2026-08-25
 
 ### Changed
@@ -162,7 +171,8 @@ Initial open-source release of **Nemus**.
 - Automatic retries with backoff on flaky network operations.
 - Optional shell integration (auto-cd on create + quick-navigate helper).
 
-[Unreleased]: https://github.com/me-public/nemus/compare/v0.2.6...HEAD
+[Unreleased]: https://github.com/me-public/nemus/compare/v0.2.7...HEAD
+[0.2.7]: https://github.com/me-public/nemus/compare/v0.2.6...v0.2.7
 [0.2.6]: https://github.com/me-public/nemus/compare/v0.2.5...v0.2.6
 [0.2.5]: https://github.com/me-public/nemus/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/me-public/nemus/compare/v0.2.3...v0.2.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.2.3",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nemus-cli/nemus",
-      "version": "0.2.3",
+      "version": "0.2.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -15,8 +15,6 @@
         "commander": "^15.0.0",
         "fuzzy": "^0.1.3",
         "ink": "^5.0.0",
-        "ink-select-input": "^6.0.0",
-        "ink-spinner": "^5.0.0",
         "inquirer": "^8.0.0",
         "inquirer-autocomplete-prompt": "^2.0.0",
         "markdown-table": "^3.0.3",
@@ -1602,21 +1600,6 @@
         }
       }
     },
-    "node_modules/figures": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
-      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-unicode-supported": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -1911,39 +1894,6 @@
         "react-devtools-core": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ink-select-input": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/ink-select-input/-/ink-select-input-6.2.0.tgz",
-      "integrity": "sha512-304fZXxkpYxJ9si5lxRCaX01GNlmPBgOZumXXRnPYbHW/iI31cgQynqk2tRypGLOF1cMIwPUzL2LSm6q4I5rQQ==",
-      "license": "MIT",
-      "dependencies": {
-        "figures": "^6.1.0",
-        "to-rotated": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "ink": ">=5.0.0",
-        "react": ">=18.0.0"
-      }
-    },
-    "node_modules/ink-spinner": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ink-spinner/-/ink-spinner-5.0.0.tgz",
-      "integrity": "sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA==",
-      "license": "MIT",
-      "dependencies": {
-        "cli-spinners": "^2.7.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "peerDependencies": {
-        "ink": ">=4.0.0",
-        "react": ">=18.0.0"
       }
     },
     "node_modules/ink/node_modules/ansi-regex": {
@@ -2288,18 +2238,6 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
-    },
-    "node_modules/is-unicode-supported": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3638,18 +3576,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/to-rotated": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/to-rotated/-/to-rotated-1.0.0.tgz",
-      "integrity": "sha512-KsEID8AfgUy+pxVRLsWp0VzCa69wxzUDZnzGbyIST/bcgcrMvTYoFBX/QORH4YApoD89EDuUovx4BTdpOn319Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/toidentifier": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Nemus — a CLI for managing multi-repository workspaces. Create, sync, and operate across dozens of repos with a single command, and wire them up to your favorite coding agent.",
   "keywords": [
     "workspace",
@@ -69,8 +69,6 @@
     "commander": "^15.0.0",
     "fuzzy": "^0.1.3",
     "ink": "^5.0.0",
-    "ink-select-input": "^6.0.0",
-    "ink-spinner": "^5.0.0",
     "inquirer": "^8.0.0",
     "inquirer-autocomplete-prompt": "^2.0.0",
     "markdown-table": "^3.0.3",

--- a/src/types/ink.d.ts
+++ b/src/types/ink.d.ts
@@ -135,37 +135,4 @@ declare module 'ink' {
   export function measureElement(ref: { current: any }): { width: number; height: number };
 }
 
-declare module 'ink-select-input' {
-  import { FC } from 'react';
 
-  export interface Item<V> {
-    key?: string;
-    label: string;
-    value: V;
-  }
-
-  export interface Props<V> {
-    items?: Array<Item<V>>;
-    isFocused?: boolean;
-    initialIndex?: number;
-    limit?: number;
-    indicatorComponent?: FC<{ isSelected: boolean }>;
-    itemComponent?: FC<{ isSelected: boolean; label: string }>;
-    onSelect?: (item: Item<V>) => void;
-    onHighlight?: (item: Item<V>) => void;
-  }
-
-  function SelectInput<V>(props: Props<V>): JSX.Element;
-  export default SelectInput;
-}
-
-declare module 'ink-spinner' {
-  import { FC } from 'react';
-
-  export interface Props {
-    type?: string;
-  }
-
-  const Spinner: FC<Props>;
-  export default Spinner;
-}


### PR DESCRIPTION
Reduces supply-chain surface (from the Socket/Snyk dependency alerts).

**Removed** `ink-select-input` and `ink-spinner` — both were only referenced in `src/types/ink.d.ts` ambient declarations, **never imported or rendered**. Also removed their dead type decls.

- Prod dependency tree: **322 → 314** packages
- `npm audit`: **0 vulnerabilities**; build + typecheck + **433 tests** green

Note: the remaining Socket 'high' alerts are mostly **capability signals** inherent to the tool (`ws` for the MCP server, `child_process` for git ops, `rxjs` via inquirer@8) rather than CVEs — see PR discussion for the plan.