### PR TITLE
ci: guard against package-lock version drift + fix current drift (0.2.9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
             if (!p.bin || !p.bin.nemus) throw new Error('missing nemus bin');
             console.log('package.json OK');"
 
+      - name: Check package-lock.json version matches package.json
+        run: node scripts/check-lock-version.js
+
       - name: Check required files
         run: |
           for f in README.md LICENSE CONTRIBUTING.md CHANGELOG.md install.sh bin/workspace.js; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
         with:
           node-version: 22
           cache: npm
+      - run: node scripts/check-lock-version.js
       - run: npm ci
       - run: npm run build
       - run: npm run typecheck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.9] - 2026-08-26
+
+### Fixed
+
+- Synced `package-lock.json` to the current version (it had drifted to 0.2.7
+  while package.json was 0.2.8, because the ink/React upgrade regenerated the
+  lockfile before the version bump).
+
+### Added
+
+- CI guard `scripts/check-lock-version.js` — fails PR CI (and the release verify
+  step) if `package-lock.json`'s `version` / `packages[""]` drift from
+  package.json, so a stale lockfile can't reach `npm ci` at release time.
+
 ## [0.2.8] - 2026-08-26
 
 ### Changed
@@ -181,7 +195,8 @@ Initial open-source release of **Nemus**.
 - Automatic retries with backoff on flaky network operations.
 - Optional shell integration (auto-cd on create + quick-navigate helper).
 
-[Unreleased]: https://github.com/me-public/nemus/compare/v0.2.8...HEAD
+[Unreleased]: https://github.com/me-public/nemus/compare/v0.2.9...HEAD
+[0.2.9]: https://github.com/me-public/nemus/compare/v0.2.8...v0.2.9
 [0.2.8]: https://github.com/me-public/nemus/compare/v0.2.7...v0.2.8
 [0.2.7]: https://github.com/me-public/nemus/compare/v0.2.6...v0.2.7
 [0.2.6]: https://github.com/me-public/nemus/compare/v0.2.5...v0.2.6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.2.7",
+  "version": "0.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nemus-cli/nemus",
-      "version": "0.2.7",
+      "version": "0.2.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Nemus — a CLI for managing multi-repository workspaces. Create, sync, and operate across dozens of repos with a single command, and wire them up to your favorite coding agent.",
   "keywords": [
     "workspace",

--- a/scripts/check-lock-version.js
+++ b/scripts/check-lock-version.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * CI guard: fail if package-lock.json's version fields drift from package.json.
+ *
+ * A stale lockfile version makes `npm ci` fail at release time (npm errors on a
+ * package.json/lock mismatch before build/publish run). This catches the drift
+ * in PR CI instead. Checks both the lockfile root `version` and the self entry
+ * at `packages[""]`.
+ *
+ * Usage: node scripts/check-lock-version.js
+ * Exit 0 when consistent, 1 (with an ::error:: annotation) otherwise.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function read(file) {
+  return JSON.parse(fs.readFileSync(path.join(__dirname, '..', file), 'utf8'));
+}
+
+const pkg = read('package.json');
+const lock = read('package-lock.json');
+
+const pkgV = pkg.version;
+const rootV = lock.version;
+const selfV = lock.packages && lock.packages[''] && lock.packages[''].version;
+
+const errs = [];
+if (rootV !== pkgV) {
+  errs.push(`package-lock.json root version "${rootV}" != package.json "${pkgV}"`);
+}
+if (selfV !== pkgV) {
+  errs.push(`package-lock.json packages[""] version "${selfV}" != package.json "${pkgV}"`);
+}
+
+if (errs.length) {
+  console.error('::error::' + errs.join('; '));
+  console.error('Fix: run `npm install --package-lock-only` and commit package-lock.json.');
+  process.exit(1);
+}
+
+console.log(`\u2713 package-lock.json version matches package.json (${pkgV})`);


### PR DESCRIPTION
## Feature-parity + bugfix
Found while checking local feature parity against `workspace-manager` main.

**Parity gap:** WM #206 added a package-lock drift CI guard that Nemus lacked.

**Active bug:** Nemus's lockfile had **drifted** — `package.json` was 0.2.8 but `package-lock.json` read **0.2.7** (the ink/React upgrade ran `npm install` before the version bump, so 0.2.8 shipped with a stale lock).

## Changes
- Add `scripts/check-lock-version.js` (checks lock root `version` **and** `packages[""]` against package.json).
- Wire it into `ci.yml` (validate-package job) and `release.yml` (verify step) — a stale lock now fails PR CI instead of breaking `npm ci` at release.
- Fix the current drift (lock \u2192 0.2.9).

## Verify
- ✅ `node scripts/check-lock-version.js` passes; lock/pkg/self all 0.2.9
- ✅ build, typecheck, **433** tests; YAML valid; 0 CVEs

## Feature-parity result
All **local** commands + recent local features (CLAUDE.md context #201, fuzzy transposition #180, investigate-first #204) are present. The only WM commands absent from Nemus are cloud-only (`cloud`, `deploy`, `ui`, `slack`, `ssh`, `fix-pr`, `iterate`, `secrets-*`, \u2026) \u2014 intentional. This guard was the one non-cloud gap.