### PR TITLE
feat(site): professional redesign — SVG icons, hero terminal, live star count

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,7 +7,6 @@
 <meta name="description" content="Nemus is a CLI for managing multi-repository workspaces. Create, sync, and operate across dozens of Git repos with a single command — and wire them up to your favorite coding agent (Claude Code, pi, OpenCode, Codex, Gemini)." />
 <link rel="icon" type="image/png" href="assets/favicon-64.png" />
 
-<!-- Open Graph / social -->
 <meta property="og:type" content="website" />
 <meta property="og:url" content="https://me-public.github.io/nemus/" />
 <meta property="og:title" content="Nemus — Multi-repo workspaces for the AI-agent era" />
@@ -18,180 +17,270 @@
 <meta name="twitter:description" content="Create, sync, and operate across dozens of Git repos with a single command — and wire them up to your favorite coding agent." />
 <meta name="twitter:image" content="https://me-public.github.io/nemus/assets/social-preview.png" />
 
-<!-- Point LLMs at the machine-readable overview -->
 <link rel="alternate" type="text/markdown" title="llms.txt" href="llms.txt" />
 
 <style>
   :root{
     --bg:#0D1117; --bg2:#010409; --panel:#161B22; --panel2:#0f141b;
-    --border:#30363D; --text:#E6EDF3; --muted:#8B949E;
-    --green:#3FB950; --green2:#2EA043; --green3:#238636;
-    --radius:14px; --maxw:1080px;
+    --border:#30363D; --border2:#21262d; --text:#E6EDF3; --muted:#8B949E;
+    --green:#3FB950; --green2:#2EA043; --green3:#238636; --mint:#7EE2A8;
+    --radius:14px; --maxw:1120px;
   }
   *{box-sizing:border-box}
   html{scroll-behavior:smooth}
   body{
     margin:0; background:var(--bg); color:var(--text);
-    font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
-    -webkit-font-smoothing:antialiased;
+    font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased; letter-spacing:.1px;
   }
   a{color:var(--green); text-decoration:none}
   a:hover{text-decoration:underline}
-  .wrap{max-width:var(--maxw); margin:0 auto; padding:0 20px}
+  .wrap{max-width:var(--maxw); margin:0 auto; padding:0 22px}
   code,kbd,pre{font-family:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace}
+  svg{display:block}
 
   /* nav */
-  header.nav{position:sticky; top:0; z-index:10; backdrop-filter:blur(10px);
-    background:rgba(13,17,23,.72); border-bottom:1px solid var(--border)}
-  .nav .wrap{display:flex; align-items:center; gap:18px; height:60px}
-  .nav img{height:26px}
-  .nav .links{margin-left:auto; display:flex; gap:22px; align-items:center; font-size:15px}
-  .nav .links a{color:var(--muted)}
-  .nav .links a:hover{color:var(--text); text-decoration:none}
-  .badge{background:var(--panel); border:1px solid var(--border); border-radius:999px;
-    padding:5px 12px; color:var(--text)!important; font-size:13px}
+  header.nav{position:sticky; top:0; z-index:20; backdrop-filter:saturate(140%) blur(12px);
+    background:rgba(13,17,23,.72); border-bottom:1px solid var(--border2)}
+  .nav .wrap{display:flex; align-items:center; gap:20px; height:62px}
+  .nav a.brand{display:flex; align-items:center}
+  .nav a.brand img{height:26px}
+  .nav .links{margin-left:auto; display:flex; gap:24px; align-items:center; font-size:14.5px}
+  .nav .links a.txt{color:var(--muted)}
+  .nav .links a.txt:hover{color:var(--text); text-decoration:none}
+  .star{display:inline-flex; align-items:center; gap:0; border:1px solid var(--border);
+    border-radius:8px; overflow:hidden; font-size:13px; font-weight:600}
+  .star:hover{text-decoration:none; border-color:var(--muted)}
+  .star .s-label{display:inline-flex; align-items:center; gap:7px; padding:6px 11px;
+    background:var(--panel); color:var(--text)}
+  .star .s-count{padding:6px 11px; background:var(--panel2); color:var(--muted);
+    border-left:1px solid var(--border); min-width:34px; text-align:center; font-variant-numeric:tabular-nums}
+  .star .s-count:empty{display:none}
+  .star svg{width:14px; height:14px; color:var(--green)}
 
   /* hero */
-  .hero{position:relative; overflow:hidden; text-align:center; padding:88px 0 64px}
-  .hero::before{content:""; position:absolute; inset:0;
+  .hero{position:relative; overflow:hidden; padding:96px 0 60px}
+  .hero::before{content:""; position:absolute; inset:0; pointer-events:none;
     background:
-      radial-gradient(600px 300px at 50% -40px, rgba(63,185,80,.18), transparent 70%),
-      radial-gradient(800px 400px at 50% 120%, rgba(35,134,54,.10), transparent 70%);
-    pointer-events:none}
-  .hero img.mark{height:64px; margin-bottom:22px; filter:drop-shadow(0 6px 24px rgba(63,185,80,.25))}
-  .hero h1{font-size:clamp(30px,5vw,50px); line-height:1.1; margin:.2em 0 .3em; letter-spacing:-.02em}
-  .hero h1 .accent{color:var(--green)}
-  .hero p.sub{max-width:680px; margin:0 auto 30px; color:var(--muted); font-size:clamp(16px,2.4vw,20px)}
-  .cta{display:flex; gap:12px; justify-content:center; flex-wrap:wrap; margin-bottom:26px}
-  .btn{display:inline-flex; align-items:center; gap:8px; padding:12px 20px; border-radius:10px;
-    font-weight:600; font-size:15px; border:1px solid transparent; cursor:pointer}
+      radial-gradient(680px 340px at 68% -30px, rgba(63,185,80,.20), transparent 70%),
+      radial-gradient(900px 460px at 20% 120%, rgba(35,134,54,.10), transparent 70%)}
+  .hero .wrap{position:relative; display:grid; grid-template-columns:1.05fr .95fr; gap:48px; align-items:center}
+  .eyebrow{display:inline-flex; align-items:center; gap:8px; font-size:13px; font-weight:600;
+    color:var(--mint); background:rgba(63,185,80,.08); border:1px solid var(--border);
+    padding:6px 12px; border-radius:999px; margin-bottom:22px}
+  .eyebrow .dot{width:7px; height:7px; border-radius:50%; background:var(--green); box-shadow:0 0 0 3px rgba(63,185,80,.18)}
+  h1{font-size:clamp(32px,4.6vw,54px); line-height:1.06; margin:0 0 18px; letter-spacing:-.025em; font-weight:800}
+  h1 .accent{color:var(--green)}
+  .sub{color:var(--muted); font-size:clamp(16px,1.5vw,19px); margin:0 0 30px; max-width:560px}
+  .cta{display:flex; gap:12px; flex-wrap:wrap; margin-bottom:26px}
+  .btn{display:inline-flex; align-items:center; gap:9px; padding:12px 20px; border-radius:10px;
+    font-weight:650; font-size:15px; border:1px solid transparent; cursor:pointer}
+  .btn svg{width:16px; height:16px}
   .btn.primary{background:var(--green3); color:#fff}
   .btn.primary:hover{background:var(--green2); text-decoration:none}
   .btn.ghost{background:var(--panel); border-color:var(--border); color:var(--text)}
   .btn.ghost:hover{border-color:var(--muted); text-decoration:none}
-
-  .install{display:inline-flex; align-items:center; gap:14px; margin:0 auto;
-    background:var(--panel); border:1px solid var(--border); border-radius:12px;
-    padding:12px 16px; font-size:15px}
-  .install code{color:var(--text)}
+  .install{display:inline-flex; align-items:center; gap:12px; background:var(--panel);
+    border:1px solid var(--border); border-radius:11px; padding:11px 14px; font-size:14.5px; max-width:100%}
   .install .prompt{color:var(--green); user-select:none}
+  .install code{color:var(--text); overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
   .copy{background:transparent; border:1px solid var(--border); color:var(--muted);
-    border-radius:8px; padding:5px 10px; font-size:12px; cursor:pointer}
+    border-radius:7px; padding:5px 10px; font-size:12px; cursor:pointer; flex:none}
   .copy:hover{color:var(--text); border-color:var(--muted)}
 
-  /* sections */
-  section{padding:56px 0; border-top:1px solid var(--border)}
-  section h2{font-size:clamp(22px,3.4vw,30px); margin:0 0 8px; letter-spacing:-.01em}
-  section .lead{color:var(--muted); margin:0 0 30px; max-width:720px}
+  /* terminal mock */
+  .term{background:#0b0f15; border:1px solid var(--border); border-radius:14px;
+    box-shadow:0 24px 60px -24px rgba(0,0,0,.7), 0 0 0 1px rgba(63,185,80,.06);
+    overflow:hidden; font-size:13.5px; line-height:1.85}
+  .term .bar{display:flex; align-items:center; gap:8px; padding:12px 14px; background:#0d1117; border-bottom:1px solid var(--border2)}
+  .term .bar i{width:11px; height:11px; border-radius:50%; display:inline-block}
+  .term .bar .t{margin-left:auto; margin-right:auto; color:#7D8590; font-size:12.5px; font-family:ui-monospace,Menlo,monospace}
+  .term .body{padding:16px 18px; font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+  .term .body div{white-space:pre}
+  .term .p{color:var(--mint)} .term .w{color:var(--text)} .term .m{color:#7D8590} .term .g{color:var(--green)}
+  .cursor{display:inline-block; width:8px; height:15px; background:var(--green); vertical-align:-2px; animation:blink 1.1s steps(1) infinite}
+  @keyframes blink{50%{opacity:0}}
 
-  .grid{display:grid; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); gap:16px}
-  .card{background:var(--panel); border:1px solid var(--border); border-radius:var(--radius);
-    padding:20px; transition:border-color .15s, transform .15s}
-  .card:hover{border-color:var(--green3); transform:translateY(-2px)}
-  .card .ico{font-size:24px; margin-bottom:10px}
-  .card h3{margin:0 0 6px; font-size:17px}
+  /* sections */
+  section{padding:64px 0; border-top:1px solid var(--border2)}
+  .sec-head{margin-bottom:34px}
+  .sec-head h2{font-size:clamp(23px,3vw,32px); margin:0 0 10px; letter-spacing:-.02em; font-weight:750}
+  .sec-head p{color:var(--muted); margin:0; max-width:680px}
+
+  .grid{display:grid; grid-template-columns:repeat(auto-fit,minmax(280px,1fr)); gap:16px}
+  .card{background:linear-gradient(180deg,var(--panel),#12161d); border:1px solid var(--border);
+    border-radius:var(--radius); padding:24px; transition:border-color .18s, transform .18s, box-shadow .18s}
+  .card:hover{border-color:var(--green3); transform:translateY(-3px); box-shadow:0 16px 40px -22px rgba(63,185,80,.5)}
+  .card .ico{width:42px; height:42px; border-radius:11px; display:flex; align-items:center; justify-content:center;
+    background:rgba(63,185,80,.10); border:1px solid rgba(63,185,80,.22); margin-bottom:16px}
+  .card .ico svg{width:21px; height:21px; color:var(--green)}
+  .card h3{margin:0 0 7px; font-size:17px; font-weight:680}
   .card p{margin:0; color:var(--muted); font-size:14.5px}
 
   pre.code{background:var(--bg2); border:1px solid var(--border); border-radius:var(--radius);
-    padding:20px; overflow-x:auto; font-size:14px; line-height:1.7}
-  pre.code .c{color:var(--muted)}
-  pre.code .g{color:var(--green)}
+    padding:22px; overflow-x:auto; font-size:13.5px; line-height:1.8}
+  pre.code .c{color:var(--muted)} pre.code .g{color:var(--green)}
 
-  .two{display:grid; grid-template-columns:1fr 1fr; gap:22px; align-items:start}
-  @media(max-width:760px){.two{grid-template-columns:1fr} .nav .links a.hide{display:none}}
+  .two{display:grid; grid-template-columns:1fr 1fr; gap:26px; align-items:center}
 
-  .agents{display:flex; flex-wrap:wrap; gap:10px; margin-top:8px}
-  .chip{background:var(--panel); border:1px solid var(--border); border-radius:999px;
-    padding:8px 16px; font-size:14px; font-weight:600}
-  .chip .dot{display:inline-block; width:8px; height:8px; border-radius:50%;
-    background:var(--green); margin-right:8px; vertical-align:middle}
+  .agents{display:flex; flex-wrap:wrap; gap:10px; margin-top:4px}
+  .chip{display:inline-flex; align-items:center; gap:9px; background:var(--panel); border:1px solid var(--border);
+    border-radius:999px; padding:9px 17px; font-size:14px; font-weight:620}
+  .chip .dot{width:8px; height:8px; border-radius:50%; background:var(--green)}
 
-  .note{background:linear-gradient(180deg, rgba(63,185,80,.07), rgba(63,185,80,0));
-    border:1px solid var(--border); border-left:3px solid var(--green); border-radius:10px; padding:18px 20px}
+  .stats{display:flex; gap:14px; flex-wrap:wrap; margin-top:8px}
+  .stat{flex:1; min-width:150px; background:var(--panel); border:1px solid var(--border); border-radius:12px; padding:18px 20px}
+  .stat .n{font-size:26px; font-weight:800; letter-spacing:-.02em}
+  .stat .l{color:var(--muted); font-size:13.5px; margin-top:2px}
+
+  .note{background:linear-gradient(180deg, rgba(63,185,80,.06), rgba(63,185,80,0));
+    border:1px solid var(--border); border-left:3px solid var(--green); border-radius:10px; padding:18px 20px; color:var(--muted)}
   .note strong{color:var(--green)}
 
-  footer{border-top:1px solid var(--border); padding:40px 0; color:var(--muted); font-size:14px}
+  footer{border-top:1px solid var(--border2); padding:44px 0; color:var(--muted); font-size:14px}
   footer .wrap{display:flex; flex-wrap:wrap; gap:20px; align-items:center; justify-content:space-between}
-  footer .flinks{display:flex; gap:20px; flex-wrap:wrap}
+  footer .flinks{display:flex; gap:22px; flex-wrap:wrap}
   footer a{color:var(--muted)} footer a:hover{color:var(--text)}
-  .kbd{background:var(--panel); border:1px solid var(--border); border-radius:6px; padding:1px 7px; font-size:12px; color:var(--muted)}
+
+  @media(max-width:840px){
+    .hero{padding:64px 0 44px} .hero .wrap{grid-template-columns:1fr; gap:34px}
+    .two{grid-template-columns:1fr} .nav .links a.txt.hide{display:none}
+  }
 </style>
 </head>
 <body>
 
 <header class="nav">
   <div class="wrap">
-    <a href="." aria-label="Nemus — home"><img src="assets/logo-wordmark.svg" alt="Nemus" /></a>
+    <a class="brand" href="." aria-label="Nemus — home"><img src="assets/logo-wordmark.svg" alt="Nemus" /></a>
     <nav class="links">
-      <a href="#features" class="hide">Features</a>
-      <a href="#quickstart" class="hide">Quick start</a>
-      <a href="#agents" class="hide">Agents</a>
-      <a href="llms.txt">llms.txt</a>
-      <a class="badge" href="https://github.com/me-public/nemus">GitHub ↗</a>
+      <a class="txt hide" href="#features">Features</a>
+      <a class="txt hide" href="#quickstart">Quick start</a>
+      <a class="txt hide" href="llms.txt">llms.txt</a>
+      <a class="star" href="https://github.com/me-public/nemus" aria-label="Star Nemus on GitHub">
+        <span class="s-label">
+          <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87L18.18 21 12 17.77 5.82 21 7 14.14l-5-4.87 6.91-1.01L12 2z"/></svg>
+          Star
+        </span>
+        <span class="s-count" data-stars></span>
+      </a>
     </nav>
   </div>
 </header>
 
 <div class="hero">
   <div class="wrap">
-    <img class="mark" src="assets/icon.svg" alt="" />
-    <h1>Multi-repo workspaces<br/>for the <span class="accent">AI-agent era</span></h1>
-    <p class="sub">Create, sync, and operate across dozens of Git repositories with a single
-      command — then wire them up to your favorite coding agent so “work on the payments stack”
-      becomes one prompt.</p>
-
-    <div class="cta">
-      <a class="btn primary" href="#quickstart">Get started</a>
-      <a class="btn ghost" href="https://www.npmjs.com/package/@nemus-cli/nemus">View on npm ↗</a>
+    <div>
+      <span class="eyebrow"><span class="dot"></span> Open source · MIT · Node ≥ 22</span>
+      <h1>Multi-repo workspaces<br/>for the <span class="accent">AI-agent era</span></h1>
+      <p class="sub">One command to clone, sync, branch, and run across dozens of Git repositories —
+        then hand the whole workspace to your coding agent.</p>
+      <div class="cta">
+        <a class="btn primary" href="#quickstart">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="8 5 8 19 19 12 8 5"/></svg>
+          Get started
+        </a>
+        <a class="btn ghost" href="https://github.com/me-public/nemus">
+          <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5A11.5 11.5 0 0 0 .5 12a11.5 11.5 0 0 0 7.86 10.92c.57.1.78-.25.78-.55v-2c-3.2.7-3.88-1.37-3.88-1.37-.53-1.34-1.3-1.7-1.3-1.7-1.05-.72.08-.71.08-.71 1.17.08 1.78 1.2 1.78 1.2 1.04 1.78 2.73 1.27 3.4.97.1-.75.4-1.27.73-1.56-2.55-.29-5.23-1.28-5.23-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.8 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.41-5.25 5.69.41.36.78 1.06.78 2.14v3.17c0 .31.21.66.79.55A11.5 11.5 0 0 0 23.5 12 11.5 11.5 0 0 0 12 .5z"/></svg>
+          View on GitHub
+        </a>
+      </div>
+      <div class="install">
+        <span class="prompt">$</span>
+        <code id="installcmd">npm install -g @nemus-cli/nemus</code>
+        <button class="copy" onclick="copyInstall(this)">Copy</button>
+      </div>
     </div>
 
-    <div class="install">
-      <span class="prompt">$</span>
-      <code id="installcmd">npm install -g @nemus-cli/nemus</code>
-      <button class="copy" onclick="copyInstall(this)">Copy</button>
+    <div class="term" aria-hidden="true">
+      <div class="bar"><i style="background:#FF5F56"></i><i style="background:#FFBD2E"></i><i style="background:#27C93F"></i><span class="t">nemus</span></div>
+      <div class="body">
+<div><span class="p">$</span> <span class="w">nemus create payments</span></div>
+<div><span class="m">✓ cloned 12 repositories in parallel</span></div>
+<div><span class="m">✓ wrote AGENTS.md · installed skills · started MCP</span></div>
+<div>&nbsp;</div>
+<div><span class="p">$</span> <span class="w">nemus run payments "npm test"</span></div>
+<div><span class="m">✓ 12/12 repos green</span></div>
+<div>&nbsp;</div>
+<div><span class="p">$</span> <span class="w">nemus -- "start the checkout refactor"</span></div>
+<div><span class="g">▸ launching agent</span><span class="cursor"></span></div>
+      </div>
     </div>
   </div>
 </div>
 
 <section id="features">
   <div class="wrap">
-    <h2>Why Nemus?</h2>
-    <p class="lead">Modern products span many repositories. Nemus keeps a <em>workspace</em> —
-      a named folder of related repos — in sync and lets you act across all of them at once.</p>
+    <div class="sec-head">
+      <h2>Everything, across every repo</h2>
+      <p>Modern products span many repositories. Nemus keeps a workspace — a named folder of related
+        repos — in sync and lets you act on all of them at once.</p>
+    </div>
     <div class="grid">
-      <div class="card"><div class="ico">🌳</div><h3>Workspaces</h3><p>Group repos, clone them all in parallel, and jump straight in.</p></div>
-      <div class="card"><div class="ico">🔁</div><h3>Operate in bulk</h3><p>status, sync, diff, run, and branch across every repo in one command.</p></div>
-      <div class="card"><div class="ico">📦</div><h3>Suites &amp; snapshots</h3><p>Save reusable repo collections and capture exact workspace states.</p></div>
-      <div class="card"><div class="ico">🤖</div><h3>Agent-native</h3><p>First-class integration with multiple coding agents, context files, skills &amp; an MCP server.</p></div>
-      <div class="card"><div class="ico">🩺</div><h3>Healthy by default</h3><p>Health checks, dependency analysis, and retries on flaky networks.</p></div>
-      <div class="card"><div class="ico">🔎</div><h3>Investigate-first</h3><p>Create an empty workspace and let an agent discover and add the repos it needs.</p></div>
+      <div class="card">
+        <div class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="6" y1="3" x2="6" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg></div>
+        <h3>Workspaces</h3><p>Group repos, clone them all in parallel, and jump straight in.</p>
+      </div>
+      <div class="card">
+        <div class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg></div>
+        <h3>Operate in bulk</h3><p>status, sync, diff, run, and branch across every repo in one command.</p>
+      </div>
+      <div class="card">
+        <div class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg></div>
+        <h3>Suites &amp; snapshots</h3><p>Save reusable repo collections and capture exact workspace states.</p>
+      </div>
+      <div class="card">
+        <div class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="2"/><rect x="9" y="9" width="6" height="6"/><line x1="9" y1="1" x2="9" y2="4"/><line x1="15" y1="1" x2="15" y2="4"/><line x1="9" y1="20" x2="9" y2="23"/><line x1="15" y1="20" x2="15" y2="23"/><line x1="20" y1="9" x2="23" y2="9"/><line x1="20" y1="14" x2="23" y2="14"/><line x1="1" y1="9" x2="4" y2="9"/><line x1="1" y1="14" x2="4" y2="14"/></svg></div>
+        <h3>Agent-native</h3><p>Generated context files, installable skills, and an MCP server for your agent.</p>
+      </div>
+      <div class="card">
+        <div class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg></div>
+        <h3>Healthy by default</h3><p>Health checks, dependency analysis, and retries on flaky networks.</p>
+      </div>
+      <div class="card">
+        <div class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></div>
+        <h3>Investigate-first</h3><p>Create an empty workspace and let an agent discover and add the repos it needs.</p>
+      </div>
     </div>
   </div>
 </section>
 
 <section id="quickstart">
-  <div class="wrap">
-    <h2>Quick start</h2>
-    <p class="lead">Install globally, configure once, then create your first workspace.</p>
+  <div class="wrap two">
+    <div>
+      <div class="sec-head">
+        <h2>Up and running in a minute</h2>
+        <p>Install globally, configure once, then create your first workspace — or describe the task
+          in plain English and let an agent set it up.</p>
+      </div>
+      <div class="stats">
+        <div class="stat"><div class="n">5</div><div class="l">coding agents supported</div></div>
+        <div class="stat"><div class="n">1</div><div class="l">command across N repos</div></div>
+        <div class="stat"><div class="n">MIT</div><div class="l">open source</div></div>
+      </div>
+    </div>
     <pre class="code"><span class="c"># Install globally</span>
 npm install -g @nemus-cli/nemus
 
-<span class="c"># One-time setup (choose your GitHub org, agent, clone protocol…)</span>
+<span class="c"># One-time setup (org, agent, clone protocol…)</span>
 <span class="g">nemus</span> configure
 
-<span class="c"># Create your first workspace (interactive repo picker with fuzzy search)</span>
+<span class="c"># Create your first workspace</span>
 <span class="g">nemus</span> create
 
-<span class="c"># …or let an agent do it — describe what you need in plain English</span>
-<span class="g">nemus</span> -- "set up a workspace for the payments stack and start on the refund bug"</pre>
+<span class="c"># …or let an agent do it, in plain English</span>
+<span class="g">nemus</span> -- "set up the payments stack
+        and start on the refund bug"</pre>
   </div>
 </section>
 
 <section id="agents">
   <div class="wrap">
-    <h2>Connect any coding agent</h2>
-    <p class="lead">Nemus generates context files, installs skills, and runs an MCP server so your
-      agent understands the whole workspace — not just one repo.</p>
+    <div class="sec-head">
+      <h2>Bring your own coding agent</h2>
+      <p>Nemus generates context files, installs skills, and runs an MCP server so your agent
+        understands the whole workspace — not just one repo.</p>
+    </div>
     <div class="agents">
       <span class="chip"><span class="dot"></span>Claude Code</span>
       <span class="chip"><span class="dot"></span>pi</span>
@@ -205,18 +294,19 @@ npm install -g @nemus-cli/nemus
 <section>
   <div class="wrap two">
     <div>
-      <h2>A full clone per workspace — on purpose</h2>
-      <p class="lead">Every workspace gets its own independent, full <code>git clone</code> of each
-        repo: separate <code>.git</code>, index, stash, hooks, config, branches, and build outputs.</p>
+      <div class="sec-head">
+        <h2>A full clone per workspace — on purpose</h2>
+        <p>Every workspace gets its own independent, full <code>git clone</code> of each repo:
+          separate <code>.git</code>, index, stash, hooks, config, branches, and build outputs.</p>
+      </div>
       <div class="note">
         <strong>Why not <code>git worktree</code>?</strong> Worktrees share one object store and are
-        great for one repo. Nemus is built for <em>many</em> repos worked on in parallel — often by
-        AI agents — where total isolation wins: two workspaces can both sit on <code>main</code>, and
-        one agent’s rebase, <code>gc</code>, or dirty tree can’t touch another’s.
+        great for one repo. Nemus targets <em>many</em> repos worked on in parallel — often by AI
+        agents — where total isolation wins: two workspaces can both sit on <code>main</code>, and one
+        agent’s rebase, <code>gc</code>, or dirty tree can’t touch another’s.
       </div>
     </div>
-    <div>
-      <pre class="code"><span class="c"># Operate across every repo at once</span>
+    <pre class="code"><span class="c"># Operate across every repo at once</span>
 <span class="g">nemus</span> status   my-stack
 <span class="g">nemus</span> sync     my-stack
 <span class="g">nemus</span> run      my-stack "npm test"
@@ -225,26 +315,27 @@ npm install -g @nemus-cli/nemus
 <span class="c"># Save &amp; reuse a set of repos</span>
 <span class="g">nemus</span> suite create payments
 <span class="g">nemus</span> create --suite payments</pre>
-    </div>
   </div>
 </section>
 
 <section>
   <div class="wrap">
-    <h2>For humans and for machines</h2>
-    <p class="lead">This site ships an <a href="llms.txt"><code>llms.txt</code></a> — a concise,
-      structured overview of Nemus in the <a href="https://llmstxt.org">llmstxt.org</a> format, so an
-      LLM can read the project at a glance and follow links to the full docs.</p>
-    <div class="cta" style="justify-content:flex-start">
-      <a class="btn ghost" href="llms.txt">Read llms.txt →</a>
-      <a class="btn ghost" href="https://github.com/me-public/nemus#readme">Full README ↗</a>
+    <div class="sec-head">
+      <h2>For humans and for machines</h2>
+      <p>This site ships an <a href="llms.txt"><code>llms.txt</code></a> — a concise, structured overview
+        of Nemus in the <a href="https://llmstxt.org">llmstxt.org</a> format — so an LLM can read the
+        project at a glance and follow links to the full docs.</p>
+    </div>
+    <div class="cta">
+      <a class="btn ghost" href="llms.txt">Read llms.txt</a>
+      <a class="btn ghost" href="https://github.com/me-public/nemus#readme">Full README</a>
     </div>
   </div>
 </section>
 
 <footer>
   <div class="wrap">
-    <div>© <span id="yr"></span> Nemus · MIT License</div>
+    <div>© <span id="yr"></span> Nemus · Released under the MIT License</div>
     <div class="flinks">
       <a href="https://github.com/me-public/nemus">GitHub</a>
       <a href="https://www.npmjs.com/package/@nemus-cli/nemus">npm</a>
@@ -257,18 +348,29 @@ npm install -g @nemus-cli/nemus
 
 <script>
   document.getElementById('yr').textContent = new Date().getFullYear();
-  // Open external links in a new tab, safely (no tabnabbing).
-  document.querySelectorAll('a[href^="http"]').forEach(function(a){
-    a.target = '_blank';
-    a.rel = 'noopener noreferrer';
-  });
+
   function copyInstall(btn){
-    const t = document.getElementById('installcmd').textContent;
-    navigator.clipboard.writeText(t).then(()=>{
-      const o = btn.textContent; btn.textContent = 'Copied!';
-      setTimeout(()=>btn.textContent=o, 1400);
+    navigator.clipboard.writeText(document.getElementById('installcmd').textContent).then(function(){
+      var o = btn.textContent; btn.textContent = 'Copied!';
+      setTimeout(function(){ btn.textContent = o; }, 1400);
     });
   }
+
+  // Open external links in a new tab, safely (no tabnabbing).
+  document.querySelectorAll('a[href^="http"]').forEach(function(a){
+    a.target = '_blank'; a.rel = 'noopener noreferrer';
+  });
+
+  // Live GitHub star count.
+  fetch('https://api.github.com/repos/me-public/nemus')
+    .then(function(r){ return r.ok ? r.json() : null; })
+    .then(function(d){
+      if (!d || typeof d.stargazers_count !== 'number') return;
+      var n = d.stargazers_count;
+      var txt = n >= 1000 ? (n/1000).toFixed(1).replace(/\.0$/, '') + 'k' : String(n);
+      document.querySelectorAll('[data-stars]').forEach(function(el){ el.textContent = txt; });
+    })
+    .catch(function(){});
 </script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -361,16 +361,32 @@ npm install -g @nemus-cli/nemus
     a.target = '_blank'; a.rel = 'noopener noreferrer';
   });
 
-  // Live GitHub star count.
-  fetch('https://api.github.com/repos/me-public/nemus')
-    .then(function(r){ return r.ok ? r.json() : null; })
-    .then(function(d){
-      if (!d || typeof d.stargazers_count !== 'number') return;
-      var n = d.stargazers_count;
-      var txt = n >= 1000 ? (n/1000).toFixed(1).replace(/\.0$/, '') + 'k' : String(n);
-      document.querySelectorAll('[data-stars]').forEach(function(el){ el.textContent = txt; });
-    })
-    .catch(function(){});
+  // Mark purely-decorative icons as hidden from assistive tech.
+  document.querySelectorAll('.card .ico svg, .btn svg').forEach(function(s){
+    s.setAttribute('aria-hidden', 'true'); s.setAttribute('focusable', 'false');
+  });
+
+  // Live GitHub star count — cached in localStorage (1h) to avoid hammering the
+  // unauthenticated API (60 req/hr/IP) and to survive rate limits / offline.
+  (function(){
+    var KEY = 'nemus-stars', TTL = 3600000;
+    function paint(n){
+      var t = n >= 1000 ? (n/1000).toFixed(1).replace(/\.0$/, '') + 'k' : String(n);
+      document.querySelectorAll('[data-stars]').forEach(function(el){ el.textContent = t; });
+    }
+    try {
+      var c = JSON.parse(localStorage.getItem(KEY) || 'null');
+      if (c && typeof c.n === 'number' && (Date.now() - c.t) < TTL) paint(c.n);
+    } catch (e) {}
+    fetch('https://api.github.com/repos/me-public/nemus')
+      .then(function(r){ return r.ok ? r.json() : null; })
+      .then(function(d){
+        if (!d || typeof d.stargazers_count !== 'number') return;
+        paint(d.stargazers_count);
+        try { localStorage.setItem(KEY, JSON.stringify({ n: d.stargazers_count, t: Date.now() })); } catch (e) {}
+      })
+      .catch(function(){});
+  })();
 </script>
 </body>
 </html>


### PR DESCRIPTION
Steps up the landing page from the first pass.

## What changed
- **No more emoji** — every feature-card icon is now a crisp inline **SVG line-icon** (git-branch, layers, box, cpu, activity, search) in a tinted rounded tile; removed the `↗` glyphs too.
- **Live GitHub star count** in the nav — a `★ Star` pill that fetches `stargazers_count` client-side (verified `access-control-allow-origin: *`) and **hides the count until it resolves**, so it degrades cleanly if the API is slow/unreachable.
- **Hero redesign** — two-column layout with an animated **terminal mockup**, an eyebrow badge, and a stats row (5 agents / 1 command / MIT).
- Refined type scale, spacing, card gradients + hover shadows, and the GitHub icon on the CTA.

## Verify
- Rendered with headless Chrome at 1280px — screenshot reviewed; tags balanced; all asset refs resolve; **no emoji** remain.
- Docs-only (`docs/`), excluded from the npm tarball. No version bump.