### PR TITLE
docs: lead with a plain-language "What is Nemus?"

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,16 +48,19 @@ single project:**
 
 ### Before vs. after
 
-**Without Nemus** — clone six repos by hand, `cd` into each, pull, branch, run tests,
-repeat six times. Your agent only sees whichever repo you opened.
+**Without Nemus** — clone each repo by hand, `cd` into every one, pull, branch, run
+tests, and repeat. Your agent only sees whichever repo you opened.
 
 **With Nemus:**
 
 ```bash
-nemus create payments          # clones the 6 payments repos into one workspace
-nemus run payments "npm test"  # runs the tests in all 6 at once
-nemus -- "add idempotency keys to the payments flow"   # the agent works across all 6
+nemus create -w payments -r api,web,ledger,gateway,workers   # clone all 5 into one workspace
+nemus run payments "npm test"                                # run the tests in all 5 at once
+nemus -- "add idempotency keys to the payments flow"         # let an agent work across all 5
 ```
+
+> Prefer to point-and-pick? Just run `nemus create` for an interactive repo picker with
+> fuzzy search, or `nemus -- "create a workspace with the payments repos"` in plain English.
 
 ## What you get
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 </p>
 
 <p align="center">
-  <b>Multi-repo workspaces for the AI-agent era.</b><br/>
-  Create, sync, and operate across dozens of Git repositories with a single command —
-  and wire them up to your favorite coding agent.
+  <b>Work on many Git repos as if they were one project.</b><br/>
+  Nemus pulls the repos you're working on into a single folder, runs commands across
+  all of them at once, and gives your AI coding agent the whole picture.
 </p>
 
 <p align="center">
@@ -28,26 +28,52 @@
 
 ---
 
+## What is Nemus?
+
+Your product's code is probably split across **many separate Git repos** — frontend,
+backend, auth, payments, shared libraries. Working on one feature means cloning,
+pulling, branching, and testing each repo by hand, one at a time — and your AI coding
+agent only ever sees the single repo you happened to open.
+
+**Nemus lets you pull the repos you're working on into one folder and treat them as a
+single project:**
+
+- **One command clones them all** — and keeps them in sync.
+- **Run any git or shell command across every repo at once** — `status`, `pull`,
+  `branch`, `npm test`, anything.
+- **Your AI agent sees the whole set at once** — so a prompt like *"add idempotency
+  keys to the payments flow"* works even when that flow spans five repos, not one.
+
+> **In short:** a **monorepo-style workflow across your many repos — without merging them.**
+
+### Before vs. after
+
+**Without Nemus** — clone six repos by hand, `cd` into each, pull, branch, run tests,
+repeat six times. Your agent only sees whichever repo you opened.
+
+**With Nemus:**
+
+```bash
+nemus create payments          # clones the 6 payments repos into one workspace
+nemus run payments "npm test"  # runs the tests in all 6 at once
+nemus -- "add idempotency keys to the payments flow"   # the agent works across all 6
+```
+
+## What you get
+
+- 🌳 **Workspaces** — group repos, clone them all in parallel, jump in.
+- 🔁 **Operate in bulk** — status, sync, diff, run, branch across every repo.
+- 📦 **Suites & snapshots** — save reusable repo collections and exact states.
+- 🤖 **Agent-native** — first-class integration with multiple coding agents
+  (Claude Code, pi, OpenCode, Codex, Gemini) via context files, skills, and an MCP server.
+- 🩺 **Healthy by default** — health checks, dependency analysis, retries.
+
 ## The name
 
 **Nemus** (_NEH-mus_) is Latin for a **grove** — a small wood of trees sharing
 soil and roots. It's a fitting picture of what the tool manages: a cluster of
 repositories, each its own tree, growing together in one workspace. It also nods
 to the branch-and-commit shape of Git itself.
-
-## Why Nemus?
-
-Modern products span many repositories. Nemus keeps a **workspace** — a named folder
-of related repos — in sync and lets you act across all of them at once: clone, pull,
-branch, run commands, check status, and diff. Then it connects that workspace to a
-coding agent (Claude Code, pi, OpenCode, Codex, Gemini) with generated context files,
-skills, and an MCP server, so "work on the payments stack" becomes a single prompt.
-
-- 🌳 **Workspaces** — group repos, clone them all, jump in.
-- 🔁 **Operate in bulk** — status, sync, diff, run, branch across every repo.
-- 📦 **Suites & snapshots** — save reusable repo collections and exact states.
-- 🤖 **Agent-native** — first-class integration with multiple coding agents.
-- 🩺 **Healthy by default** — health checks, dependency analysis, retries.
 
 ## A full clone per workspace — on purpose
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -181,9 +181,10 @@
   <div class="wrap">
     <div>
       <span class="eyebrow"><span class="dot"></span> Open source · MIT · Node ≥ 22</span>
-      <h1>Multi-repo workspaces<br/>for the <span class="accent">AI-agent era</span></h1>
-      <p class="sub">One command to clone, sync, branch, and run across dozens of Git repositories —
-        then hand the whole workspace to your coding agent.</p>
+      <h1>Work on many repos<br/>as if they were <span class="accent">one project</span></h1>
+      <p class="sub">Your code is split across many Git repos. Nemus pulls the ones you're working on into
+        one folder, runs commands across all of them at once, and gives your AI coding agent the
+        whole picture — <b>a monorepo-style workflow without merging your repos.</b></p>
       <div class="cta">
         <a class="btn primary" href="#quickstart">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="8 5 8 19 19 12 8 5"/></svg>
@@ -211,8 +212,9 @@
   <div class="wrap">
     <div class="sec-head">
       <h2>Everything, across every repo</h2>
-      <p>Modern products span many repositories. Nemus keeps a workspace — a named folder of related
-        repos — in sync and lets you act on all of them at once.</p>
+      <p>A <b>workspace</b> is just a folder holding the repos you're working on. One command clones
+        them all; then <code>status</code>, <code>sync</code>, <code>branch</code>, and <code>run</code>
+        act on every repo at once — and your agent sees the whole set.</p>
     </div>
     <div class="grid">
       <div class="card">

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1,6 +1,8 @@
 # Nemus — full documentation
 
-> Multi-repo workspaces for the AI-agent era. This file inlines the full
+> Work on many Git repos as if they were one project. Nemus pulls the repos
+> you're working on into one folder, runs commands across all of them at once,
+> and gives your AI coding agent the whole picture. This file inlines the full
 > project README for LLM consumption. Canonical source:
 > https://github.com/me-public/nemus
 
@@ -11,24 +13,70 @@
 </p>
 
 <p align="center">
-  <b>Multi-repo workspaces for the AI-agent era.</b><br/>
-  Create, sync, and operate across dozens of Git repositories with a single command —
-  and wire them up to your favorite coding agent.
+  <b>Work on many Git repos as if they were one project.</b><br/>
+  Nemus pulls the repos you're working on into a single folder, runs commands across
+  all of them at once, and gives your AI coding agent the whole picture.
 </p>
 
 <p align="center">
+  <a href="https://me-public.github.io/nemus/"><img src="https://img.shields.io/badge/website-nemus-3FB950.svg" alt="Website" /></a>
   <a href="https://github.com/me-public/nemus/actions/workflows/ci.yml"><img src="https://github.com/me-public/nemus/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="https://www.npmjs.com/package/@nemus-cli/nemus"><img src="https://img.shields.io/npm/v/@nemus-cli/nemus.svg" alt="npm" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT" /></a>
   <a href="https://www.npmjs.com/package/@nemus-cli/nemus"><img src="https://img.shields.io/npm/dm/@nemus-cli/nemus.svg" alt="npm downloads" /></a>
   <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen.svg" alt="Node >= 22" />
+  <a href="https://x.com/nemus_cli"><img src="https://img.shields.io/badge/follow-%40nemus__cli-000000.svg?logo=x&logoColor=white" alt="Follow @nemus_cli on X" /></a>
 </p>
 
 <p align="center">
-  📦 <b><a href="https://www.npmjs.com/package/@nemus-cli/nemus">@nemus-cli/nemus</a></b> on npm &nbsp;—&nbsp; <code>npm install -g @nemus-cli/nemus</code>
+  🌐 <b><a href="https://me-public.github.io/nemus/">me-public.github.io/nemus</a></b> &nbsp;—&nbsp; 📦 <b><a href="https://www.npmjs.com/package/@nemus-cli/nemus">@nemus-cli/nemus</a></b> on npm &nbsp;—&nbsp; 𝕏 <b><a href="https://x.com/nemus_cli">@nemus_cli</a></b> &nbsp;—&nbsp; <code>npm install -g @nemus-cli/nemus</code>
+</p>
+
+<p align="center">
+  <a href="https://me-public.github.io/nemus/"><img src="https://raw.githubusercontent.com/me-public/nemus/main/docs/assets/nemus-demo.gif" alt="Nemus terminal demo — create a workspace, run across every repo, hand it to your agent" width="760" /></a>
 </p>
 
 ---
+
+## What is Nemus?
+
+Your product's code is probably split across **many separate Git repos** — frontend,
+backend, auth, payments, shared libraries. Working on one feature means cloning,
+pulling, branching, and testing each repo by hand, one at a time — and your AI coding
+agent only ever sees the single repo you happened to open.
+
+**Nemus lets you pull the repos you're working on into one folder and treat them as a
+single project:**
+
+- **One command clones them all** — and keeps them in sync.
+- **Run any git or shell command across every repo at once** — `status`, `pull`,
+  `branch`, `npm test`, anything.
+- **Your AI agent sees the whole set at once** — so a prompt like *"add idempotency
+  keys to the payments flow"* works even when that flow spans five repos, not one.
+
+> **In short:** a **monorepo-style workflow across your many repos — without merging them.**
+
+### Before vs. after
+
+**Without Nemus** — clone six repos by hand, `cd` into each, pull, branch, run tests,
+repeat six times. Your agent only sees whichever repo you opened.
+
+**With Nemus:**
+
+```bash
+nemus create payments          # clones the 6 payments repos into one workspace
+nemus run payments "npm test"  # runs the tests in all 6 at once
+nemus -- "add idempotency keys to the payments flow"   # the agent works across all 6
+```
+
+## What you get
+
+- 🌳 **Workspaces** — group repos, clone them all in parallel, jump in.
+- 🔁 **Operate in bulk** — status, sync, diff, run, branch across every repo.
+- 📦 **Suites & snapshots** — save reusable repo collections and exact states.
+- 🤖 **Agent-native** — first-class integration with multiple coding agents
+  (Claude Code, pi, OpenCode, Codex, Gemini) via context files, skills, and an MCP server.
+- 🩺 **Healthy by default** — health checks, dependency analysis, retries.
 
 ## The name
 
@@ -36,20 +84,6 @@
 soil and roots. It's a fitting picture of what the tool manages: a cluster of
 repositories, each its own tree, growing together in one workspace. It also nods
 to the branch-and-commit shape of Git itself.
-
-## Why Nemus?
-
-Modern products span many repositories. Nemus keeps a **workspace** — a named folder
-of related repos — in sync and lets you act across all of them at once: clone, pull,
-branch, run commands, check status, and diff. Then it connects that workspace to a
-coding agent (Claude Code, pi, OpenCode, Codex, Gemini) with generated context files,
-skills, and an MCP server, so "work on the payments stack" becomes a single prompt.
-
-- 🌳 **Workspaces** — group repos, clone them all, jump in.
-- 🔁 **Operate in bulk** — status, sync, diff, run, branch across every repo.
-- 📦 **Suites & snapshots** — save reusable repo collections and exact states.
-- 🤖 **Agent-native** — first-class integration with multiple coding agents.
-- 🩺 **Healthy by default** — health checks, dependency analysis, retries.
 
 ## A full clone per workspace — on purpose
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -58,16 +58,19 @@ single project:**
 
 ### Before vs. after
 
-**Without Nemus** — clone six repos by hand, `cd` into each, pull, branch, run tests,
-repeat six times. Your agent only sees whichever repo you opened.
+**Without Nemus** — clone each repo by hand, `cd` into every one, pull, branch, run
+tests, and repeat. Your agent only sees whichever repo you opened.
 
 **With Nemus:**
 
 ```bash
-nemus create payments          # clones the 6 payments repos into one workspace
-nemus run payments "npm test"  # runs the tests in all 6 at once
-nemus -- "add idempotency keys to the payments flow"   # the agent works across all 6
+nemus create -w payments -r api,web,ledger,gateway,workers   # clone all 5 into one workspace
+nemus run payments "npm test"                                # run the tests in all 5 at once
+nemus -- "add idempotency keys to the payments flow"         # let an agent work across all 5
 ```
+
+> Prefer to point-and-pick? Just run `nemus create` for an interactive repo picker with
+> fuzzy search, or `nemus -- "create a workspace with the payments repos"` in plain English.
 
 ## What you get
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -9,9 +9,13 @@
 
 Concretely, with Nemus you can:
 
-- `nemus create payments` — clone the 6 payments repos into one workspace folder.
-- `nemus run payments "npm test"` — run the same command in all 6 repos at once.
-- `nemus -- "add idempotency keys to the payments flow"` — an agent works across all 6.
+- `nemus create -w payments -r api,web,ledger,gateway,workers` — clone those 5 repos
+  into one workspace folder (or `nemus create` for an interactive fuzzy picker).
+- `nemus run payments "npm test"` — run the same command in all 5 repos at once.
+- `nemus -- "add idempotency keys to the payments flow"` — an agent works across all 5.
+
+Command shapes: `create` takes options (`-w/--workspace <name>`, `-r/--repos <csv>`),
+not a positional; `run [workspace] "<command>"` runs a shell command across every repo.
 
 It connects a workspace to a coding agent (Claude Code, pi, OpenCode, Codex, Gemini)
 via generated context files, installable skills, and an MCP server — so a task that

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,10 +1,21 @@
 # Nemus
 
-> Nemus is a command-line tool for managing multi-repository development workspaces.
-> It creates, syncs, and operates across dozens of Git repositories at once, then
-> connects a workspace to a coding agent (Claude Code, pi, OpenCode, Codex, Gemini)
-> via generated context files, installable skills, and an MCP server — so a task
-> that spans many repos becomes a single prompt.
+> Nemus is a command-line tool that lets you work on many separate Git repositories
+> as if they were one project. Your product's code is split across many repos
+> (frontend, backend, auth, payments, shared libraries); Nemus pulls the repos you're
+> working on into a single folder (a "workspace"), runs any git or shell command
+> across all of them at once, and gives your AI coding agent the whole set at once.
+> It is, in short, a monorepo-style workflow across many repos — without merging them.
+
+Concretely, with Nemus you can:
+
+- `nemus create payments` — clone the 6 payments repos into one workspace folder.
+- `nemus run payments "npm test"` — run the same command in all 6 repos at once.
+- `nemus -- "add idempotency keys to the payments flow"` — an agent works across all 6.
+
+It connects a workspace to a coding agent (Claude Code, pi, OpenCode, Codex, Gemini)
+via generated context files, installable skills, and an MCP server — so a task that
+spans many repos becomes a single prompt.
 
 Key ideas an LLM should know:
 


### PR DESCRIPTION
Some people said they couldn't tell **what Nemus actually does**. The cause: the README opened with the *etymology* ("The name") before ever explaining the tool, and both the README tagline and the site hero led with the abstract line *"Multi-repo workspaces for the AI-agent era."* Nothing stated the concrete problem→solution in the first five seconds.

### Changes (docs-only — no version bump)
- **README** — new **`## What is Nemus?`** as the *first* section: plain problem framing, a one-line mental model (**"a monorepo-style workflow across your many repos — without merging them"**), and a **before/after** with real commands. "The name" moved below it; "Why Nemus?" folded into **"What you get."** Tagline made concrete.
- **Site (`docs/index.html`)** — hero is now **"Work on many repos as if they were one project"** with a plain sub-line; the features intro now says what a *workspace* actually is.
- **`llms.txt`** — concrete summary + example commands so an LLM describes Nemus correctly.
- **`llms-full.txt`** — regenerated from the updated README (it had drifted to the old copy).

### Before / after (hero)
Old: *"Multi-repo workspaces for the AI-agent era"* → abstract.
New: *"Work on many repos as if they were one project. Your code is split across many Git repos. Nemus pulls the ones you're working on into one folder, runs commands across all of them at once, and gives your AI coding agent the whole picture."*

No code touched; site auto-deploys on merge.