### PR TITLE
feat(cloud): provisioning seam — OpenTofu provisioner + Fargate module (P2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,10 @@ Thumbs.db
 # The image installs THIS commit rather than the last published release.
 infra/docker/workspace-manager.tgz
 *.tgz
+
+# OpenTofu / Terraform local state + provider caches (IaC modules are templates)
+**/.terraform/
+**/.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+crash.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`openPR`/`getChecks`/`comment`) with a dependency-free GitHub implementation;
   and the **in-image agent orchestrator** (runner-image env contract, versioned
   `result.json` schema, and `runAgentTask`: clone all → run the agent once over
-  the workspace → open a PR per changed repo, with per-repo error isolation).
+  the workspace → open a PR per changed repo, with per-repo error isolation);
+  the **OCI image + `nemus-cloud-agent` entrypoint** (a Dockerfile with node +
+  git + gh + pi/claude); and the **provisioning** seam (P2, in progress): a
+  generic `OpenTofuProvisioner` (delegates to `tofu`/`terraform`, maps a module's
+  `target` output → `TargetDescriptor`) + registry, plus a first **AWS Fargate**
+  OpenTofu module (`iac/fargate/`, validated with real `tofu validate`).
   Design: `docs/plans/2026-08-26-cloud-iac.md`.
 
 ## [0.2.9] - 2026-08-26

--- a/docs/plans/2026-08-26-cloud-iac.md
+++ b/docs/plans/2026-08-26-cloud-iac.md
@@ -148,8 +148,18 @@ in log streams. PAT is always the zero-config fallback.
   exit code), and a Dockerfile (node + git + gh + pi/claude, non-root). **← done
   (P1 complete).** Follow-ups: two-phase plan/execute in the invoker; log +
   `result.json` upload; then the CI-loop (P3).
-- **P2 — IaC + first cloud provider.** OpenTofu modules; `nemus cloud init/up/down`;
-  first cloud target (Fly *or* AWS Fargate).
+- **P2 — IaC + first cloud provider.** _(in progress)_ **Provisioning seam done:**
+  a single generic `OpenTofuProvisioner` (shells `tofu`/`terraform`, injectable
+  exec, maps the module's `target` output → `TargetDescriptor`) + a provisioner
+  **registry** (`opentofu`/`terraform`), unit-tested; and the **first module**,
+  `iac/fargate/` (ECS Fargate cluster + log group + egress-only SG + execution
+  role; emits the `aws-fargate` `TargetDescriptor`), **validated with real
+  `tofu validate` against `hashicorp/aws`**. Chose Fargate over Fly as the first
+  module purely for validatability (solid provider vs. flaky Fly community
+  provider) — the provisioner is generic, so **Fly is just another module**
+  (follow-up). **Next:** the matching cloud **`Runner`** (`aws-fargate`:
+  register task-def + `RunTask` + logs via CloudWatch) and a thin `nemus cloud
+  up/down/run` CLI (its own bin in this package).
 - **P3 — report-back (draft PR) + bounded CI-loop** over `GitForge`.
 - **P4 — more providers (plugins), optional Slack, optional hosted UI.**
 

--- a/packages/cloud/README.md
+++ b/packages/cloud/README.md
@@ -62,6 +62,29 @@ await runner.status(handle); // { state: 'succeeded' | 'failed' | … }
 The **`docker` runner is the portability boundary's proof**: if a feature can't
 work against a local Docker socket, it doesn't belong in core.
 
+## The provisioning seam: IaC modules
+
+Provisioning (stand up a place to run) is split from execution (run a task).
+Rather than invent an IaC DSL, one generic **`OpenTofuProvisioner`** delegates to
+real `tofu`/`terraform` over a module directory and maps the module's `target`
+output to a `TargetDescriptor`. Provider quirks (VPC, roles, Fly org) stay in the
+module's HCL + vars — never in core. One provisioner, many modules.
+
+```ts
+import { createProvisioner } from '@nemus-cli/cloud';
+
+const p = createProvisioner('opentofu', {
+  moduleDir: require.resolve('@nemus-cli/cloud/iac/fargate'),
+  vars: { region: 'us-east-1', name: 'nemus' },
+});
+const target = await p.up();   // tofu init + apply -> TargetDescriptor
+// … createRunner(target.runner).launch(spec, target) …
+await p.down(target);          // tofu destroy
+```
+
+Shipped modules live under [`iac/`](./iac): `iac/fargate/` (AWS ECS Fargate,
+validated with real `tofu validate`). Fly and others are just more modules.
+
 ## Develop
 
 ```bash

--- a/packages/cloud/README.md
+++ b/packages/cloud/README.md
@@ -71,10 +71,10 @@ output to a `TargetDescriptor`. Provider quirks (VPC, roles, Fly org) stay in th
 module's HCL + vars — never in core. One provisioner, many modules.
 
 ```ts
-import { createProvisioner } from '@nemus-cli/cloud';
+import { createProvisioner, iacModuleDir } from '@nemus-cli/cloud';
 
 const p = createProvisioner('opentofu', {
-  moduleDir: require.resolve('@nemus-cli/cloud/iac/fargate'),
+  moduleDir: iacModuleDir('fargate'), // a real path to the shipped module
   vars: { region: 'us-east-1', name: 'nemus' },
 });
 const target = await p.up();   // tofu init + apply -> TargetDescriptor
@@ -84,6 +84,12 @@ await p.down(target);          // tofu destroy
 
 Shipped modules live under [`iac/`](./iac): `iac/fargate/` (AWS ECS Fargate,
 validated with real `tofu validate`). Fly and others are just more modules.
+
+The shipped module is a **template** — running `tofu` against `iacModuleDir(...)`
+directly writes state under `node_modules`. For anything real, **copy it to your
+own working dir** (or point a remote backend at it) so state is durable, and
+**don't pass secrets as `-var`** (they land in argv and the streamed apply log —
+use the provider's own credential env / a `SecretSource`).
 
 ## Develop
 

--- a/packages/cloud/iac/fargate/README.md
+++ b/packages/cloud/iac/fargate/README.md
@@ -1,0 +1,59 @@
+# Nemus cloud target — AWS Fargate (OpenTofu module)
+
+Provisions the **durable** half of a Fargate execution target: an ECS cluster
+(Fargate capacity provider), a CloudWatch log group, an egress-only task
+security group, and a task **execution** role. The per-run task definition and
+`RunTask` are the *Runner's* job — fast and ephemeral — so this module owns only
+what is slow, stateful, and rare.
+
+It emits a single `target` output that maps directly to a Nemus
+`TargetDescriptor` for the `aws-fargate` runner.
+
+## Use it via Nemus
+
+```ts
+import { createProvisioner, createRunner } from '@nemus-cli/cloud';
+
+const provisioner = createProvisioner('opentofu', {
+  moduleDir: require.resolve('@nemus-cli/cloud/iac/fargate'), // or a path
+  vars: { region: 'us-east-1', name: 'nemus' },
+});
+
+const target = await provisioner.up();      // tofu init + apply -> TargetDescriptor
+// const runner = createRunner('aws-fargate'); // (P2 follow-up) launches tasks on `target`
+// … run tasks …
+await provisioner.down(target);             // tofu destroy
+```
+
+## Use it directly
+
+```bash
+cd packages/cloud/iac/fargate
+tofu init
+tofu apply -var region=us-east-1 -var name=nemus
+tofu output -json target
+```
+
+## Inputs
+
+| var | default | notes |
+| --- | --- | --- |
+| `region` | `us-east-1` | AWS region |
+| `name` | `nemus` | prefix for cluster/log-group/role |
+| `vpc_id` | `""` | empty → the account's **default VPC** |
+| `subnet_ids` | `[]` | empty → all subnets in the selected VPC |
+| `log_retention_days` | `14` | CloudWatch Logs retention |
+| `tags` | `{}` | extra tags on every resource |
+
+## Notes
+
+- **Credentials:** standard AWS provider auth (`AWS_PROFILE` / env / SSO). The
+  module needs permissions to create ECS, IAM, CloudWatch Logs, and EC2 SG
+  resources.
+- **State** is local by default. For a team, add your own
+  [backend](https://opentofu.org/docs/language/settings/backends/configuration/)
+  block — the module is backend-agnostic.
+- **No task role.** The agent authenticates to the git forge with a token from
+  its environment (a `ForgeTokenSource`), not cloud IAM, so tasks are granted no
+  AWS permissions. The *execution* role only pulls the image and writes logs.
+- Validated with `tofu validate` against `hashicorp/aws ~> 5.60`.

--- a/packages/cloud/iac/fargate/README.md
+++ b/packages/cloud/iac/fargate/README.md
@@ -53,9 +53,12 @@ tofu output -json target
 - **This is a template.** Running `tofu` against the copy shipped under
   `node_modules` writes `.terraform/` + state there (fragile / sometimes
   read-only). Copy this directory into your own working dir first.
-- **State** is local by default. For a team, add your own
+- **State** is local by default. For a team — or to `down()` from a *different*
+  machine than the one that ran `up()` — add your own
   [backend](https://opentofu.org/docs/language/settings/backends/configuration/)
-  block — the module is backend-agnostic.
+  block. The descriptor's `extra.tofu_vars` hand-back only re-derives the input
+  *vars*; tofu still needs the **state**, and local state isn't portable, so a
+  truly stateless teardown requires a shared/remote backend.
 - **Subnets:** by default the module surfaces *all* subnets in the VPC. Fargate
   tasks need to reach the image registry + git forge, so the Runner must place
   them on public subnets with a public IP, or on private subnets behind a NAT.

--- a/packages/cloud/iac/fargate/README.md
+++ b/packages/cloud/iac/fargate/README.md
@@ -12,10 +12,10 @@ It emits a single `target` output that maps directly to a Nemus
 ## Use it via Nemus
 
 ```ts
-import { createProvisioner, createRunner } from '@nemus-cli/cloud';
+import { createProvisioner, iacModuleDir } from '@nemus-cli/cloud';
 
 const provisioner = createProvisioner('opentofu', {
-  moduleDir: require.resolve('@nemus-cli/cloud/iac/fargate'), // or a path
+  moduleDir: iacModuleDir('fargate'), // a real path to this shipped module
   vars: { region: 'us-east-1', name: 'nemus' },
 });
 
@@ -50,9 +50,18 @@ tofu output -json target
 - **Credentials:** standard AWS provider auth (`AWS_PROFILE` / env / SSO). The
   module needs permissions to create ECS, IAM, CloudWatch Logs, and EC2 SG
   resources.
+- **This is a template.** Running `tofu` against the copy shipped under
+  `node_modules` writes `.terraform/` + state there (fragile / sometimes
+  read-only). Copy this directory into your own working dir first.
 - **State** is local by default. For a team, add your own
   [backend](https://opentofu.org/docs/language/settings/backends/configuration/)
   block — the module is backend-agnostic.
+- **Subnets:** by default the module surfaces *all* subnets in the VPC. Fargate
+  tasks need to reach the image registry + git forge, so the Runner must place
+  them on public subnets with a public IP, or on private subnets behind a NAT.
+  Pass `subnet_ids` to pin the right ones.
+- **Don't pass secrets as `-var`** — they land in argv and the streamed apply
+  log. Use the AWS provider's own credential env.
 - **No task role.** The agent authenticates to the git forge with a token from
   its environment (a `ForgeTokenSource`), not cloud IAM, so tasks are granted no
   AWS permissions. The *execution* role only pulls the image and writes logs.

--- a/packages/cloud/iac/fargate/main.tf
+++ b/packages/cloud/iac/fargate/main.tf
@@ -1,0 +1,97 @@
+locals {
+  tags = merge({
+    "managed-by"      = "nemus"
+    "nemus:component" = "cloud-runner"
+  }, var.tags)
+}
+
+# --- Network: use the account's default VPC/subnets unless the caller overrides.
+data "aws_vpc" "default" {
+  count   = var.vpc_id == "" ? 1 : 0
+  default = true
+}
+
+locals {
+  vpc_id = var.vpc_id != "" ? var.vpc_id : data.aws_vpc.default[0].id
+}
+
+data "aws_subnets" "selected" {
+  count = length(var.subnet_ids) == 0 ? 1 : 0
+  filter {
+    name   = "vpc-id"
+    values = [local.vpc_id]
+  }
+}
+
+locals {
+  subnet_ids = length(var.subnet_ids) > 0 ? var.subnet_ids : data.aws_subnets.selected[0].ids
+}
+
+# --- Durable, provision-once resources. The per-run task definition + RunTask
+#     are the Runner's job (fast, ephemeral); this module owns only what's slow
+#     and stateful: the cluster, its log group, the task SG, and the exec role.
+resource "aws_ecs_cluster" "this" {
+  name = var.name
+  tags = local.tags
+}
+
+resource "aws_ecs_cluster_capacity_providers" "this" {
+  cluster_name       = aws_ecs_cluster.this.name
+  capacity_providers = ["FARGATE"]
+
+  default_capacity_provider_strategy {
+    capacity_provider = "FARGATE"
+    weight            = 1
+  }
+}
+
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/nemus/${var.name}"
+  retention_in_days = var.log_retention_days
+  tags              = local.tags
+}
+
+# Egress-only SG: tasks pull the image and reach the git forge; nothing inbound.
+resource "aws_security_group" "task" {
+  name_prefix = "${var.name}-task-"
+  description = "Nemus Fargate task security group (egress only)"
+  vpc_id      = local.vpc_id
+
+  egress {
+    description = "All egress"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = local.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# --- Task EXECUTION role: pull the image + write logs. The task ROLE (app
+#     permissions) is deliberately omitted — the agent authenticates to the git
+#     forge with a token from env, not cloud IAM, so it needs no AWS permissions.
+data "aws_iam_policy_document" "assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "execution" {
+  name_prefix        = "${var.name}-exec-"
+  assume_role_policy = data.aws_iam_policy_document.assume.json
+  tags               = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "execution" {
+  role       = aws_iam_role.execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}

--- a/packages/cloud/iac/fargate/outputs.tf
+++ b/packages/cloud/iac/fargate/outputs.tf
@@ -1,0 +1,23 @@
+# The single output Nemus reads: a TargetDescriptor for the `aws-fargate` runner.
+# The OpenTofuProvisioner maps `output.target.value` straight to a
+# TargetDescriptor; provider-specific handles live under `extra`.
+output "target" {
+  description = "Nemus TargetDescriptor for the aws-fargate runner."
+  value = {
+    version = 1
+    runner  = "aws-fargate"
+    region  = var.region
+    cluster = aws_ecs_cluster.this.name
+    extra = {
+      subnets            = local.subnet_ids
+      security_group_id  = aws_security_group.task.id
+      execution_role_arn = aws_iam_role.execution.arn
+      log_group          = aws_cloudwatch_log_group.this.name
+      # Handed back so a stateless `down` can re-derive the module's vars.
+      tofuVars = {
+        region = var.region
+        name   = var.name
+      }
+    }
+  }
+}

--- a/packages/cloud/iac/fargate/outputs.tf
+++ b/packages/cloud/iac/fargate/outputs.tf
@@ -13,8 +13,9 @@ output "target" {
       security_group_id  = aws_security_group.task.id
       execution_role_arn = aws_iam_role.execution.arn
       log_group          = aws_cloudwatch_log_group.this.name
-      # Handed back so a stateless `down` can re-derive the module's vars.
-      tofuVars = {
+      # Handed back so `down` can re-derive the module's vars. (snake_case to
+      # match the other extra handles; core reads target.extra.tofu_vars.)
+      tofu_vars = {
         region = var.region
         name   = var.name
       }

--- a/packages/cloud/iac/fargate/variables.tf
+++ b/packages/cloud/iac/fargate/variables.tf
@@ -1,0 +1,35 @@
+variable "region" {
+  description = "AWS region to provision the Fargate target in."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "name" {
+  description = "Name prefix for the cluster and related resources."
+  type        = string
+  default     = "nemus"
+}
+
+variable "vpc_id" {
+  description = "VPC to run tasks in. Empty string uses the account's default VPC."
+  type        = string
+  default     = ""
+}
+
+variable "subnet_ids" {
+  description = "Subnets for tasks. Empty list uses all subnets in the selected VPC."
+  type        = list(string)
+  default     = []
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch Logs retention (days) for task logs."
+  type        = number
+  default     = 14
+}
+
+variable "tags" {
+  description = "Extra tags applied to every resource."
+  type        = map(string)
+  default     = {}
+}

--- a/packages/cloud/iac/fargate/versions.tf
+++ b/packages/cloud/iac/fargate/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.60"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -26,6 +26,7 @@
   "files": [
     "dist/**/*",
     "image/**/*",
+    "iac/**/*",
     "README.md"
   ],
   "scripts": {

--- a/packages/cloud/src/index.ts
+++ b/packages/cloud/src/index.ts
@@ -38,6 +38,12 @@ export { ShellAgentInvoker, buildAgentCommand } from './agent/agent-invoker';
 export { shellExec, run as runCommand } from './agent/exec';
 export type { Exec } from './agent/exec';
 
+// Provisioning seam: one generic OpenTofu/Terraform provisioner, many modules.
+export { OpenTofuProvisioner, parseTargetDescriptor } from './provision/opentofu';
+export type { OpenTofuProvisionerOptions } from './provision/opentofu';
+export { createProvisioner, registerProvisioner, provisionerNames } from './provision/registry';
+export type { ProvisionerFactory } from './provision/registry';
+
 import { ForgeTokenSource } from './forge/types';
 import { PatTokenSource } from './forge/pat';
 import { GitHubAppTokenSource, GitHubAppConfig } from './forge/github-app';

--- a/packages/cloud/src/index.ts
+++ b/packages/cloud/src/index.ts
@@ -43,6 +43,7 @@ export { OpenTofuProvisioner, parseTargetDescriptor } from './provision/opentofu
 export type { OpenTofuProvisionerOptions } from './provision/opentofu';
 export { createProvisioner, registerProvisioner, provisionerNames } from './provision/registry';
 export type { ProvisionerFactory } from './provision/registry';
+export { iacModuleDir } from './provision/modules';
 
 import { ForgeTokenSource } from './forge/types';
 import { PatTokenSource } from './forge/pat';

--- a/packages/cloud/src/provision/modules.ts
+++ b/packages/cloud/src/provision/modules.ts
@@ -1,0 +1,19 @@
+import * as path from 'node:path';
+
+/**
+ * Absolute path to a shipped IaC module directory (e.g. `iacModuleDir('fargate')`),
+ * for use as {@link OpenTofuProvisioner}'s `moduleDir`.
+ *
+ * The shipped module is a **template**. Running `tofu` directly against this
+ * path writes `.terraform/` + local state *inside the installed package* (under
+ * `node_modules`), which is fragile (wiped on reinstall, sometimes read-only).
+ * For anything real, copy the returned directory into your own working dir — or
+ * point a remote backend at it — so state lives somewhere durable.
+ *
+ * Works both from source (tests) and from `dist/` at runtime: `src/provision`
+ * and `dist/provision` are both direct children of the package root, next to
+ * `iac/`.
+ */
+export function iacModuleDir(name: string): string {
+  return path.join(__dirname, '..', '..', 'iac', name);
+}

--- a/packages/cloud/src/provision/opentofu.test.ts
+++ b/packages/cloud/src/provision/opentofu.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest';
+import { existsSync } from 'node:fs';
+import * as path from 'node:path';
 import { OpenTofuProvisioner, parseTargetDescriptor } from './opentofu';
 import { createProvisioner, provisionerNames, registerProvisioner } from './registry';
+import { iacModuleDir } from './modules';
 import { Exec, ExecResultRaw } from '../agent/exec';
 
 function recorder(outputs: Record<string, ExecResultRaw> = {}) {
@@ -83,5 +86,15 @@ describe('provisioner registry', () => {
   it('is extensible', () => {
     registerProvisioner('fake', () => ({ id: 'fake', up: async () => ({ version: 1, runner: 'fake' }), down: async () => {} }));
     expect(createProvisioner('fake').id).toBe('fake');
+  });
+});
+
+describe('iacModuleDir', () => {
+  it('resolves to a shipped module that actually exists on disk', () => {
+    const dir = iacModuleDir('fargate');
+    expect(dir.endsWith(path.join('iac', 'fargate'))).toBe(true);
+    // the whole point of the helper: the path is real (require.resolve on a
+    // dir throws MODULE_NOT_FOUND, which is the bug it replaces)
+    expect(existsSync(path.join(dir, 'versions.tf'))).toBe(true);
   });
 });

--- a/packages/cloud/src/provision/opentofu.test.ts
+++ b/packages/cloud/src/provision/opentofu.test.ts
@@ -17,7 +17,7 @@ function recorder(outputs: Record<string, ExecResultRaw> = {}) {
 }
 
 const targetJson = JSON.stringify({
-  target: { value: { version: 1, runner: 'aws-fargate', region: 'us-east-1', cluster: 'nemus', extra: { logGroup: '/nemus' } } },
+  target: { value: { version: 1, runner: 'aws-fargate', region: 'us-east-1', cluster: 'nemus', extra: { log_group: '/nemus' } } },
   other: { value: 'ignored' },
 });
 
@@ -38,18 +38,20 @@ describe('OpenTofuProvisioner.up', () => {
     expect(apply).toContain('region=us-east-1');
     expect(apply).toContain('app_name=demo');
     expect(apply).toContain('replicas=2'); // non-string JSON-stringified
-    expect(target).toEqual({ version: 1, runner: 'aws-fargate', region: 'us-east-1', cluster: 'nemus', extra: { logGroup: '/nemus' } });
+    expect(target).toEqual({ version: 1, runner: 'aws-fargate', region: 'us-east-1', cluster: 'nemus', extra: { log_group: '/nemus' } });
   });
 
-  it('down runs destroy with construction + handed-back vars', async () => {
+  it('down runs init THEN destroy with construction + handed-back vars', async () => {
     const { exec, calls } = recorder();
     const p = new OpenTofuProvisioner({ moduleDir: '/iac/fly', bin: 'terraform', vars: { org: 'acme' }, exec });
-    await p.down({ version: 1, runner: 'fly', extra: { tofuVars: { app: 'demo' } } });
-    expect(calls[0].bin).toBe('terraform');
-    expect(calls[0].args[1]).toBe('destroy');
-    expect(calls[0].args).toContain('-auto-approve');
-    expect(calls[0].args).toContain('org=acme');
-    expect(calls[0].args).toContain('app=demo');
+    await p.down({ version: 1, runner: 'fly', extra: { tofu_vars: { app: 'demo' } } });
+    // init must run before destroy: a fresh process has no provider plugins
+    expect(calls.map((c) => c.args[1])).toEqual(['init', 'destroy']);
+    expect(calls.every((c) => c.bin === 'terraform')).toBe(true);
+    const destroy = calls[1].args;
+    expect(destroy).toContain('-auto-approve');
+    expect(destroy).toContain('org=acme');
+    expect(destroy).toContain('app=demo');
   });
 
   it('requires a moduleDir', () => {
@@ -77,8 +79,9 @@ describe('provisioner registry', () => {
   it('ships opentofu + terraform', () => {
     expect(provisionerNames()).toEqual(expect.arrayContaining(['opentofu', 'terraform']));
   });
-  it('createProvisioner builds by name', () => {
+  it('createProvisioner builds by name, and terraform self-reports its own id', () => {
     expect(createProvisioner('opentofu', { moduleDir: '/x' }).id).toBe('opentofu');
+    expect(createProvisioner('terraform', { moduleDir: '/x' }).id).toBe('terraform');
   });
   it('unknown name throws with the available list', () => {
     expect(() => createProvisioner('nope', {})).toThrow(/unknown provisioner 'nope'.*opentofu/s);

--- a/packages/cloud/src/provision/opentofu.test.ts
+++ b/packages/cloud/src/provision/opentofu.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { OpenTofuProvisioner, parseTargetDescriptor } from './opentofu';
+import { createProvisioner, provisionerNames, registerProvisioner } from './registry';
+import { Exec, ExecResultRaw } from '../agent/exec';
+
+function recorder(outputs: Record<string, ExecResultRaw> = {}) {
+  const calls: { bin: string; args: string[] }[] = [];
+  const exec: Exec = async (bin, args) => {
+    calls.push({ bin, args });
+    const cmd = args.find((a) => !a.startsWith('-')) ?? '';
+    return outputs[cmd] ?? { code: 0, stdout: '', stderr: '' };
+  };
+  return { exec, calls };
+}
+
+const targetJson = JSON.stringify({
+  target: { value: { version: 1, runner: 'aws-fargate', region: 'us-east-1', cluster: 'nemus', extra: { logGroup: '/nemus' } } },
+  other: { value: 'ignored' },
+});
+
+describe('OpenTofuProvisioner.up', () => {
+  it('runs init → apply → output with -chdir + vars, returns the descriptor', async () => {
+    const { exec, calls } = recorder({ output: { code: 0, stdout: targetJson, stderr: '' } });
+    const p = new OpenTofuProvisioner({ moduleDir: '/iac/fargate', vars: { region: 'us-east-1' }, exec });
+
+    const target = await p.up({ app_name: 'demo', replicas: 2 });
+
+    expect(calls.map((c) => c.args[1])).toEqual(['init', 'apply', 'output']); // subcommand is arg[1] after -chdir
+    expect(calls[0].bin).toBe('tofu');
+    expect(calls.every((c) => c.args[0] === '-chdir=/iac/fargate')).toBe(true);
+    expect(calls.every((c) => c.args.includes('-input=false') && c.args.includes('-no-color'))).toBe(true);
+    // apply carries -auto-approve + merged, stringified vars
+    const apply = calls[1].args;
+    expect(apply).toContain('-auto-approve');
+    expect(apply).toContain('region=us-east-1');
+    expect(apply).toContain('app_name=demo');
+    expect(apply).toContain('replicas=2'); // non-string JSON-stringified
+    expect(target).toEqual({ version: 1, runner: 'aws-fargate', region: 'us-east-1', cluster: 'nemus', extra: { logGroup: '/nemus' } });
+  });
+
+  it('down runs destroy with construction + handed-back vars', async () => {
+    const { exec, calls } = recorder();
+    const p = new OpenTofuProvisioner({ moduleDir: '/iac/fly', bin: 'terraform', vars: { org: 'acme' }, exec });
+    await p.down({ version: 1, runner: 'fly', extra: { tofuVars: { app: 'demo' } } });
+    expect(calls[0].bin).toBe('terraform');
+    expect(calls[0].args[1]).toBe('destroy');
+    expect(calls[0].args).toContain('-auto-approve');
+    expect(calls[0].args).toContain('org=acme');
+    expect(calls[0].args).toContain('app=demo');
+  });
+
+  it('requires a moduleDir', () => {
+    expect(() => new OpenTofuProvisioner({ moduleDir: '' })).toThrow(/moduleDir/);
+  });
+});
+
+describe('parseTargetDescriptor', () => {
+  it('extracts and validates the named output', () => {
+    expect(parseTargetDescriptor(targetJson).runner).toBe('aws-fargate');
+  });
+  it('throws when the output is missing', () => {
+    expect(() => parseTargetDescriptor('{}')).toThrow(/no 'target' output/);
+  });
+  it('throws on a non-descriptor value', () => {
+    expect(() => parseTargetDescriptor(JSON.stringify({ target: { value: { runner: 'x' } } }))).toThrow(/TargetDescriptor/);
+    expect(() => parseTargetDescriptor(JSON.stringify({ target: { value: { version: 1 } } }))).toThrow(/TargetDescriptor/);
+  });
+  it('throws on unparseable json', () => {
+    expect(() => parseTargetDescriptor('not json')).toThrow(/could not parse/);
+  });
+});
+
+describe('provisioner registry', () => {
+  it('ships opentofu + terraform', () => {
+    expect(provisionerNames()).toEqual(expect.arrayContaining(['opentofu', 'terraform']));
+  });
+  it('createProvisioner builds by name', () => {
+    expect(createProvisioner('opentofu', { moduleDir: '/x' }).id).toBe('opentofu');
+  });
+  it('unknown name throws with the available list', () => {
+    expect(() => createProvisioner('nope', {})).toThrow(/unknown provisioner 'nope'.*opentofu/s);
+  });
+  it('is extensible', () => {
+    registerProvisioner('fake', () => ({ id: 'fake', up: async () => ({ version: 1, runner: 'fake' }), down: async () => {} }));
+    expect(createProvisioner('fake').id).toBe('fake');
+  });
+});

--- a/packages/cloud/src/provision/opentofu.ts
+++ b/packages/cloud/src/provision/opentofu.ts
@@ -8,6 +8,8 @@ export interface OpenTofuProvisionerOptions {
   vars?: Record<string, string>;
   /** IaC binary: 'tofu' (default) or 'terraform' — the CLIs are arg-compatible here. */
   bin?: string;
+  /** Provisioner id; defaults to the bin ('tofu' → 'opentofu', 'terraform' → 'terraform'). */
+  id?: string;
   /** Injectable for tests. */
   exec?: Exec;
   /** Name of the module output holding the TargetDescriptor JSON. Default 'target'. */
@@ -25,7 +27,7 @@ export interface OpenTofuProvisionerOptions {
  * unit-tested without touching real cloud state.
  */
 export class OpenTofuProvisioner implements Provisioner {
-  readonly id = 'opentofu';
+  readonly id: string;
   private readonly moduleDir: string;
   private readonly vars: Record<string, string>;
   private readonly bin: string;
@@ -37,6 +39,8 @@ export class OpenTofuProvisioner implements Provisioner {
     this.moduleDir = opts.moduleDir;
     this.vars = opts.vars ?? {};
     this.bin = opts.bin ?? 'tofu';
+    // A terraform-bin instance must not self-report as 'opentofu'.
+    this.id = opts.id ?? (this.bin === 'terraform' ? 'terraform' : 'opentofu');
     this.exec = opts.exec ?? shellExec;
     this.outputName = opts.outputName ?? 'target';
   }
@@ -52,8 +56,14 @@ export class OpenTofuProvisioner implements Provisioner {
   async down(target: TargetDescriptor): Promise<void> {
     // Vars can be handed back through the descriptor so a fresh process can tear
     // down what another stood up; construction vars remain the base.
-    const handed = (target.extra?.tofuVars as Record<string, string> | undefined) ?? {};
+    const handed = (target.extra?.tofu_vars as Record<string, string> | undefined) ?? {};
     const vars = { ...this.vars, ...handed };
+    // init before destroy: a fresh process (or a cleaned .terraform/) has no
+    // provider plugins installed, so destroy would fail without it. init is
+    // idempotent + cheap. (Note: with the default LOCAL state backend, a truly
+    // fresh process also has no state to destroy — portable teardown needs a
+    // shared/remote backend; see the module README.)
+    await run(this.exec, this.bin, this.args('init', []), { stream: true });
     await run(this.exec, this.bin, this.args('destroy', ['-auto-approve', ...varArgs(vars)]), { stream: true });
   }
 
@@ -82,6 +92,9 @@ export function parseTargetDescriptor(outputJson: string, outputName = 'target')
   try {
     all = JSON.parse(outputJson);
   } catch {
+    throw new Error(`could not parse '${outputName}' from tofu output -json`);
+  }
+  if (all === null || typeof all !== 'object') {
     throw new Error(`could not parse '${outputName}' from tofu output -json`);
   }
   const entry = all[outputName];

--- a/packages/cloud/src/provision/opentofu.ts
+++ b/packages/cloud/src/provision/opentofu.ts
@@ -1,0 +1,98 @@
+import { Exec, run, shellExec } from '../agent/exec';
+import { Provisioner, TargetDescriptor } from '../runner/types';
+
+export interface OpenTofuProvisionerOptions {
+  /** Directory containing the .tf module. */
+  moduleDir: string;
+  /** Input variables, passed as `-var k=v`. Merged with (overridden by) up()'s config. */
+  vars?: Record<string, string>;
+  /** IaC binary: 'tofu' (default) or 'terraform' — the CLIs are arg-compatible here. */
+  bin?: string;
+  /** Injectable for tests. */
+  exec?: Exec;
+  /** Name of the module output holding the TargetDescriptor JSON. Default 'target'. */
+  outputName?: string;
+}
+
+/**
+ * A single, generic Provisioner that delegates to a real IaC tool (OpenTofu /
+ * Terraform) over a module directory, and maps the module's `target` output to
+ * a {@link TargetDescriptor}. Provider quirks (VPC, roles, Fly org, …) live in
+ * the module's HCL + its vars — never here. This is the whole "don't invent an
+ * IaC DSL" decision made concrete: one provisioner, N modules.
+ *
+ * `exec` is injectable so the command construction + output parsing are
+ * unit-tested without touching real cloud state.
+ */
+export class OpenTofuProvisioner implements Provisioner {
+  readonly id = 'opentofu';
+  private readonly moduleDir: string;
+  private readonly vars: Record<string, string>;
+  private readonly bin: string;
+  private readonly exec: Exec;
+  private readonly outputName: string;
+
+  constructor(opts: OpenTofuProvisionerOptions) {
+    if (!opts.moduleDir) throw new Error('OpenTofuProvisioner requires a moduleDir');
+    this.moduleDir = opts.moduleDir;
+    this.vars = opts.vars ?? {};
+    this.bin = opts.bin ?? 'tofu';
+    this.exec = opts.exec ?? shellExec;
+    this.outputName = opts.outputName ?? 'target';
+  }
+
+  async up(config: Record<string, unknown> = {}): Promise<TargetDescriptor> {
+    const vars = { ...this.vars, ...stringifyVars(config) };
+    await run(this.exec, this.bin, this.args('init', []), { stream: true });
+    await run(this.exec, this.bin, this.args('apply', ['-auto-approve', ...varArgs(vars)]), { stream: true });
+    const { stdout } = await run(this.exec, this.bin, this.args('output', ['-json']));
+    return parseTargetDescriptor(stdout, this.outputName);
+  }
+
+  async down(target: TargetDescriptor): Promise<void> {
+    // Vars can be handed back through the descriptor so a fresh process can tear
+    // down what another stood up; construction vars remain the base.
+    const handed = (target.extra?.tofuVars as Record<string, string> | undefined) ?? {};
+    const vars = { ...this.vars, ...handed };
+    await run(this.exec, this.bin, this.args('destroy', ['-auto-approve', ...varArgs(vars)]), { stream: true });
+  }
+
+  /** `tofu -chdir=<dir> <cmd> -input=false -no-color [extra…]` */
+  private args(cmd: string, extra: string[]): string[] {
+    return [`-chdir=${this.moduleDir}`, cmd, '-input=false', '-no-color', ...extra];
+  }
+}
+
+function varArgs(vars: Record<string, string>): string[] {
+  return Object.entries(vars).flatMap(([k, v]) => ['-var', `${k}=${v}`]);
+}
+
+function stringifyVars(config: Record<string, unknown>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(config)) {
+    if (v === undefined || v === null) continue;
+    out[k] = typeof v === 'string' ? v : JSON.stringify(v);
+  }
+  return out;
+}
+
+/** Parse `tofu output -json` and extract + validate the named TargetDescriptor. */
+export function parseTargetDescriptor(outputJson: string, outputName = 'target'): TargetDescriptor {
+  let all: Record<string, { value?: unknown }>;
+  try {
+    all = JSON.parse(outputJson);
+  } catch {
+    throw new Error(`could not parse '${outputName}' from tofu output -json`);
+  }
+  const entry = all[outputName];
+  if (!entry || typeof entry !== 'object' || !('value' in entry)) {
+    throw new Error(
+      `OpenTofu module has no '${outputName}' output — add:\n  output "${outputName}" { value = { version = 1, runner = "<name>", … } }`,
+    );
+  }
+  const v = entry.value as Partial<TargetDescriptor>;
+  if (!v || typeof v !== 'object' || v.version !== 1 || typeof v.runner !== 'string' || !v.runner) {
+    throw new Error(`'${outputName}' output must be a TargetDescriptor: { version = 1, runner = "<name>", … }`);
+  }
+  return v as TargetDescriptor;
+}

--- a/packages/cloud/src/provision/registry.ts
+++ b/packages/cloud/src/provision/registry.ts
@@ -1,0 +1,31 @@
+import { Provisioner } from '../runner/types';
+import { OpenTofuProvisioner, OpenTofuProvisionerOptions } from './opentofu';
+
+/** A factory that builds a Provisioner from opaque options. */
+export type ProvisionerFactory = (opts: Record<string, unknown>) => Provisioner;
+
+const registry = new Map<string, ProvisionerFactory>();
+
+/** Register (or override) a provisioner factory by name. */
+export function registerProvisioner(name: string, factory: ProvisionerFactory): void {
+  registry.set(name, factory);
+}
+
+/** Build a provisioner by name. Throws a helpful error listing what's available. */
+export function createProvisioner(name: string, opts: Record<string, unknown> = {}): Provisioner {
+  const factory = registry.get(name);
+  if (!factory) {
+    throw new Error(`unknown provisioner '${name}'. Available: ${provisionerNames().join(', ') || '(none)'}`);
+  }
+  return factory(opts);
+}
+
+/** Names of all registered provisioners. */
+export function provisionerNames(): string[] {
+  return [...registry.keys()];
+}
+
+// Built-in: OpenTofu/Terraform. One provisioner, many modules.
+registerProvisioner('opentofu', (o) => new OpenTofuProvisioner(o as unknown as OpenTofuProvisionerOptions));
+// `terraform` is the same provisioner with a different bin.
+registerProvisioner('terraform', (o) => new OpenTofuProvisioner({ ...(o as object), bin: 'terraform' } as OpenTofuProvisionerOptions));


### PR DESCRIPTION
## What

Starts **P2** of the cloud plan: the **provisioning seam**, split cleanly from execution.

- **`OpenTofuProvisioner`** — one *generic* `Provisioner` that delegates to real `tofu`/`terraform` over a module directory (`init` → `apply` → `output -json`) and maps the module's `target` output to a `TargetDescriptor`. Hands vars back through `extra.tofuVars` so a stateless `down()` can tear down. Injectable `exec` → command construction + output parsing are unit-tested. Works with both `tofu` and `terraform`.
- **Provisioner registry** — `createProvisioner`/`registerProvisioner`/`provisionerNames`; ships `opentofu`+`terraform`, extensible (mirrors the runner registry).
- **First module `iac/fargate/`** — ECS Fargate cluster + capacity provider, CloudWatch log group, egress-only task SG, and a task **execution** role (no task role — the agent authenticates to the forge with an env token, not cloud IAM). Emits the `aws-fargate` `TargetDescriptor`.

## Why Fargate first (not Fly)

Chosen purely for **validatability**: `hashicorp/aws` is solid and on the OpenTofu registry, so the module is verified with **real `tofu validate`** — the Fly community provider is flaky and wouldn't validate. The provisioner is generic, so **Fly is just another module** (follow-up).

## Verification

- **72 cloud tests** pass (+11: `up`/`down` arg construction, var merge + stringify, descriptor parse + validation errors, registry).
- `tofu fmt -check` clean; `tofu init` + **`tofu validate` → "Success! The configuration is valid."** against `hashicorp/aws ~> 5.60`.
- Core CLI untouched; no version bump.

## Not in this PR (next)

- The matching **`aws-fargate` Runner** (register task-def + `RunTask` + CloudWatch logs).
- A thin **`nemus cloud up/down/run`** CLI (its own bin in this package).

Design + roadmap: `docs/plans/2026-08-26-cloud-iac.md`.