### PR TITLE
feat(cloud): aws-fargate Runner (P2 execution)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   git + gh + pi/claude); and the **provisioning** seam (P2, in progress): a
   generic `OpenTofuProvisioner` (delegates to `tofu`/`terraform`, maps a module's
   `target` output → `TargetDescriptor`) + registry, plus a first **AWS Fargate**
-  OpenTofu module (`iac/fargate/`, validated with real `tofu validate`).
+  OpenTofu module (`iac/fargate/`, validated with real `tofu validate`); and the
+  matching **`aws-fargate` Runner** (dependency-free, shells the `aws` CLI:
+  `register-task-definition` → `run-task`, `describe-tasks` → status, CloudWatch
+  `logs tail` streaming, `stop-task`).
   Design: `docs/plans/2026-08-26-cloud-iac.md`.
 
 ## [0.2.9] - 2026-08-26

--- a/docs/plans/2026-08-26-cloud-iac.md
+++ b/docs/plans/2026-08-26-cloud-iac.md
@@ -157,9 +157,14 @@ in log streams. PAT is always the zero-config fallback.
   `tofu validate` against `hashicorp/aws`**. Chose Fargate over Fly as the first
   module purely for validatability (solid provider vs. flaky Fly community
   provider) — the provisioner is generic, so **Fly is just another module**
-  (follow-up). **Next:** the matching cloud **`Runner`** (`aws-fargate`:
-  register task-def + `RunTask` + logs via CloudWatch) and a thin `nemus cloud
-  up/down/run` CLI (its own bin in this package).
+  (follow-up). **Cloud runner done:** `FargateRunner` (`aws-fargate`) —
+  dependency-free (shells the `aws` CLI): `register-task-definition` → `run-task`
+  reading the module's descriptor (cluster/region/subnets/SG/exec-role/
+  log-group), `describe-tasks` → `Status`, CloudWatch `logs tail` streaming,
+  `stop-task`; `exec:false` reported honestly (ECS Exec unwired). The Handle
+  carries cluster/region/log-stream so status/logs/stop work. Unit-tested with a
+  mocked `aws` CLI. **Next:** a thin `nemus cloud up/down/run` CLI (its own bin)
+  tying provisioner + runner + agent image together end-to-end.
 - **P3 — report-back (draft PR) + bounded CI-loop** over `GitForge`.
 - **P4 — more providers (plugins), optional Slack, optional hosted UI.**
 

--- a/packages/cloud/src/index.ts
+++ b/packages/cloud/src/index.ts
@@ -16,6 +16,8 @@ export type { GitHubAppConfig } from './forge/github-app';
 export * from './runner/types';
 export { DockerRunner } from './runner/docker';
 export type { DockerRunnerOptions, CommandRunner, LogStreamer } from './runner/docker';
+export { FargateRunner, mapFargateState } from './runner/fargate';
+export type { FargateRunnerOptions } from './runner/fargate';
 export { createRunner, registerRunner, runnerNames } from './runner/registry';
 export type { RunnerFactory } from './runner/registry';
 

--- a/packages/cloud/src/runner/fargate.test.ts
+++ b/packages/cloud/src/runner/fargate.test.ts
@@ -80,6 +80,32 @@ describe('FargateRunner.launch', () => {
     expect((handle.raw as any).logStream).toBe('nemus-agent/nemus-agent/abc123');
   });
 
+  it('cpu is vCPU count -> units, defaulting to 1024', async () => {
+    const { run, calls } = awsMock({
+      'ecs register-task-definition': { taskDefinition: { taskDefinitionArn: 'arn:task/1' } },
+      'ecs run-task': { tasks: [{ taskArn: 'arn:aws:ecs:us-east-1:1:task/nemus/x' }] },
+    });
+    const runner = new FargateRunner({ run });
+    await runner.launch({ ...spec, resources: { cpu: 2, memoryMB: 4096 } }, target);
+    expect(calls[0].json.cpu).toBe('2048');
+    expect(calls[0].json.memory).toBe('4096');
+    // default when unset
+    calls.length = 0;
+    await runner.launch({ ...spec, resources: undefined }, target);
+    expect(calls[0].json.cpu).toBe('1024');
+    expect(calls[0].json.memory).toBe('2048');
+  });
+
+  it('refuses labels that cannot be safely encoded as ECS tags', async () => {
+    const { run } = awsMock({
+      'ecs register-task-definition': { taskDefinition: { taskDefinitionArn: 'arn:task/1' } },
+      'ecs run-task': { tasks: [{ taskArn: 'arn:task/x' }] },
+    });
+    await expect(
+      new FargateRunner({ run }).launch({ ...spec, labels: { 'nemus.note': 'a,b=c' } }, target),
+    ).rejects.toThrow(/cannot be encoded as an ECS tag/);
+  });
+
   it('rejects a mismatched target and unresolved secrets', async () => {
     const { run } = awsMock({});
     const runner = new FargateRunner({ run });

--- a/packages/cloud/src/runner/fargate.test.ts
+++ b/packages/cloud/src/runner/fargate.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+import { FargateRunner, mapFargateState } from './fargate';
+import { createRunner, runnerNames } from './registry';
+import { CommandRunner } from './docker';
+import { TargetDescriptor, TaskSpec, LogLine } from './types';
+
+const target: TargetDescriptor = {
+  version: 1,
+  runner: 'aws-fargate',
+  region: 'us-east-1',
+  cluster: 'nemus',
+  extra: {
+    subnets: ['subnet-a', 'subnet-b'],
+    security_group_id: 'sg-123',
+    execution_role_arn: 'arn:aws:iam::1:role/exec',
+    log_group: '/nemus/nemus',
+  },
+};
+
+const spec: TaskSpec = {
+  image: 'ghcr.io/acme/agent:latest',
+  env: { NEMUS_TASK: 'do it', GIT_TOKEN: 't' },
+  command: ['nemus-cloud-agent'],
+  resources: { cpu: 1, memoryMB: 2048 },
+  labels: { 'nemus.owner': 'octocat' },
+};
+
+/** A CommandRunner that returns queued JSON by subcommand and records calls. */
+function awsMock(responses: Record<string, unknown>) {
+  const calls: { args: string[]; json?: any }[] = [];
+  const run: CommandRunner = async (_bin, args) => {
+    const key = `${args[0]} ${args[1]}`; // e.g. 'ecs register-task-definition'
+    const jsonArg = args.includes('--cli-input-json') ? args[args.indexOf('--cli-input-json') + 1] : undefined;
+    const ncArg = args.includes('--network-configuration') ? args[args.indexOf('--network-configuration') + 1] : undefined;
+    calls.push({ args, json: jsonArg ? JSON.parse(jsonArg) : ncArg ? JSON.parse(ncArg) : undefined });
+    return { code: 0, stdout: JSON.stringify(responses[key] ?? {}), stderr: '' };
+  };
+  return { run, calls };
+}
+
+describe('FargateRunner.launch', () => {
+  it('registers a task definition then runs it, wiring target + spec', async () => {
+    const { run, calls } = awsMock({
+      'ecs register-task-definition': { taskDefinition: { taskDefinitionArn: 'arn:task/1' } },
+      'ecs run-task': { tasks: [{ taskArn: 'arn:aws:ecs:us-east-1:1:task/nemus/abc123' }] },
+    });
+    const runner = new FargateRunner({ run });
+    const handle = await runner.launch(spec, target);
+
+    // register-task-definition JSON
+    const reg = calls[0];
+    expect(reg.args.slice(0, 2)).toEqual(['ecs', 'register-task-definition']);
+    expect(reg.json.family).toBe('nemus-agent');
+    expect(reg.json.requiresCompatibilities).toEqual(['FARGATE']);
+    expect(reg.json.networkMode).toBe('awsvpc');
+    expect(reg.json.cpu).toBe('1024'); // 1 vCPU -> 1024 units
+    expect(reg.json.memory).toBe('2048');
+    expect(reg.json.executionRoleArn).toBe('arn:aws:iam::1:role/exec');
+    const cd = reg.json.containerDefinitions[0];
+    expect(cd.image).toBe('ghcr.io/acme/agent:latest');
+    expect(cd.command).toEqual(['nemus-cloud-agent']);
+    expect(cd.environment).toContainEqual({ name: 'NEMUS_TASK', value: 'do it' });
+    expect(cd.logConfiguration.options['awslogs-group']).toBe('/nemus/nemus');
+    expect(cd.logConfiguration.options['awslogs-region']).toBe('us-east-1');
+
+    // run-task network + tags + region
+    const rt = calls[1];
+    expect(rt.args).toContain('--launch-type');
+    expect(rt.args).toContain('FARGATE');
+    expect(rt.args).toContain('--cluster');
+    expect(rt.json.awsvpcConfiguration.subnets).toEqual(['subnet-a', 'subnet-b']);
+    expect(rt.json.awsvpcConfiguration.securityGroups).toEqual(['sg-123']);
+    expect(rt.json.awsvpcConfiguration.assignPublicIp).toBe('ENABLED');
+    expect(rt.args).toContain('key=nemus.owner,value=octocat');
+    expect(rt.args).toEqual(expect.arrayContaining(['--region', 'us-east-1', '--output', 'json']));
+
+    // handle carries what status/logs/stop need
+    expect(handle.id).toBe('arn:aws:ecs:us-east-1:1:task/nemus/abc123');
+    expect((handle.raw as any).cluster).toBe('nemus');
+    expect((handle.raw as any).logStream).toBe('nemus-agent/nemus-agent/abc123');
+  });
+
+  it('rejects a mismatched target and unresolved secrets', async () => {
+    const { run } = awsMock({});
+    const runner = new FargateRunner({ run });
+    await expect(runner.launch(spec, { version: 1, runner: 'docker' })).rejects.toThrow(/not "aws-fargate"/);
+    await expect(
+      runner.launch({ ...spec, secrets: [{ name: 'X', from: 'env:X' }] }, target),
+    ).rejects.toThrow(/no secret store/);
+  });
+
+  it('surfaces run-task failures', async () => {
+    const { run } = awsMock({
+      'ecs register-task-definition': { taskDefinition: { taskDefinitionArn: 'arn:task/1' } },
+      'ecs run-task': { failures: [{ reason: 'RESOURCE:MEMORY' }], tasks: [] },
+    });
+    await expect(new FargateRunner({ run }).launch(spec, target)).rejects.toThrow(/RESOURCE:MEMORY/);
+  });
+
+  it('errors when the target lacks subnets', async () => {
+    const { run } = awsMock({});
+    await expect(
+      new FargateRunner({ run }).launch(spec, { ...target, extra: { ...target.extra, subnets: [] } }),
+    ).rejects.toThrow(/subnets/);
+  });
+});
+
+describe('FargateRunner.status / stop / logs', () => {
+  const handle = { runner: 'aws-fargate', id: 'arn:task/abc', raw: { cluster: 'nemus', region: 'us-east-1', logGroup: '/nemus/nemus', logStream: 's', taskDefArn: 'arn:td' } };
+
+  it('maps describe-tasks to a Status', async () => {
+    const { run, calls } = awsMock({
+      'ecs describe-tasks': { tasks: [{ lastStatus: 'STOPPED', startedAt: '2026-01-01T00:00:00Z', stoppedAt: '2026-01-01T00:05:00Z', containers: [{ exitCode: 0 }] }] },
+    });
+    const st = await new FargateRunner({ run }).status(handle as any);
+    expect(st.state).toBe('succeeded');
+    expect(st.exitCode).toBe(0);
+    expect(calls[0].args).toEqual(expect.arrayContaining(['--cluster', 'nemus', '--tasks', 'arn:task/abc']));
+  });
+
+  it('stop calls ecs stop-task', async () => {
+    const { run, calls } = awsMock({ 'ecs stop-task': {} });
+    await new FargateRunner({ run }).stop(handle as any);
+    expect(calls[0].args.slice(0, 2)).toEqual(['ecs', 'stop-task']);
+    expect(calls[0].args).toEqual(expect.arrayContaining(['--task', 'arn:task/abc']));
+  });
+
+  it('logs streams CloudWatch lines via the injected streamer', async () => {
+    const stream = async function* (): AsyncIterable<LogLine> {
+      yield { stream: 'stdout', line: 'hello' };
+    };
+    const runner = new FargateRunner({ run: awsMock({}).run, stream: () => stream() });
+    const out: string[] = [];
+    for await (const l of runner.logs(handle as any)) out.push(l.line);
+    expect(out).toEqual(['hello']);
+  });
+
+  it('logs is empty when no log group is configured', async () => {
+    const runner = new FargateRunner({ run: awsMock({}).run });
+    const out: LogLine[] = [];
+    for await (const l of runner.logs({ runner: 'aws-fargate', id: 'x', raw: { cluster: 'c' } } as any)) out.push(l);
+    expect(out).toEqual([]);
+  });
+});
+
+describe('mapFargateState + registry', () => {
+  it('maps ECS lastStatus values', () => {
+    expect(mapFargateState('PROVISIONING')).toBe('pending');
+    expect(mapFargateState('RUNNING')).toBe('running');
+    expect(mapFargateState('STOPPED', 0)).toBe('succeeded');
+    expect(mapFargateState('STOPPED', 137)).toBe('failed');
+    expect(mapFargateState('WAT')).toBe('unknown');
+  });
+
+  it('is registered in-box and reports exec:false honestly', () => {
+    expect(runnerNames()).toContain('aws-fargate');
+    const r = createRunner('aws-fargate');
+    expect(r.id).toBe('aws-fargate');
+    expect(r.capabilities.exec).toBe(false);
+    expect(r.exec).toBeUndefined();
+  });
+});

--- a/packages/cloud/src/runner/fargate.ts
+++ b/packages/cloud/src/runner/fargate.ts
@@ -1,0 +1,306 @@
+import { spawn } from 'node:child_process';
+import { CommandRunner, LogStreamer } from './docker';
+import { shellExec } from '../agent/exec';
+import {
+  Capabilities,
+  Handle,
+  LogLine,
+  Runner,
+  Status,
+  TargetDescriptor,
+  TaskSpec,
+} from './types';
+
+export interface FargateRunnerOptions {
+  /** aws binary (default 'aws'). */
+  bin?: string;
+  run?: CommandRunner;
+  stream?: LogStreamer;
+  /** Fargate needs a public IP (or a NAT) to pull the image + reach the forge. */
+  assignPublicIp?: 'ENABLED' | 'DISABLED';
+  /** Task family + container + log-stream-prefix name (default 'nemus-agent'). */
+  family?: string;
+}
+
+const FARGATE_CAPS: Capabilities = {
+  // ECS Exec needs enableExecuteCommand + an SSM-enabled task; not wired here, so
+  // we report it honestly rather than pretend. (Features degrade, never lie.)
+  exec: false,
+  logStream: true, // CloudWatch Logs
+  persistentDisk: false, // Fargate tasks are ephemeral (EFS is a future opt-in)
+  secretStore: false, // resolve TaskSpec.secrets into env before launch (like docker)
+  portForward: false,
+};
+
+/** What the runner stashes on the Handle so status/logs/stop (which only get a
+ *  Handle) can reach the cluster/region/log-group. Core never reads this. */
+interface FargateHandleRaw {
+  cluster: string;
+  region?: string;
+  logGroup?: string;
+  logStream?: string;
+  taskDefArn: string;
+}
+
+/**
+ * Runs one task as an AWS ECS Fargate task. Dependency-free: shells the `aws`
+ * CLI (like DockerRunner shells docker). Reads its target from the descriptor
+ * the `iac/fargate` module emits (`cluster`, `region`, `extra.subnets`,
+ * `extra.security_group_id`, `extra.execution_role_arn`, `extra.log_group`).
+ *
+ * launch = register-task-definition → run-task; the durable cluster/roles/logs
+ * were provisioned once by the Provisioner. `run`/`stream` are injectable so the
+ * (many) aws CLI invocations + JSON parsing are unit-tested without AWS.
+ */
+export class FargateRunner implements Runner {
+  readonly id = 'aws-fargate';
+  readonly capabilities = FARGATE_CAPS;
+  private readonly bin: string;
+  private readonly run: CommandRunner;
+  private readonly stream: LogStreamer;
+  private readonly assignPublicIp: 'ENABLED' | 'DISABLED';
+  private readonly family: string;
+
+  constructor(opts: FargateRunnerOptions = {}) {
+    this.bin = opts.bin ?? 'aws';
+    this.run = opts.run ?? ((b, a) => shellExec(b, a));
+    this.stream = opts.stream ?? defaultCloudWatchStream;
+    this.assignPublicIp = opts.assignPublicIp ?? 'ENABLED';
+    this.family = opts.family ?? 'nemus-agent';
+  }
+
+  async launch(spec: TaskSpec, target: TargetDescriptor): Promise<Handle> {
+    if (target.runner !== this.id) {
+      throw new Error(`fargate runner: target is for "${target.runner}", not "${this.id}"`);
+    }
+    if (spec.secrets?.length) {
+      throw new Error(
+        'fargate runner has no secret store — resolve TaskSpec.secrets into env before launch',
+      );
+    }
+    const cluster = target.cluster;
+    if (!cluster) throw new Error('fargate target missing "cluster"');
+    const region = target.region;
+    const extra = (target.extra ?? {}) as Record<string, unknown>;
+    const subnets = asStringArray(extra.subnets);
+    if (!subnets.length) throw new Error('fargate target missing "extra.subnets"');
+    const securityGroups = extra.security_group_id ? [String(extra.security_group_id)] : [];
+    const executionRoleArn = extra.execution_role_arn ? String(extra.execution_role_arn) : undefined;
+    const logGroup = extra.log_group ? String(extra.log_group) : undefined;
+
+    // 1) Register the per-run task definition.
+    const taskDef = this.buildTaskDefinition(spec, { executionRoleArn, logGroup, region });
+    const reg = await this.aws(
+      ['ecs', 'register-task-definition', '--cli-input-json', JSON.stringify(taskDef)],
+      region,
+    );
+    const taskDefArn: string = reg.taskDefinition?.taskDefinitionArn;
+    if (!taskDefArn) throw new Error('register-task-definition returned no ARN');
+
+    // 2) Run it.
+    const runArgs = [
+      'ecs', 'run-task',
+      '--cluster', cluster,
+      '--task-definition', taskDefArn,
+      '--launch-type', 'FARGATE',
+      '--count', '1',
+      '--network-configuration',
+      JSON.stringify({
+        awsvpcConfiguration: {
+          subnets,
+          securityGroups,
+          assignPublicIp: this.assignPublicIp,
+        },
+      }),
+    ];
+    const tags = tagArgs(spec.labels);
+    if (tags.length) runArgs.push('--tags', ...tags);
+
+    const runOut = await this.aws(runArgs, region);
+    const failure = runOut.failures?.[0];
+    if (failure) throw new Error(`run-task failed: ${failure.reason ?? JSON.stringify(failure)}`);
+    const taskArn: string = runOut.tasks?.[0]?.taskArn;
+    if (!taskArn) throw new Error('run-task returned no taskArn');
+
+    const raw: FargateHandleRaw = {
+      cluster,
+      region,
+      logGroup,
+      logStream: logGroup ? `${this.family}/${this.family}/${taskId(taskArn)}` : undefined,
+      taskDefArn,
+    };
+    return { runner: this.id, id: taskArn, raw };
+  }
+
+  async status(handle: Handle): Promise<Status> {
+    const raw = handle.raw as FargateHandleRaw;
+    const out = await this.aws(
+      ['ecs', 'describe-tasks', '--cluster', raw.cluster, '--tasks', handle.id],
+      raw.region,
+    );
+    const task = out.tasks?.[0];
+    if (!task) return { state: 'unknown' };
+    const container = task.containers?.[0];
+    const exitCode = typeof container?.exitCode === 'number' ? container.exitCode : undefined;
+    return {
+      state: mapFargateState(task.lastStatus, exitCode),
+      exitCode,
+      startedAt: parseDate(task.startedAt),
+      finishedAt: parseDate(task.stoppedAt),
+    };
+  }
+
+  logs(handle: Handle): AsyncIterable<LogLine> {
+    const raw = handle.raw as FargateHandleRaw;
+    if (!raw.logGroup || !raw.logStream) return emptyAsync();
+    const args = ['logs', 'tail', raw.logGroup, '--follow', '--format', 'short', '--log-stream-names', raw.logStream];
+    if (raw.region) args.push('--region', raw.region);
+    return this.stream(this.bin, args);
+  }
+
+  async stop(handle: Handle): Promise<void> {
+    const raw = handle.raw as FargateHandleRaw;
+    await this.run(this.bin, awsArgs(['ecs', 'stop-task', '--cluster', raw.cluster, '--task', handle.id], raw.region));
+  }
+
+  /** Build the register-task-definition input (pure → unit-tested). */
+  private buildTaskDefinition(
+    spec: TaskSpec,
+    opts: { executionRoleArn?: string; logGroup?: string; region?: string },
+  ): Record<string, unknown> {
+    const environment = Object.entries(spec.env ?? {}).map(([name, value]) => ({ name, value }));
+    const container: Record<string, unknown> = {
+      name: this.family,
+      image: spec.image,
+      essential: true,
+      environment,
+    };
+    if (spec.command?.length) container.command = spec.command;
+    if (opts.logGroup) {
+      container.logConfiguration = {
+        logDriver: 'awslogs',
+        options: {
+          'awslogs-group': opts.logGroup,
+          'awslogs-region': opts.region ?? '',
+          'awslogs-stream-prefix': this.family,
+        },
+      };
+    }
+    const def: Record<string, unknown> = {
+      family: this.family,
+      requiresCompatibilities: ['FARGATE'],
+      networkMode: 'awsvpc',
+      cpu: String(cpuUnits(spec.resources?.cpu)),
+      memory: String(spec.resources?.memoryMB ?? 2048),
+      containerDefinitions: [container],
+    };
+    if (opts.executionRoleArn) def.executionRoleArn = opts.executionRoleArn;
+    return def;
+  }
+
+  /** Run an aws subcommand with `--output json` and parse stdout. */
+  private async aws(args: string[], region?: string): Promise<any> {
+    const full = awsArgs(args, region);
+    const { code, stdout, stderr } = await this.run(this.bin, full);
+    if (code !== 0) throw new Error(`aws ${args.slice(0, 2).join(' ')} failed (${code}): ${stderr.trim() || stdout.trim()}`);
+    if (!stdout.trim()) return {};
+    try {
+      return JSON.parse(stdout);
+    } catch {
+      throw new Error(`aws ${args.slice(0, 2).join(' ')}: could not parse JSON output`);
+    }
+  }
+}
+
+/** Append `--region` + force JSON output. Exported-shape helper (pure). */
+function awsArgs(args: string[], region?: string): string[] {
+  const out = [...args, '--output', 'json'];
+  if (region) out.push('--region', region);
+  return out;
+}
+
+function tagArgs(labels?: Record<string, string>): string[] {
+  return Object.entries(labels ?? {}).map(([k, v]) => `key=${k},value=${v}`);
+}
+
+/** Fargate cpu is in CPU units (1 vCPU = 1024). We accept vCPU as a fraction. */
+function cpuUnits(cpu?: number): number {
+  if (!cpu || cpu <= 0) return 1024;
+  return cpu < 16 ? Math.round(cpu * 1024) : Math.round(cpu); // treat >=16 as already-units
+}
+
+function asStringArray(v: unknown): string[] {
+  return Array.isArray(v) ? v.map(String) : [];
+}
+
+function taskId(taskArn: string): string {
+  return taskArn.split('/').pop() ?? taskArn;
+}
+
+export function mapFargateState(lastStatus: string | undefined, exitCode?: number): Status['state'] {
+  switch (lastStatus) {
+    case 'PROVISIONING':
+    case 'PENDING':
+    case 'ACTIVATING':
+      return 'pending';
+    case 'RUNNING':
+    case 'DEACTIVATING':
+    case 'STOPPING':
+    case 'DEPROVISIONING':
+      return 'running';
+    case 'STOPPED':
+      return exitCode === 0 ? 'succeeded' : 'failed';
+    default:
+      return 'unknown';
+  }
+}
+
+function parseDate(s?: string | number): Date | undefined {
+  if (s === undefined || s === null) return undefined;
+  const t = new Date(s).getTime();
+  return Number.isFinite(t) ? new Date(t) : undefined;
+}
+
+async function* emptyAsync(): AsyncIterable<LogLine> {
+  // no log group configured → nothing to stream
+}
+
+/** `aws logs tail --follow` streamer (CloudWatch merges streams → all stdout). */
+const defaultCloudWatchStream: LogStreamer = async function* (bin, args) {
+  const child = spawn(bin, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+  const queue: LogLine[] = [];
+  let done = false;
+  let failure: Error | undefined;
+  let notify: (() => void) | null = null;
+  child.stdout.on('data', (buf: Buffer) => {
+    for (const raw of buf.toString().split('\n')) {
+      if (raw === '') continue;
+      queue.push({ stream: 'stdout', line: raw });
+    }
+    notify?.();
+  });
+  child.stderr.on('data', (buf: Buffer) => {
+    for (const raw of buf.toString().split('\n')) {
+      if (raw === '') continue;
+      queue.push({ stream: 'stderr', line: raw });
+    }
+    notify?.();
+  });
+  child.on('error', (e) => {
+    failure = e instanceof Error ? e : new Error(String(e));
+    done = true;
+    notify?.();
+  });
+  child.on('close', () => {
+    done = true;
+    notify?.();
+  });
+  while (!done || queue.length) {
+    if (queue.length) yield queue.shift()!;
+    else {
+      await new Promise<void>((r) => (notify = r));
+      notify = null;
+    }
+  }
+  if (failure) throw new Error(`aws logs tail stream failed: ${failure.message}`);
+};

--- a/packages/cloud/src/runner/fargate.ts
+++ b/packages/cloud/src/runner/fargate.ts
@@ -88,7 +88,10 @@ export class FargateRunner implements Runner {
     const executionRoleArn = extra.execution_role_arn ? String(extra.execution_role_arn) : undefined;
     const logGroup = extra.log_group ? String(extra.log_group) : undefined;
 
-    // 1) Register the per-run task definition.
+    // 1) Register the per-run task definition. NOTE: this creates a new task-def
+    //    REVISION on every launch; ECS retains them, so a long-lived cluster
+    //    accumulates revisions. Follow-up: dedupe by hashing the def, or
+    //    deregister on stop.
     const taskDef = this.buildTaskDefinition(spec, { executionRoleArn, logGroup, region });
     const reg = await this.aws(
       ['ecs', 'register-task-definition', '--cli-input-json', JSON.stringify(taskDef)],
@@ -220,13 +223,23 @@ function awsArgs(args: string[], region?: string): string[] {
 }
 
 function tagArgs(labels?: Record<string, string>): string[] {
-  return Object.entries(labels ?? {}).map(([k, v]) => `key=${k},value=${v}`);
+  return Object.entries(labels ?? {}).map(([k, v]) => {
+    // The `--tags key=K,value=V` shorthand is delimited by ',' and '=', so a
+    // key/value containing either would silently corrupt into the wrong tags.
+    // Fail loudly rather than mis-tag (labels are Nemus-controlled, so this is
+    // an assertion, not an expected path).
+    if (/[,=]/.test(k) || /[,=]/.test(v)) {
+      throw new Error(`fargate: label "${k}" cannot be encoded as an ECS tag (contains ',' or '=')`);
+    }
+    return `key=${k},value=${v}`;
+  });
 }
 
-/** Fargate cpu is in CPU units (1 vCPU = 1024). We accept vCPU as a fraction. */
+/** Fargate `cpu` is in CPU units (1 vCPU = 1024). TaskSpec.resources.cpu is a
+ *  vCPU count (same meaning as DockerRunner's `--cpus`), so multiply. */
 function cpuUnits(cpu?: number): number {
   if (!cpu || cpu <= 0) return 1024;
-  return cpu < 16 ? Math.round(cpu * 1024) : Math.round(cpu); // treat >=16 as already-units
+  return Math.round(cpu * 1024);
 }
 
 function asStringArray(v: unknown): string[] {

--- a/packages/cloud/src/runner/registry.ts
+++ b/packages/cloud/src/runner/registry.ts
@@ -1,5 +1,6 @@
 import { Runner } from './types';
 import { DockerRunner, DockerRunnerOptions } from './docker';
+import { FargateRunner, FargateRunnerOptions } from './fargate';
 
 /**
  * A runner factory. Third-party backends ship as `@nemus-cli/cloud-<name>` and
@@ -34,3 +35,5 @@ export function createRunner(name: string, opts?: Record<string, unknown>): Runn
 
 // Ship the local Docker runner in-box.
 registerRunner('docker', (opts) => new DockerRunner(opts as DockerRunnerOptions));
+// AWS ECS Fargate (pairs with the iac/fargate module). Dependency-free (aws CLI).
+registerRunner('aws-fargate', (opts) => new FargateRunner(opts as FargateRunnerOptions));


### PR DESCRIPTION
## What

The execution half of **P2**, pairing with the `iac/fargate` module from #34: a **`FargateRunner`** (`id: 'aws-fargate'`) that launches the agent image as an ECS Fargate task.

- **Dependency-free** — shells the `aws` CLI (same approach as `DockerRunner` shelling docker), `run`/`stream` injectable.
- **`launch`** reads the module's `TargetDescriptor` (`cluster`, `region`, `extra.{subnets, security_group_id, execution_role_arn, log_group}`), `register-task-definition` (image/env/command/log config; cpu vCPU→units, `memoryMB`) → `run-task` with awsvpc network config (public IP so the task can pull the image + reach the forge) and `labels`→ECS tags.
- **`status`** maps `describe-tasks` → `Status`; **`logs`** streams CloudWatch via `aws logs tail --follow`; **`stop`** → `stop-task`. The `Handle` carries cluster/region/log-stream so those work from a Handle alone (core never reads `raw`).
- **Capability-honest:** `exec:false` (ECS Exec needs `enableExecuteCommand`+SSM, unwired → `runner.exec` is `undefined`); `secretStore:false` (resolve secrets to env first, like docker). Registered in-box.

## Verification

- **83 cloud tests** (+11 with a mocked `aws` CLI: task-def + run-task JSON wiring, target/secret validation, run-task failure surfacing, missing-subnets, status/stop/logs mapping, state map, registry + `exec:false`).
- typecheck + build clean; core CLI untouched; no version bump.

## Next (P2 finish)

A thin **`nemus cloud up/down/run`** CLI (own bin) tying provisioner + runner + agent image end-to-end. Then **P3**: report-back draft PR + bounded CI-loop over `GitForge`.

Design: `docs/plans/2026-08-26-cloud-iac.md`.