### PR TITLE
feat(cloud): nemus-cloud CLI — up/down/run (P2 complete)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   OpenTofu module (`iac/fargate/`, validated with real `tofu validate`); and the
   matching **`aws-fargate` Runner** (dependency-free, shells the `aws` CLI:
   `register-task-definition` → `run-task`, `describe-tasks` → status, CloudWatch
-  `logs tail` streaming, `stop-task`).
-  Design: `docs/plans/2026-08-26-cloud-iac.md`.
+  `logs tail` streaming, `stop-task`); and the **`nemus-cloud` CLI** (own bin,
+  dependency-free) — `up`/`down` drive the provisioner, `run` launches the agent
+  image on a target (`--follow` logs, `--wait` for the exit code). This
+  completes P2. Design: `docs/plans/2026-08-26-cloud-iac.md`.
 
 ## [0.2.9] - 2026-08-26
 

--- a/docs/plans/2026-08-26-cloud-iac.md
+++ b/docs/plans/2026-08-26-cloud-iac.md
@@ -163,8 +163,10 @@ in log streams. PAT is always the zero-config fallback.
   log-group), `describe-tasks` → `Status`, CloudWatch `logs tail` streaming,
   `stop-task`; `exec:false` reported honestly (ECS Exec unwired). The Handle
   carries cluster/region/log-stream so status/logs/stop work. Unit-tested with a
-  mocked `aws` CLI. **Next:** a thin `nemus cloud up/down/run` CLI (its own bin)
-  tying provisioner + runner + agent image together end-to-end.
+  mocked `aws` CLI. **CLI done:** `nemus-cloud` (own bin, dependency-free) —
+  `up`/`down` drive the Provisioner, `run` builds the agent env contract + a
+  tag-safe `TaskSpec` and launches it via the target's Runner (`--follow` logs,
+  `--wait` for the exit code). All I/O injected → unit-tested. **P2 complete.**
 - **P3 — report-back (draft PR) + bounded CI-loop** over `GitForge`.
 - **P4 — more providers (plugins), optional Slack, optional hosted UI.**
 

--- a/packages/cloud/README.md
+++ b/packages/cloud/README.md
@@ -91,6 +91,27 @@ own working dir** (or point a remote backend at it) so state is durable, and
 **don't pass secrets as `-var`** (they land in argv and the streamed apply log —
 use the provider's own credential env / a `SecretSource`).
 
+## The CLI: `nemus-cloud`
+
+A thin, dependency-free CLI ties the seams together end-to-end:
+
+```bash
+# 1) provision a target (writes .nemus-target.json)
+nemus-cloud up --module fargate --var region=us-east-1 --var name=nemus
+
+# 2) run the agent image on it (forge auth from env: GITHUB_TOKEN or GITHUB_APP_*)
+nemus-cloud run --image ghcr.io/acme/agent:latest \
+  --repos acme/api,acme/web --task "add idempotency keys" --owner acme --follow --wait
+
+# 3) tear it down
+nemus-cloud down --module fargate
+```
+
+`up`/`down` drive the `OpenTofuProvisioner`; `run` builds the agent env contract
++ a tag-safe `TaskSpec` and launches it via the target's `Runner`, optionally
+streaming logs (`--follow`) and waiting for the exit code (`--wait`). Run
+`nemus-cloud help` for all flags.
+
 ## Develop
 
 ```bash

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -21,7 +21,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "nemus-cloud-agent": "dist/agent/cli.js"
+    "nemus-cloud-agent": "dist/agent/cli.js",
+    "nemus-cloud": "dist/cli/cloud.js"
   },
   "files": [
     "dist/**/*",

--- a/packages/cloud/src/cli/cloud.test.ts
+++ b/packages/cloud/src/cli/cloud.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import { parseArgs, parseVars, buildRunTaskSpec, main, CloudCliDeps } from './cloud';
+import { TargetDescriptor, LogLine, Status } from '../runner/types';
+
+describe('parseArgs', () => {
+  it('handles --k v, --k=v, bare flags, and repeats', () => {
+    const { cmd, positionals, flags } = parseArgs([
+      'run', 'pos1', '--image', 'img', '--repos=a,b', '--follow', '--var', 'x=1', '--var', 'y=2',
+    ]);
+    expect(cmd).toBe('run');
+    expect(positionals).toEqual(['pos1']);
+    expect(flags.image).toBe('img');
+    expect(flags.repos).toBe('a,b');
+    expect(flags.follow).toBe(true);
+    expect(flags.var).toEqual(['x=1', 'y=2']);
+  });
+});
+
+describe('parseVars', () => {
+  it('splits key=value, keeps = in the value', () => {
+    expect(parseVars(['region=us-east-1', 'k=a=b'])).toEqual({ region: 'us-east-1', k: 'a=b' });
+  });
+  it('rejects a var without =', () => {
+    expect(() => parseVars(['bad'])).toThrow(/key=value/);
+  });
+});
+
+describe('buildRunTaskSpec', () => {
+  const flags = { image: 'img', repos: 'acme/api,acme/web', task: 'do it', owner: 'acme' };
+
+  it('wires the runner-image env contract + tag-safe labels', () => {
+    const spec = buildRunTaskSpec(flags, { GITHUB_TOKEN: 't' });
+    expect(spec.image).toBe('img');
+    expect(spec.command).toEqual(['nemus-cloud-agent']);
+    expect(spec.env).toMatchObject({
+      NEMUS_REPOS: 'acme/api,acme/web',
+      NEMUS_TASK: 'do it',
+      NEMUS_AGENT: 'pi',
+      REPORT_MODE: 'pr',
+      NEMUS_OWNER: 'acme',
+      GITHUB_TOKEN: 't',
+    });
+    // the comma-bearing repo list must NOT leak into labels (ECS tag guard)
+    expect(spec.labels).toEqual({ 'nemus.agent': 'pi', 'nemus.owner': 'acme' });
+    expect(Object.values(spec.labels!).some((v) => v.includes(','))).toBe(false);
+  });
+
+  it('passes GitHub App creds through when present', () => {
+    const spec = buildRunTaskSpec(flags, {
+      GITHUB_APP_ID: '1', GITHUB_APP_PRIVATE_KEY: 'k', GITHUB_APP_INSTALLATION_ID: '2',
+    });
+    expect(spec.env).toMatchObject({ GITHUB_APP_ID: '1', GITHUB_APP_INSTALLATION_ID: '2' });
+    expect(spec.env!.GITHUB_TOKEN).toBeUndefined();
+  });
+
+  it('requires image/repos/task and forge auth', () => {
+    expect(() => buildRunTaskSpec({ repos: 'a', task: 't' }, { GITHUB_TOKEN: 't' })).toThrow(/--image/);
+    expect(() => buildRunTaskSpec({ image: 'i', task: 't' }, { GITHUB_TOKEN: 't' })).toThrow(/--repos/);
+    expect(() => buildRunTaskSpec({ image: 'i', repos: 'a' }, { GITHUB_TOKEN: 't' })).toThrow(/--task/);
+    expect(() => buildRunTaskSpec(flags, {})).toThrow(/no forge auth/);
+  });
+});
+
+// --------- main() dispatch with fully injected deps (no real fs/cloud) ---------
+
+function harness(overrides: Partial<CloudCliDeps> = {}) {
+  const files = new Map<string, string>();
+  const out: string[] = [];
+  const calls: string[] = [];
+  const target: TargetDescriptor = { version: 1, runner: 'fake', cluster: 'c', region: 'r' };
+  const deps: CloudCliDeps = {
+    createProvisioner: ((name: string, opts: any) => {
+      calls.push(`provisioner:${name}:${opts.moduleDir}`);
+      return {
+        id: name,
+        up: async () => { calls.push('up'); return target; },
+        down: async () => { calls.push('down'); },
+      };
+    }) as any,
+    createRunner: ((name: string) => {
+      calls.push(`runner:${name}`);
+      return {
+        id: name,
+        capabilities: {} as any,
+        launch: async () => { calls.push('launch'); return { runner: name, id: 'task-1' }; },
+        status: async (): Promise<Status> => ({ state: 'succeeded', exitCode: 0 }),
+        logs: async function* (): AsyncIterable<LogLine> { yield { stream: 'stdout', line: 'hello' }; },
+        stop: async () => {},
+      };
+    }) as any,
+    iacModuleDir: (n) => `/iac/${n}`,
+    readFile: (p) => { if (!files.has(p)) throw new Error('ENOENT'); return files.get(p)!; },
+    writeFile: (p, c) => { files.set(p, c); },
+    log: (s) => out.push(s),
+    errlog: (s) => out.push('ERR:' + s),
+    env: { GITHUB_TOKEN: 't' },
+    sleep: async () => {},
+    ...overrides,
+  };
+  return { deps, files, out, calls, target };
+}
+
+describe('main dispatch', () => {
+  it('up: provisions and writes the descriptor file', async () => {
+    const { deps, files, calls } = harness();
+    const code = await main(['up', '--module', 'fargate', '--var', 'region=r'], deps);
+    expect(code).toBe(0);
+    expect(calls).toContain('provisioner:opentofu:/iac/fargate');
+    expect(calls).toContain('up');
+    expect(JSON.parse(files.get('.nemus-target.json')!).runner).toBe('fake');
+  });
+
+  it('run: loads target, launches, follows logs, waits for exit', async () => {
+    const { deps, files, out, calls } = harness();
+    files.set('.nemus-target.json', JSON.stringify({ version: 1, runner: 'fake' }));
+    const code = await main(
+      ['run', '--image', 'img', '--repos', 'a,b', '--task', 'x', '--follow', '--wait'],
+      deps,
+    );
+    expect(code).toBe(0);
+    expect(calls).toEqual(expect.arrayContaining(['runner:fake', 'launch']));
+    expect(out).toContain('hello'); // streamed log
+    expect(out.some((l) => l.includes('succeeded'))).toBe(true);
+  });
+
+  it('run: returns 1 when the task fails', async () => {
+    const { deps, files } = harness({
+      createRunner: ((name: string) => ({
+        id: name, capabilities: {} as any,
+        launch: async () => ({ runner: name, id: 't' }),
+        status: async (): Promise<Status> => ({ state: 'failed', exitCode: 2 }),
+        logs: async function* (): AsyncIterable<LogLine> {},
+        stop: async () => {},
+      })) as any,
+    });
+    files.set('.nemus-target.json', JSON.stringify({ version: 1, runner: 'fake' }));
+    const code = await main(['run', '--image', 'i', '--repos', 'a', '--task', 't', '--wait'], deps);
+    expect(code).toBe(1);
+  });
+
+  it('down: reads target then destroys', async () => {
+    const { deps, files, calls } = harness();
+    files.set('.nemus-target.json', JSON.stringify({ version: 1, runner: 'fake' }));
+    const code = await main(['down', '--module', 'fargate'], deps);
+    expect(code).toBe(0);
+    expect(calls).toContain('down');
+  });
+
+  it('unknown command + missing forge auth surface errors', async () => {
+    const bad = harness();
+    expect(await main(['wat'], bad.deps)).toBe(1);
+    expect(bad.out.some((l) => l.startsWith('ERR:'))).toBe(true);
+
+    const noauth = harness({ env: {} });
+    noauth.files.set('.nemus-target.json', JSON.stringify({ version: 1, runner: 'fake' }));
+    expect(await main(['run', '--image', 'i', '--repos', 'a', '--task', 't'], noauth.deps)).toBe(1);
+    expect(noauth.out.some((l) => l.includes('no forge auth'))).toBe(true);
+  });
+});

--- a/packages/cloud/src/cli/cloud.ts
+++ b/packages/cloud/src/cli/cloud.ts
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'node:fs';
+import { createProvisioner } from '../provision/registry';
+import { iacModuleDir } from '../provision/modules';
+import { createRunner } from '../runner/registry';
+import { TargetDescriptor, TaskSpec } from '../runner/types';
+
+/**
+ * `nemus-cloud` — the thin CLI that ties the P2 seams together:
+ *   up    provision a target (Provisioner)         -> writes a descriptor file
+ *   down  tear a target down (Provisioner)
+ *   run   launch the agent image on a target (Runner) + stream logs / wait
+ *
+ * Dependency-free (hand-rolled arg parsing; the core CLI's commander stays out
+ * of this zero-dep package). All I/O is injected so the logic is unit-tested.
+ */
+
+const DEFAULT_TARGET_FILE = '.nemus-target.json';
+
+export interface CloudCliDeps {
+  createProvisioner: typeof createProvisioner;
+  createRunner: typeof createRunner;
+  iacModuleDir: (name: string) => string;
+  readFile: (path: string) => string;
+  writeFile: (path: string, content: string) => void;
+  log: (s: string) => void;
+  errlog: (s: string) => void;
+  env: NodeJS.ProcessEnv;
+  sleep: (ms: number) => Promise<void>;
+}
+
+const defaultDeps: CloudCliDeps = {
+  createProvisioner,
+  createRunner,
+  iacModuleDir,
+  readFile: (p) => readFileSync(p, 'utf8'),
+  writeFile: (p, c) => writeFileSync(p, c),
+  log: (s) => process.stdout.write(s + '\n'),
+  errlog: (s) => process.stderr.write(s + '\n'),
+  env: process.env,
+  sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+};
+
+// ---------------------------------------------------------------- arg parsing
+
+export type Flags = Record<string, string | string[] | boolean>;
+export interface ParsedArgs {
+  cmd: string | undefined;
+  positionals: string[];
+  flags: Flags;
+}
+
+/** Tiny parser: `--k v`, `--k=v`, repeated `--k` → array, bare `--k` → true. */
+export function parseArgs(argv: string[]): ParsedArgs {
+  const [cmd, ...rest] = argv;
+  const flags: Flags = {};
+  const positionals: string[] = [];
+  for (let i = 0; i < rest.length; i++) {
+    const tok = rest[i];
+    if (!tok.startsWith('--')) {
+      positionals.push(tok);
+      continue;
+    }
+    const body = tok.slice(2);
+    let key: string;
+    let val: string | boolean;
+    const eq = body.indexOf('=');
+    if (eq !== -1) {
+      key = body.slice(0, eq);
+      val = body.slice(eq + 1);
+    } else {
+      key = body;
+      const next = rest[i + 1];
+      if (next !== undefined && !next.startsWith('--')) {
+        val = next;
+        i++;
+      } else {
+        val = true;
+      }
+    }
+    const existing = flags[key];
+    if (existing === undefined) flags[key] = val;
+    else if (Array.isArray(existing)) existing.push(String(val));
+    else flags[key] = [String(existing), String(val)];
+  }
+  return { cmd, positionals, flags };
+}
+
+function str(flags: Flags, key: string): string | undefined {
+  const v = flags[key];
+  if (v === undefined || typeof v === 'boolean') return undefined;
+  return Array.isArray(v) ? v[v.length - 1] : v;
+}
+
+function multi(flags: Flags, key: string): string[] {
+  const v = flags[key];
+  if (v === undefined || typeof v === 'boolean') return [];
+  return Array.isArray(v) ? v : [v];
+}
+
+function bool(flags: Flags, key: string): boolean {
+  return flags[key] === true || flags[key] === 'true';
+}
+
+/** `["k=v", "a=b"]` → `{ k: 'v', a: 'b' }`. */
+export function parseVars(list: string[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const item of list) {
+    const eq = item.indexOf('=');
+    if (eq === -1) throw new Error(`--var "${item}" must be key=value`);
+    out[item.slice(0, eq)] = item.slice(eq + 1);
+  }
+  return out;
+}
+
+// -------------------------------------------------------------- run TaskSpec
+
+/** Build the agent TaskSpec (image + the runner-image env contract) from flags.
+ *  Pure + exported so the env wiring is unit-tested. */
+export function buildRunTaskSpec(flags: Flags, env: NodeJS.ProcessEnv): TaskSpec {
+  const image = str(flags, 'image');
+  const repos = str(flags, 'repos');
+  const task = str(flags, 'task');
+  if (!image) throw new Error('run: --image is required');
+  if (!repos) throw new Error('run: --repos is required (comma-separated)');
+  if (!task) throw new Error('run: --task is required');
+
+  const agent = str(flags, 'agent') ?? 'pi';
+  const owner = str(flags, 'owner');
+  const report = str(flags, 'report') ?? 'pr';
+  const token = env.GITHUB_TOKEN || env.GIT_TOKEN;
+  const hasApp = !!(env.GITHUB_APP_ID && env.GITHUB_APP_PRIVATE_KEY && env.GITHUB_APP_INSTALLATION_ID);
+  if (!token && !hasApp) {
+    throw new Error('run: no forge auth — set GITHUB_TOKEN (or GITHUB_APP_ID/_PRIVATE_KEY/_INSTALLATION_ID)');
+  }
+
+  const taskEnv: Record<string, string> = {
+    NEMUS_REPOS: repos,
+    NEMUS_TASK: task,
+    NEMUS_AGENT: agent,
+    REPORT_MODE: report,
+  };
+  if (owner) taskEnv.NEMUS_OWNER = owner;
+  if (str(flags, 'git-host')) taskEnv.GIT_HOST = str(flags, 'git-host')!;
+  if (token) taskEnv.GITHUB_TOKEN = token;
+  // Pass App creds straight through when present (least-privilege in-task auth).
+  for (const k of ['GITHUB_APP_ID', 'GITHUB_APP_PRIVATE_KEY', 'GITHUB_APP_INSTALLATION_ID']) {
+    if (env[k]) taskEnv[k] = env[k]!;
+  }
+
+  const cpu = str(flags, 'cpu');
+  const memory = str(flags, 'memory');
+  const resources =
+    cpu || memory ? { cpu: cpu ? Number(cpu) : undefined, memoryMB: memory ? Number(memory) : undefined } : undefined;
+
+  // Labels must be tag-safe (no commas) — so NEVER put the repo list here.
+  const labels: Record<string, string> = { 'nemus.agent': agent };
+  if (owner) labels['nemus.owner'] = owner;
+
+  return { image, env: taskEnv, command: ['nemus-cloud-agent'], resources, labels };
+}
+
+function loadTarget(deps: CloudCliDeps, file: string): TargetDescriptor {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(deps.readFile(file));
+  } catch {
+    throw new Error(`could not read target descriptor "${file}" (run \`nemus-cloud up\` first?)`);
+  }
+  const t = parsed as Partial<TargetDescriptor>;
+  if (!t || t.version !== 1 || typeof t.runner !== 'string' || !t.runner) {
+    throw new Error(`"${file}" is not a valid TargetDescriptor (need { version: 1, runner })`);
+  }
+  return t as TargetDescriptor;
+}
+
+function resolveModuleDir(deps: CloudCliDeps, flags: Flags): string {
+  const dir = str(flags, 'module-dir');
+  if (dir) return dir;
+  const name = str(flags, 'module');
+  if (name) return deps.iacModuleDir(name);
+  throw new Error('provide --module <name> (a shipped module) or --module-dir <path>');
+}
+
+// ------------------------------------------------------------------ commands
+
+async function cmdUp(flags: Flags, deps: CloudCliDeps): Promise<number> {
+  const moduleDir = resolveModuleDir(deps, flags);
+  const vars = parseVars(multi(flags, 'var'));
+  const p = deps.createProvisioner(str(flags, 'provisioner') ?? 'opentofu', { moduleDir, vars });
+  const target = await p.up({});
+  const out = str(flags, 'out') ?? DEFAULT_TARGET_FILE;
+  deps.writeFile(out, JSON.stringify(target, null, 2));
+  deps.log(`provisioned ${target.runner} → wrote ${out}`);
+  return 0;
+}
+
+async function cmdDown(flags: Flags, deps: CloudCliDeps): Promise<number> {
+  const file = str(flags, 'target') ?? DEFAULT_TARGET_FILE;
+  const target = loadTarget(deps, file);
+  const moduleDir = resolveModuleDir(deps, flags);
+  const vars = parseVars(multi(flags, 'var'));
+  const p = deps.createProvisioner(str(flags, 'provisioner') ?? 'opentofu', { moduleDir, vars });
+  await p.down(target);
+  deps.log(`destroyed ${target.runner}`);
+  return 0;
+}
+
+async function cmdRun(flags: Flags, deps: CloudCliDeps): Promise<number> {
+  const spec = buildRunTaskSpec(flags, deps.env);
+  const target = loadTarget(deps, str(flags, 'target') ?? DEFAULT_TARGET_FILE);
+  const runner = deps.createRunner(target.runner);
+  const handle = await runner.launch(spec, target);
+  deps.log(`launched ${handle.runner} task ${handle.id}`);
+
+  if (bool(flags, 'follow')) {
+    for await (const line of runner.logs(handle)) deps.log(line.line);
+  }
+  if (bool(flags, 'wait')) {
+    for (;;) {
+      const st = await runner.status(handle);
+      if (st.state === 'succeeded' || st.state === 'failed' || st.state === 'stopped') {
+        deps.log(`task ${st.state}${st.exitCode !== undefined ? ` (exit ${st.exitCode})` : ''}`);
+        return st.state === 'succeeded' ? 0 : 1;
+      }
+      await deps.sleep(5000);
+    }
+  }
+  return 0;
+}
+
+const USAGE = `nemus-cloud — provision + run Nemus agents on your own infra
+
+Usage:
+  nemus-cloud up    --module <name|--module-dir dir> [--var k=v]... [--provisioner opentofu] [--out FILE]
+  nemus-cloud down  [--target FILE] --module <name|--module-dir dir> [--var k=v]...
+  nemus-cloud run   --image REF --repos a,b --task "..." [--target FILE]
+                    [--agent pi] [--owner ORG] [--report pr|none] [--cpu N] [--memory MB]
+                    [--git-host HOST] [--follow] [--wait]
+
+Forge auth for \`run\` comes from the environment: GITHUB_TOKEN, or
+GITHUB_APP_ID/_PRIVATE_KEY/_INSTALLATION_ID.`;
+
+export async function main(argv: string[], deps: CloudCliDeps = defaultDeps): Promise<number> {
+  const { cmd, flags } = parseArgs(argv);
+  try {
+    switch (cmd) {
+      case 'up':
+        return await cmdUp(flags, deps);
+      case 'down':
+        return await cmdDown(flags, deps);
+      case 'run':
+        return await cmdRun(flags, deps);
+      case undefined:
+      case 'help':
+      case '--help':
+      case '-h':
+        deps.log(USAGE);
+        return cmd === undefined ? 1 : 0;
+      default:
+        deps.errlog(`unknown command "${cmd}"\n\n${USAGE}`);
+        return 1;
+    }
+  } catch (e) {
+    deps.errlog(`nemus-cloud: ${(e as Error).message}`);
+    return 1;
+  }
+}
+
+if (require.main === module) {
+  main(process.argv.slice(2))
+    .then((code) => process.exit(code))
+    .catch((e) => {
+      process.stderr.write(`nemus-cloud: fatal: ${e}\n`);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## What

The thin CLI that ties the P2 seams together end-to-end — **P2 is now complete**. Ships as its own bin `nemus-cloud` in `@nemus-cli/cloud`, dependency-free (hand-rolled arg parsing; all I/O injected so the logic is unit-tested).

```bash
nemus-cloud up   --module fargate --var region=us-east-1 --var name=nemus   # -> .nemus-target.json
nemus-cloud run  --image ghcr.io/acme/agent:latest --repos acme/api,acme/web \
                 --task "add idempotency keys" --owner acme --follow --wait
nemus-cloud down --module fargate
```

- **`up`** resolves a shipped module (`--module fargate` → `iacModuleDir`, or `--module-dir`), takes `--var k=v`, runs `OpenTofuProvisioner.up()`, writes the descriptor.
- **`down`** loads the descriptor and runs `.down()`.
- **`run`** builds the runner-image **env contract** + a **tag-safe** `TaskSpec` from flags and launches it on `target.runner`; `--follow` streams logs, `--wait` polls to a terminal `Status` and returns the **task's exit code**.

Forge auth for `run` comes from the environment (`GITHUB_TOKEN` or `GITHUB_APP_*`), passed straight into the task. The comma-bearing repo list goes in `NEMUS_REPOS` env, **never** in labels (would trip the Fargate tag guard).

## Verification

- **96 cloud tests** (+11: arg-parse forms, `--var` parsing, `TaskSpec` env/label wiring + required/auth errors, and `main()` dispatch for up/run/down incl. follow+wait exit codes and error paths) with fully injected fs/provisioner/runner.
- typecheck + build clean; `nemus-cloud help`/error exit codes smoke-tested; core CLI untouched; no version bump.

## Status

**P2 done** (provisioner #34 + runner #36 + this CLI). Next up is **P3**: report-back draft PR + a bounded CI-loop over `GitForge`.

Design: `docs/plans/2026-08-26-cloud-iac.md`.