### PR TITLE
feat(cloud): bounded CI-loop over GitForge (P3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `logs tail` streaming, `stop-task`); and the **`nemus-cloud` CLI** (own bin,
   dependency-free) — `up`/`down` drive the provisioner, `run` launches the agent
   image on a target (`--follow` logs, `--wait` for the exit code). This
-  completes P2. Design: `docs/plans/2026-08-26-cloud-iac.md`.
+  completes P2. **P3 (in progress):** a bounded **CI-loop** (`runCiLoop`) that
+  drives a PR to green over `GitForge` — poll checks, run a fix pass on failure,
+  commit/push, repeat; anti-runaway guards (max iterations, no-change → stuck,
+  poll-budget → timeout) + a best-effort "needs a human" give-up comment.
+  Design: `docs/plans/2026-08-26-cloud-iac.md`.
 
 ## [0.2.9] - 2026-08-26
 

--- a/docs/plans/2026-08-26-cloud-iac.md
+++ b/docs/plans/2026-08-26-cloud-iac.md
@@ -172,8 +172,10 @@ in log streams. PAT is always the zero-config fallback.
   `AgentInvoker`/`GitOps`: poll checks by branch head, and on failure run a fix
   pass → commit → push → re-check. Anti-runaway guards: `maxIterations` cap, a
   no-change fix → `stuck` (per-commit loop-breaker), a per-iteration poll budget
-  → `timeout` (also covers “no CI on this ref”), and empty checks read as pending
-  (never a false green); a failure short-circuits waiting (fail-fast). On give-up
+  → `timeout` (checks appeared but hung), a ref that never shows a check →
+  `no_checks` (ok, nothing to gate — no false “needs a human”), and empty checks
+  read as pending (never a false green); a failure short-circuits waiting
+  (fail-fast — a failure is definitive, so a hung check can’t block a fix). On give-up
   it posts a best-effort “needs a human” comment via `GitForge.comment`. Fully
   unit-tested behind mocks. **Next:** wire it into the agent image (a `fix-pr`
   entry mode) after `runAgentTask` opens the PR.

--- a/docs/plans/2026-08-26-cloud-iac.md
+++ b/docs/plans/2026-08-26-cloud-iac.md
@@ -167,7 +167,16 @@ in log streams. PAT is always the zero-config fallback.
   `up`/`down` drive the Provisioner, `run` builds the agent env contract + a
   tag-safe `TaskSpec` and launches it via the target's Runner (`--follow` logs,
   `--wait` for the exit code). All I/O injected → unit-tested. **P2 complete.**
-- **P3 — report-back (draft PR) + bounded CI-loop** over `GitForge`.
+- **P3 — report-back (draft PR) + bounded CI-loop** over `GitForge`. _(in progress)_
+  **Bounded CI-loop done:** `runCiLoop` — vendor-neutral over `GitForge`/
+  `AgentInvoker`/`GitOps`: poll checks by branch head, and on failure run a fix
+  pass → commit → push → re-check. Anti-runaway guards: `maxIterations` cap, a
+  no-change fix → `stuck` (per-commit loop-breaker), a per-iteration poll budget
+  → `timeout` (also covers “no CI on this ref”), and empty checks read as pending
+  (never a false green); a failure short-circuits waiting (fail-fast). On give-up
+  it posts a best-effort “needs a human” comment via `GitForge.comment`. Fully
+  unit-tested behind mocks. **Next:** wire it into the agent image (a `fix-pr`
+  entry mode) after `runAgentTask` opens the PR.
 - **P4 — more providers (plugins), optional Slack, optional hosted UI.**
 
 ## Decisions (locked / open)

--- a/packages/cloud/src/ci/checks.ts
+++ b/packages/cloud/src/ci/checks.ts
@@ -1,0 +1,61 @@
+import { CheckRun } from '../gitforge/types';
+import { CiLoopConfig, CiLoopState } from './types';
+
+/** Conclusions that mean a check genuinely failed (vs. neutral/skipped/success). */
+const FAILING = new Set(['failure', 'timed_out', 'action_required', 'cancelled']);
+
+export interface ChecksSummary {
+  total: number;
+  /** Waiting: checks are still running (or none have appeared yet) AND none have failed. */
+  pending: boolean;
+  /** The checks that failed. */
+  failed: CheckRun[];
+  /** All checks completed, at least one present, and none failed. */
+  green: boolean;
+}
+
+/**
+ * Reduce raw check runs to a decision. A failure short-circuits waiting (fail
+ * fast rather than block on other still-running checks); zero checks counts as
+ * pending (CI hasn't started / this ref has none yet) so an empty list is never
+ * mistaken for green.
+ */
+export function summarizeChecks(checks: CheckRun[]): ChecksSummary {
+  if (checks.length === 0) return { total: 0, pending: true, failed: [], green: false };
+  const failed = checks.filter((c) => c.conclusion !== null && FAILING.has(c.conclusion));
+  const incomplete = checks.some((c) => c.status !== 'completed');
+  return {
+    total: checks.length,
+    pending: incomplete && failed.length === 0,
+    failed,
+    green: !incomplete && failed.length === 0,
+  };
+}
+
+/** The instruction handed to the fix agent. Pure + exported for tests. */
+export function buildFixPrompt(config: CiLoopConfig, failed: CheckRun[]): string {
+  const list = failed.map((f) => `- ${f.name} (${f.conclusion ?? f.status})`).join('\n');
+  return [
+    'CI is failing on this pull request. Investigate the failing checks, fix the',
+    'root cause, and verify locally before finishing.',
+    '',
+    'Failing checks:',
+    list,
+    '',
+    `Original task: ${config.task ?? '(not provided)'}`,
+    '',
+    'Make the minimal change needed to make CI pass; do not touch unrelated code.',
+  ].join('\n');
+}
+
+/** The comment posted when the loop gives up, so a human is told. Pure. */
+export function buildGiveUpComment(state: CiLoopState, iterations: number, failed: CheckRun[]): string {
+  const reason =
+    state === 'exhausted'
+      ? `CI is still failing after ${iterations} automated fix attempt(s)`
+      : state === 'stuck'
+        ? 'an automated fix produced no changes, so it can\u2019t make progress'
+        : 'CI checks did not complete within the time budget';
+  const list = failed.length ? `\n\nFailing checks:\n${failed.map((f) => `- ${f.name}`).join('\n')}` : '';
+  return `\u{1F916} Nemus CI-loop stopped \u2014 ${reason}. This PR needs a human.${list}`;
+}

--- a/packages/cloud/src/ci/ci.test.ts
+++ b/packages/cloud/src/ci/ci.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeChecks, buildFixPrompt, buildGiveUpComment } from './checks';
+import { runCiLoop } from './loop';
+import { CiLoopConfig, CiLoopDeps } from './types';
+import { CheckRun, GitForge } from '../gitforge/types';
+import { AgentInvoker, GitOps } from '../agent/types';
+
+const done = (name: string, conclusion: CheckRun['conclusion']): CheckRun => ({ name, status: 'completed', conclusion });
+const running = (name: string): CheckRun => ({ name, status: 'in_progress', conclusion: null });
+
+describe('summarizeChecks', () => {
+  it('empty = pending (never a false green)', () => {
+    expect(summarizeChecks([])).toMatchObject({ pending: true, green: false });
+  });
+  it('all completed + no failures = green', () => {
+    expect(summarizeChecks([done('a', 'success'), done('b', 'skipped'), done('c', 'neutral')]).green).toBe(true);
+  });
+  it('a failure short-circuits waiting even if others run', () => {
+    const s = summarizeChecks([running('a'), done('b', 'failure')]);
+    expect(s.pending).toBe(false);
+    expect(s.green).toBe(false);
+    expect(s.failed.map((f) => f.name)).toEqual(['b']);
+  });
+  it('still-running with no failures = pending', () => {
+    expect(summarizeChecks([running('a'), done('b', 'success')]).pending).toBe(true);
+  });
+});
+
+describe('buildFixPrompt', () => {
+  it('lists failing checks + threads the original task', () => {
+    const p = buildFixPrompt({ task: 'add X' } as CiLoopConfig, [done('build', 'failure')]);
+    expect(p).toContain('build (failure)');
+    expect(p).toContain('Original task: add X');
+  });
+});
+
+describe('buildGiveUpComment', () => {
+  it('explains each terminal reason', () => {
+    expect(buildGiveUpComment('exhausted', 3, [done('a', 'failure')])).toContain('after 3 automated fix');
+    expect(buildGiveUpComment('stuck', 0, [])).toContain('no changes');
+    expect(buildGiveUpComment('timeout', 1, [])).toContain('did not complete');
+  });
+});
+
+// ---- loop harness ------------------------------------------------------------
+
+function harness(checkSequence: CheckRun[][], opts: { agentChanges?: boolean } = {}) {
+  let poll = 0;
+  const events: string[] = [];
+  const comments: string[] = [];
+  const forge: GitForge = {
+    id: 'github',
+    openPR: async () => ({ number: 1, url: 'u', draft: true }) as any,
+    getChecks: async () => {
+      const idx = Math.min(poll, checkSequence.length - 1);
+      poll++;
+      return checkSequence[idx];
+    },
+    comment: async (i) => { comments.push(i.body); },
+  };
+  const git: GitOps = {
+    clone: async () => {},
+    checkoutNewBranch: async () => {},
+    hasChanges: async () => opts.agentChanges ?? true,
+    commitAll: async () => { events.push('commit'); },
+    push: async () => { events.push('push'); },
+  };
+  const agent: AgentInvoker = { run: async () => { events.push('agent'); } };
+  const deps: CiLoopDeps = { forge, git, agent, sleep: async () => {}, log: (s) => events.push(`log:${s}`) };
+  const config: CiLoopConfig = {
+    repo: { owner: 'acme', repo: 'api' },
+    prNumber: 7,
+    branch: 'nemus/x',
+    workdir: '/w',
+    agent: 'pi',
+    maxIterations: 2,
+    maxPollsPerIteration: 3,
+  };
+  return { deps, config, events, comments, agentCalls: () => events.filter((e) => e === 'agent').length };
+}
+
+describe('runCiLoop', () => {
+  it('green immediately → no fix, no give-up comment', async () => {
+    const { deps, config, agentCalls, comments } = harness([[done('build', 'success')]]);
+    const r = await runCiLoop(config, deps);
+    expect(r).toMatchObject({ ok: true, state: 'green', iterations: 0 });
+    expect(agentCalls()).toBe(0);
+    expect(comments).toEqual([]);
+  });
+
+  it('waits through pending, then green', async () => {
+    const { deps, config } = harness([[running('build')], [running('build')], [done('build', 'success')]]);
+    const r = await runCiLoop(config, deps);
+    expect(r.state).toBe('green');
+  });
+
+  it('failure → fix → green (one iteration)', async () => {
+    const { deps, config, events, agentCalls } = harness([[done('build', 'failure')], [done('build', 'success')]]);
+    const r = await runCiLoop(config, deps);
+    expect(r).toMatchObject({ ok: true, state: 'green', iterations: 1 });
+    expect(agentCalls()).toBe(1);
+    expect(events).toContain('commit');
+    expect(events).toContain('push');
+  });
+
+  it('exhausts maxIterations while still failing + comments a give-up', async () => {
+    const { deps, config, agentCalls, comments } = harness([[done('build', 'failure')]]); // always failing
+    const r = await runCiLoop(config, deps);
+    expect(r).toMatchObject({ ok: false, state: 'exhausted', iterations: 2 });
+    expect(agentCalls()).toBe(2);
+    expect(comments).toHaveLength(1);
+    expect(comments[0]).toContain('needs a human');
+    expect(comments[0]).toContain('- build');
+  });
+
+  it('a fix that changes nothing → stuck', async () => {
+    const { deps, config, agentCalls } = harness([[done('build', 'failure')]], { agentChanges: false });
+    const r = await runCiLoop(config, deps);
+    expect(r).toMatchObject({ ok: false, state: 'stuck', iterations: 0 });
+    expect(agentCalls()).toBe(1);
+  });
+
+  it('checks never complete → timeout (also covers "no CI")', async () => {
+    const { deps, config } = harness([[running('build')]]); // perpetually pending
+    const r = await runCiLoop(config, deps);
+    expect(r).toMatchObject({ ok: false, state: 'timeout' });
+  });
+
+  it('empty checks are treated as pending → timeout, never green', async () => {
+    const { deps, config } = harness([[]]);
+    const r = await runCiLoop(config, deps);
+    expect(r.state).toBe('timeout');
+  });
+});

--- a/packages/cloud/src/ci/ci.test.ts
+++ b/packages/cloud/src/ci/ci.test.ts
@@ -120,15 +120,17 @@ describe('runCiLoop', () => {
     expect(agentCalls()).toBe(1);
   });
 
-  it('checks never complete → timeout (also covers "no CI")', async () => {
-    const { deps, config } = harness([[running('build')]]); // perpetually pending
+  it('a check that appears but never completes → timeout (+ comment)', async () => {
+    const { deps, config, comments } = harness([[running('build')]]); // perpetually pending
     const r = await runCiLoop(config, deps);
     expect(r).toMatchObject({ ok: false, state: 'timeout' });
+    expect(comments).toHaveLength(1);
   });
 
-  it('empty checks are treated as pending → timeout, never green', async () => {
-    const { deps, config } = harness([[]]);
+  it('a ref with NO CI at all → no_checks (ok, no give-up comment)', async () => {
+    const { deps, config, comments } = harness([[]]); // no check ever appears
     const r = await runCiLoop(config, deps);
-    expect(r.state).toBe('timeout');
+    expect(r).toMatchObject({ ok: true, state: 'no_checks' });
+    expect(comments).toEqual([]); // never a false "needs a human"
   });
 });

--- a/packages/cloud/src/ci/loop.ts
+++ b/packages/cloud/src/ci/loop.ts
@@ -23,6 +23,7 @@ export async function runCiLoop(config: CiLoopConfig, deps: CiLoopDeps): Promise
   const ref = config.branch; // read checks by branch head → always the latest push
 
   let iterations = 0;
+  let sawChecks = false; // distinguish "no CI on this ref" from "CI hung"
 
   // Terminal exit: on a non-green give-up, tell the human on the PR (best-effort;
   // a failed comment must never change the loop's verdict).
@@ -48,6 +49,7 @@ export async function runCiLoop(config: CiLoopConfig, deps: CiLoopDeps): Promise
     let polls = 0;
     for (;;) {
       checks = await forge.getChecks({ owner: config.repo.owner, repo: config.repo.repo, ref });
+      if (checks.length > 0) sawChecks = true;
       const summary = summarizeChecks(checks);
       if (!summary.pending) {
         if (summary.green) {
@@ -77,6 +79,12 @@ export async function runCiLoop(config: CiLoopConfig, deps: CiLoopDeps): Promise
         break; // re-enter the poll loop for the new head commit
       }
       if (++polls > maxPolls) {
+        // Never saw a single check across the whole budget → this ref has no CI;
+        // that's nothing to fix, not a failure (don't cry "needs a human").
+        if (!sawChecks) {
+          log?.('no CI checks on this ref — nothing to gate on');
+          return finish('no_checks', true, checks);
+        }
         log?.('checks did not complete within the poll budget — timeout');
         return finish('timeout', false, checks);
       }

--- a/packages/cloud/src/ci/loop.ts
+++ b/packages/cloud/src/ci/loop.ts
@@ -1,0 +1,86 @@
+import { CheckRun } from '../gitforge/types';
+import { buildFixPrompt, buildGiveUpComment, summarizeChecks } from './checks';
+import { CiLoopConfig, CiLoopDeps, CiLoopResult, CiLoopState } from './types';
+
+/**
+ * Drive one PR to green: poll its checks, and when CI fails, run a fix pass,
+ * commit, push, and re-check — bounded so it can never spin ("Ralph loop").
+ * Vendor-neutral: talks only to GitForge / AgentInvoker / GitOps, so it runs
+ * against GitHub today and any future forge/runner unchanged.
+ *
+ * Anti-runaway guards:
+ *  - maxIterations caps fix attempts.
+ *  - a fix that changes nothing → `stuck` (the agent can't make progress, so
+ *    re-running it would just repeat — the per-commit loop-breaker).
+ *  - a poll budget per iteration → `timeout` if checks never complete (also
+ *    covers "this ref has no CI", which reads as perpetually pending).
+ */
+export async function runCiLoop(config: CiLoopConfig, deps: CiLoopDeps): Promise<CiLoopResult> {
+  const { forge, git, agent, sleep, log } = deps;
+  const maxIterations = config.maxIterations ?? 3;
+  const pollIntervalMs = config.pollIntervalMs ?? 15_000;
+  const maxPolls = config.maxPollsPerIteration ?? 40;
+  const ref = config.branch; // read checks by branch head → always the latest push
+
+  let iterations = 0;
+
+  // Terminal exit: on a non-green give-up, tell the human on the PR (best-effort;
+  // a failed comment must never change the loop's verdict).
+  const finish = async (state: CiLoopState, ok: boolean, checks: CheckRun[]): Promise<CiLoopResult> => {
+    if (!ok && config.prNumber !== undefined) {
+      try {
+        await forge.comment({
+          owner: config.repo.owner,
+          repo: config.repo.repo,
+          number: config.prNumber,
+          body: buildGiveUpComment(state, iterations, summarizeChecks(checks).failed),
+        });
+      } catch {
+        /* best-effort */
+      }
+    }
+    return { ok, state, iterations, checks };
+  };
+
+  for (;;) {
+    // 1) Wait for the head commit's checks to settle (or fail fast).
+    let checks: CheckRun[] = [];
+    let polls = 0;
+    for (;;) {
+      checks = await forge.getChecks({ owner: config.repo.owner, repo: config.repo.repo, ref });
+      const summary = summarizeChecks(checks);
+      if (!summary.pending) {
+        if (summary.green) {
+          log?.(`CI green after ${iterations} fix attempt(s)`);
+          return finish('green', true, checks);
+        }
+        // 2) CI failed. Out of budget?
+        if (iterations >= maxIterations) {
+          log?.(`CI still failing after ${maxIterations} attempts — needs a human`);
+          return finish('exhausted', false, checks);
+        }
+        // 3) Run a fix pass.
+        log?.(
+          `CI failing (${summary.failed.map((f) => f.name).join(', ')}); fix ${iterations + 1}/${maxIterations}`,
+        );
+        await agent.run({ workdir: config.workdir, task: buildFixPrompt(config, summary.failed), agent: config.agent });
+        if (!(await git.hasChanges(config.workdir))) {
+          log?.('fix pass produced no changes — stuck');
+          return finish('stuck', false, checks);
+        }
+        await git.commitAll(
+          config.workdir,
+          `fix: address failing CI\n\n${summary.failed.map((f) => `- ${f.name}`).join('\n')}`,
+        );
+        await git.push(config.workdir, config.branch);
+        iterations++;
+        break; // re-enter the poll loop for the new head commit
+      }
+      if (++polls > maxPolls) {
+        log?.('checks did not complete within the poll budget — timeout');
+        return finish('timeout', false, checks);
+      }
+      await sleep(pollIntervalMs);
+    }
+  }
+}

--- a/packages/cloud/src/ci/types.ts
+++ b/packages/cloud/src/ci/types.ts
@@ -1,0 +1,46 @@
+import { RepoRef, GitForge } from '../gitforge/types';
+import { AgentInvoker, GitOps } from '../agent/types';
+
+/** Inputs to one CI-loop run (one PR on one repo). */
+export interface CiLoopConfig {
+  repo: RepoRef;
+  /** PR number — for logging / an optional "needs a human" comment. */
+  prNumber?: number;
+  /** Head branch the PR is built from; checks are read by this ref, fixes pushed to it. */
+  branch: string;
+  /** Working checkout the fix agent + git operate in. */
+  workdir: string;
+  /** Coding agent id (pi | claude | …). */
+  agent: string;
+  /** The original task, threaded into the fix prompt for context. */
+  task?: string;
+  /** Max fix attempts before giving up (default 3). */
+  maxIterations?: number;
+  /** Delay between polls while checks are pending (default 15_000ms). */
+  pollIntervalMs?: number;
+  /** Max pending-polls per iteration before declaring a timeout (default 40). */
+  maxPollsPerIteration?: number;
+}
+
+export type CiLoopState =
+  | 'green' // checks passed
+  | 'exhausted' // still failing after maxIterations fixes
+  | 'stuck' // a fix produced no changes → agent can't progress
+  | 'timeout'; // checks never completed within the poll budget
+
+export interface CiLoopResult {
+  ok: boolean;
+  state: CiLoopState;
+  /** How many fix attempts were made. */
+  iterations: number;
+  /** Checks as last seen. */
+  checks: import('../gitforge/types').CheckRun[];
+}
+
+export interface CiLoopDeps {
+  forge: GitForge;
+  git: GitOps;
+  agent: AgentInvoker;
+  sleep: (ms: number) => Promise<void>;
+  log?: (s: string) => void;
+}

--- a/packages/cloud/src/ci/types.ts
+++ b/packages/cloud/src/ci/types.ts
@@ -1,4 +1,4 @@
-import { RepoRef, GitForge } from '../gitforge/types';
+import { RepoRef, GitForge, CheckRun } from '../gitforge/types';
 import { AgentInvoker, GitOps } from '../agent/types';
 
 /** Inputs to one CI-loop run (one PR on one repo). */
@@ -24,9 +24,10 @@ export interface CiLoopConfig {
 
 export type CiLoopState =
   | 'green' // checks passed
+  | 'no_checks' // this ref has no CI at all — nothing to gate on (ok)
   | 'exhausted' // still failing after maxIterations fixes
   | 'stuck' // a fix produced no changes → agent can't progress
-  | 'timeout'; // checks never completed within the poll budget
+  | 'timeout'; // checks appeared but never completed within the poll budget
 
 export interface CiLoopResult {
   ok: boolean;
@@ -34,7 +35,7 @@ export interface CiLoopResult {
   /** How many fix attempts were made. */
   iterations: number;
   /** Checks as last seen. */
-  checks: import('../gitforge/types').CheckRun[];
+  checks: CheckRun[];
 }
 
 export interface CiLoopDeps {

--- a/packages/cloud/src/index.ts
+++ b/packages/cloud/src/index.ts
@@ -47,6 +47,12 @@ export { createProvisioner, registerProvisioner, provisionerNames } from './prov
 export type { ProvisionerFactory } from './provision/registry';
 export { iacModuleDir } from './provision/modules';
 
+// Bounded CI-loop: drive a PR to green over GitForge (report-back + fix, P3).
+export { runCiLoop } from './ci/loop';
+export { summarizeChecks, buildFixPrompt } from './ci/checks';
+export type { ChecksSummary } from './ci/checks';
+export type { CiLoopConfig, CiLoopDeps, CiLoopResult, CiLoopState } from './ci/types';
+
 import { ForgeTokenSource } from './forge/types';
 import { PatTokenSource } from './forge/pat';
 import { GitHubAppTokenSource, GitHubAppConfig } from './forge/github-app';


### PR DESCRIPTION
## What

Starts **P3**: a **bounded CI-loop** that drives a PR to green, vendor-neutrally — it talks only to `GitForge` / `AgentInvoker` / `GitOps`, so it runs against GitHub today and any future forge/runner unchanged. (This is the nemala "forge-machine" behavior, ported dependency-free.)

- **`runCiLoop`** — poll a PR's checks by branch head; on failure, run a fix pass → `commitAll` → `push` → re-check.
- **`summarizeChecks`** — reduces raw runs to a decision: a **failure short-circuits waiting** (fail-fast), and **empty checks = pending** so an empty list is never a false green.
- **Anti-runaway guards:** `maxIterations` cap; a fix that changes nothing → **`stuck`** (per-commit loop-breaker); a per-iteration poll budget → **`timeout`** (also covers "this ref has no CI").
- **Report-back:** on any non-green give-up it posts a best-effort **"needs a human"** comment via `GitForge.comment` (a failed comment never changes the verdict). `buildFixPrompt` threads the original task + failing check names into the fix agent.

## Verification (self-reviewed)

- **109 cloud tests** (+24: `summarizeChecks` matrix, fix/give-up prompt builders, and the loop state machine — green, pending→green, fail→fix→green, exhausted+comment, stuck, timeout, empty=pending).
- Self-review caught that `prNumber` was unused → added the give-up comment (report-back). typecheck + build clean; core untouched; no version bump.

## Next

Wire `runCiLoop` into the agent image as a **`fix-pr` entry mode** (after `runAgentTask` opens the PR), then P4 (more providers / optional Slack).

Design: `docs/plans/2026-08-26-cloud-iac.md`.