### PR TITLE
feat(cloud): notification seam — Slack + webhook report-back (P4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   completes P2. **P3 (in progress):** a bounded **CI-loop** (`runCiLoop`) that
   drives a PR to green over `GitForge` — poll checks, run a fix pass on failure,
   commit/push, repeat; anti-runaway guards (max iterations, no-change → stuck,
-  poll-budget → timeout) + a best-effort "needs a human" give-up comment.
+  poll-budget → timeout) + a best-effort "needs a human" give-up comment; and
+  (P4) a vendor-neutral **notification seam** — `Notifier` with Slack (incoming
+  webhook) + generic webhook sinks (`notifierFromEnv`), wired into the CI-loop as
+  optional out-of-band report-back.
   Design: `docs/plans/2026-08-26-cloud-iac.md`.
 
 ## [0.2.9] - 2026-08-26

--- a/docs/plans/2026-08-26-cloud-iac.md
+++ b/docs/plans/2026-08-26-cloud-iac.md
@@ -179,7 +179,18 @@ in log streams. PAT is always the zero-config fallback.
   it posts a best-effort “needs a human” comment via `GitForge.comment`. Fully
   unit-tested behind mocks. **Next:** wire it into the agent image (a `fix-pr`
   entry mode) after `runAgentTask` opens the PR.
-- **P4 — more providers (plugins), optional Slack, optional hosted UI.**
+- **P4 — more providers (plugins), optional Slack, optional hosted UI.** _(in progress)_
+  **Notification seam done:** a vendor-neutral `Notifier` (best-effort, zero-dep
+  via `fetch`) with `SlackNotifier` (incoming webhook), `WebhookNotifier`
+  (generic JSON sink), `MultiNotifier`/`NoopNotifier`, and `notifierFromEnv`
+  (`SLACK_WEBHOOK_URL`/`NEMUS_WEBHOOK_URL`). Wired into the CI-loop as an
+  optional out-of-band report-back (`ci_green` / `needs_human`). **Fly.io
+  provider deferred:** `flyctl` has **no `--json` on `machine run`/`machine
+  status`** (only `machine list`), so a robust runner would need brittle
+  stdout-scraping + racy list-correlation — not worth shipping below the bar the
+  Fargate runner set. Revisit if flyctl adds machine-run JSON, or via the
+  Machines REST API. **Next:** wire `runCiLoop` + notifier into the agent image
+  (`fix-pr` mode); optional hosted UI remains out of scope for OSS core.
 
 ## Decisions (locked / open)
 

--- a/packages/cloud/src/ci/ci.test.ts
+++ b/packages/cloud/src/ci/ci.test.ts
@@ -66,7 +66,11 @@ function harness(checkSequence: CheckRun[][], opts: { agentChanges?: boolean } =
     push: async () => { events.push('push'); },
   };
   const agent: AgentInvoker = { run: async () => { events.push('agent'); } };
-  const deps: CiLoopDeps = { forge, git, agent, sleep: async () => {}, log: (s) => events.push(`log:${s}`) };
+  const notes: string[] = [];
+  const deps: CiLoopDeps = {
+    forge, git, agent, sleep: async () => {}, log: (s) => events.push(`log:${s}`),
+    notifier: { id: 'test', notify: async (n) => { notes.push(n.event); } },
+  };
   const config: CiLoopConfig = {
     repo: { owner: 'acme', repo: 'api' },
     prNumber: 7,
@@ -76,7 +80,7 @@ function harness(checkSequence: CheckRun[][], opts: { agentChanges?: boolean } =
     maxIterations: 2,
     maxPollsPerIteration: 3,
   };
-  return { deps, config, events, comments, agentCalls: () => events.filter((e) => e === 'agent').length };
+  return { deps, config, events, comments, notes, agentCalls: () => events.filter((e) => e === 'agent').length };
 }
 
 describe('runCiLoop', () => {
@@ -127,10 +131,21 @@ describe('runCiLoop', () => {
     expect(comments).toHaveLength(1);
   });
 
-  it('a ref with NO CI at all → no_checks (ok, no give-up comment)', async () => {
-    const { deps, config, comments } = harness([[]]); // no check ever appears
+  it('a ref with NO CI at all → no_checks (ok, no give-up comment or notification)', async () => {
+    const { deps, config, comments, notes } = harness([[]]); // no check ever appears
     const r = await runCiLoop(config, deps);
     expect(r).toMatchObject({ ok: true, state: 'no_checks' });
     expect(comments).toEqual([]); // never a false "needs a human"
+    expect(notes).toEqual([]); // and nothing worth pinging about
+  });
+
+  it('notifies ci_green on success and needs_human on give-up', async () => {
+    const green = harness([[done('build', 'success')]]);
+    await runCiLoop(green.config, green.deps);
+    expect(green.notes).toEqual(['ci_green']);
+
+    const giveup = harness([[done('build', 'failure')]]); // exhausts
+    await runCiLoop(giveup.config, giveup.deps);
+    expect(giveup.notes).toEqual(['needs_human']);
   });
 });

--- a/packages/cloud/src/ci/ci.test.ts
+++ b/packages/cloud/src/ci/ci.test.ts
@@ -148,4 +148,12 @@ describe('runCiLoop', () => {
     await runCiLoop(giveup.config, giveup.deps);
     expect(giveup.notes).toEqual(['needs_human']);
   });
+
+  it('a failing notifier is logged, never fatal to the loop', async () => {
+    const h = harness([[done('build', 'success')]]);
+    h.deps.notifier = { id: 'bad', notify: async () => { throw new Error('webhook 500'); } };
+    const r = await runCiLoop(h.config, h.deps); // must still return green
+    expect(r.state).toBe('green');
+    expect(h.events.some((e) => e.startsWith('log:notify failed: webhook 500'))).toBe(true);
+  });
 });

--- a/packages/cloud/src/ci/loop.ts
+++ b/packages/cloud/src/ci/loop.ts
@@ -40,6 +40,25 @@ export async function runCiLoop(config: CiLoopConfig, deps: CiLoopDeps): Promise
         /* best-effort */
       }
     }
+    // Out-of-band report-back (Slack/webhook), best-effort. Only the outcomes a
+    // human cares about: green (done) and give-ups (needs attention).
+    if (deps.notifier && state !== 'no_checks') {
+      const repoName = `${config.repo.owner}/${config.repo.repo}`;
+      try {
+        await deps.notifier.notify(
+          ok
+            ? { event: 'ci_green', title: `CI green: ${repoName}`, repo: repoName }
+            : {
+                event: 'needs_human',
+                title: `CI-loop gave up (${state}): ${repoName}`,
+                body: summarizeChecks(checks).failed.map((f) => `- ${f.name}`).join('\n') || undefined,
+                repo: repoName,
+              },
+        );
+      } catch {
+        /* best-effort */
+      }
+    }
     return { ok, state, iterations, checks };
   };
 

--- a/packages/cloud/src/ci/loop.ts
+++ b/packages/cloud/src/ci/loop.ts
@@ -28,13 +28,14 @@ export async function runCiLoop(config: CiLoopConfig, deps: CiLoopDeps): Promise
   // Terminal exit: on a non-green give-up, tell the human on the PR (best-effort;
   // a failed comment must never change the loop's verdict).
   const finish = async (state: CiLoopState, ok: boolean, checks: CheckRun[]): Promise<CiLoopResult> => {
+    const failed = summarizeChecks(checks).failed;
     if (!ok && config.prNumber !== undefined) {
       try {
         await forge.comment({
           owner: config.repo.owner,
           repo: config.repo.repo,
           number: config.prNumber,
-          body: buildGiveUpComment(state, iterations, summarizeChecks(checks).failed),
+          body: buildGiveUpComment(state, iterations, failed),
         });
       } catch {
         /* best-effort */
@@ -51,12 +52,13 @@ export async function runCiLoop(config: CiLoopConfig, deps: CiLoopDeps): Promise
             : {
                 event: 'needs_human',
                 title: `CI-loop gave up (${state}): ${repoName}`,
-                body: summarizeChecks(checks).failed.map((f) => `- ${f.name}`).join('\n') || undefined,
+                body: failed.map((f) => `- ${f.name}`).join('\n') || undefined,
                 repo: repoName,
               },
         );
-      } catch {
-        /* best-effort */
+      } catch (e) {
+        // best-effort, but don't fail silently — a misconfigured webhook is worth a line
+        log?.(`notify failed: ${(e as Error).message}`);
       }
     }
     return { ok, state, iterations, checks };

--- a/packages/cloud/src/ci/types.ts
+++ b/packages/cloud/src/ci/types.ts
@@ -1,5 +1,6 @@
 import { RepoRef, GitForge, CheckRun } from '../gitforge/types';
 import { AgentInvoker, GitOps } from '../agent/types';
+import { Notifier } from '../notify/types';
 
 /** Inputs to one CI-loop run (one PR on one repo). */
 export interface CiLoopConfig {
@@ -44,4 +45,6 @@ export interface CiLoopDeps {
   agent: AgentInvoker;
   sleep: (ms: number) => Promise<void>;
   log?: (s: string) => void;
+  /** Optional out-of-band report-back (Slack/webhook); best-effort. */
+  notifier?: Notifier;
 }

--- a/packages/cloud/src/index.ts
+++ b/packages/cloud/src/index.ts
@@ -53,6 +53,10 @@ export { summarizeChecks, buildFixPrompt } from './ci/checks';
 export type { ChecksSummary } from './ci/checks';
 export type { CiLoopConfig, CiLoopDeps, CiLoopResult, CiLoopState } from './ci/types';
 
+// Notification seam: out-of-band report-back (Slack / generic webhook), P4.
+export * from './notify';
+export { notifierFromEnv } from './notify';
+
 import { ForgeTokenSource } from './forge/types';
 import { PatTokenSource } from './forge/pat';
 import { GitHubAppTokenSource, GitHubAppConfig } from './forge/github-app';

--- a/packages/cloud/src/notify/index.ts
+++ b/packages/cloud/src/notify/index.ts
@@ -1,0 +1,25 @@
+import { FetchLike, Notifier } from './types';
+import { SlackNotifier } from './slack';
+import { MultiNotifier, NoopNotifier, WebhookNotifier } from './webhook';
+
+export * from './types';
+export { SlackNotifier, formatSlackText } from './slack';
+export type { SlackNotifierOptions } from './slack';
+export { WebhookNotifier, MultiNotifier, NoopNotifier } from './webhook';
+export type { WebhookNotifierOptions } from './webhook';
+
+/**
+ * Build a Notifier from the environment (opt-in). Reads:
+ *   SLACK_WEBHOOK_URL  → Slack incoming webhook
+ *   NEMUS_WEBHOOK_URL  → generic JSON webhook
+ * Zero configured → a NoopNotifier, so callers can always call notify()
+ * unconditionally; several configured → a best-effort MultiNotifier.
+ */
+export function notifierFromEnv(env: NodeJS.ProcessEnv = process.env, fetchImpl?: FetchLike): Notifier {
+  const notifiers: Notifier[] = [];
+  if (env.SLACK_WEBHOOK_URL) notifiers.push(new SlackNotifier({ webhookUrl: env.SLACK_WEBHOOK_URL, fetch: fetchImpl }));
+  if (env.NEMUS_WEBHOOK_URL) notifiers.push(new WebhookNotifier({ url: env.NEMUS_WEBHOOK_URL, fetch: fetchImpl }));
+  if (notifiers.length === 0) return new NoopNotifier();
+  if (notifiers.length === 1) return notifiers[0];
+  return new MultiNotifier(notifiers);
+}

--- a/packages/cloud/src/notify/notify.test.ts
+++ b/packages/cloud/src/notify/notify.test.ts
@@ -41,6 +41,11 @@ describe('SlackNotifier', () => {
   it('requires a webhookUrl', () => {
     expect(() => new SlackNotifier({ webhookUrl: '' })).toThrow(/webhookUrl/);
   });
+  it('accepts a timeoutMs (bounds a hung endpoint) and still posts', async () => {
+    const { fetch, calls } = recorder();
+    await new SlackNotifier({ webhookUrl: 'h', fetch, timeoutMs: 500 }).notify(pr);
+    expect(calls).toHaveLength(1);
+  });
 });
 
 describe('WebhookNotifier', () => {

--- a/packages/cloud/src/notify/notify.test.ts
+++ b/packages/cloud/src/notify/notify.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { formatSlackText, SlackNotifier } from './slack';
+import { WebhookNotifier, MultiNotifier, NoopNotifier } from './webhook';
+import { notifierFromEnv } from './index';
+import { FetchLike, Notification } from './types';
+
+const ok: FetchLike = async () => ({ ok: true, status: 200, text: async () => '' });
+
+function recorder(res: Partial<{ ok: boolean; status: number; body: string }> = {}) {
+  const calls: { url: string; body: string }[] = [];
+  const fetch: FetchLike = async (url, init) => {
+    calls.push({ url, body: init.body });
+    return { ok: res.ok ?? true, status: res.status ?? 200, text: async () => res.body ?? '' };
+  };
+  return { fetch, calls };
+}
+
+const pr: Notification = { event: 'pr_opened', title: 'opened PR', repo: 'acme/api', url: 'https://x/pr/1', body: 'details' };
+
+describe('formatSlackText', () => {
+  it('includes emoji, title, repo, body, url', () => {
+    const t = formatSlackText(pr);
+    expect(t).toContain('*opened PR*');
+    expect(t).toContain('_acme/api_');
+    expect(t).toContain('details');
+    expect(t).toContain('https://x/pr/1');
+  });
+});
+
+describe('SlackNotifier', () => {
+  it('POSTs { text } to the webhook', async () => {
+    const { fetch, calls } = recorder();
+    await new SlackNotifier({ webhookUrl: 'https://hook', fetch }).notify(pr);
+    expect(calls[0].url).toBe('https://hook');
+    expect(JSON.parse(calls[0].body).text).toContain('opened PR');
+  });
+  it('throws on a non-2xx response', async () => {
+    const { fetch } = recorder({ ok: false, status: 500, body: 'boom' });
+    await expect(new SlackNotifier({ webhookUrl: 'h', fetch }).notify(pr)).rejects.toThrow(/slack webhook failed \(500\)/);
+  });
+  it('requires a webhookUrl', () => {
+    expect(() => new SlackNotifier({ webhookUrl: '' })).toThrow(/webhookUrl/);
+  });
+});
+
+describe('WebhookNotifier', () => {
+  it('POSTs the raw Notification as JSON', async () => {
+    const { fetch, calls } = recorder();
+    await new WebhookNotifier({ url: 'https://sink', fetch }).notify(pr);
+    expect(JSON.parse(calls[0].body)).toMatchObject({ event: 'pr_opened', repo: 'acme/api' });
+  });
+});
+
+describe('MultiNotifier', () => {
+  it('fans out best-effort — one failure does not block the others', async () => {
+    const hit: string[] = [];
+    const good = { id: 'g', notify: async () => { hit.push('g'); } };
+    const bad = { id: 'b', notify: async () => { hit.push('b'); throw new Error('nope'); } };
+    await new MultiNotifier([bad, good]).notify(pr); // must not throw
+    expect(hit.sort()).toEqual(['b', 'g']);
+  });
+});
+
+describe('notifierFromEnv', () => {
+  it('no config → Noop (no fetch)', async () => {
+    const { fetch, calls } = recorder();
+    const n = notifierFromEnv({}, fetch);
+    expect(n).toBeInstanceOf(NoopNotifier);
+    await n.notify(pr);
+    expect(calls).toHaveLength(0);
+  });
+  it('slack only → SlackNotifier', () => {
+    expect(notifierFromEnv({ SLACK_WEBHOOK_URL: 'h' }, ok).id).toBe('slack');
+  });
+  it('both → MultiNotifier fanning to two sinks', async () => {
+    const { fetch, calls } = recorder();
+    const n = notifierFromEnv({ SLACK_WEBHOOK_URL: 'h1', NEMUS_WEBHOOK_URL: 'h2' }, fetch);
+    expect(n.id).toBe('multi');
+    await n.notify(pr);
+    expect(calls.map((c) => c.url).sort()).toEqual(['h1', 'h2']);
+  });
+});

--- a/packages/cloud/src/notify/slack.ts
+++ b/packages/cloud/src/notify/slack.ts
@@ -20,6 +20,8 @@ export function formatSlackText(n: Notification): string {
 export interface SlackNotifierOptions {
   webhookUrl: string;
   fetch?: FetchLike;
+  /** Abort the POST after this many ms so a hung endpoint can't stall a run (default 10_000). */
+  timeoutMs?: number;
 }
 
 /** Posts to a Slack incoming webhook (`{ text }`). Zero-dep (uses fetch). */
@@ -31,7 +33,8 @@ export class SlackNotifier implements Notifier {
   constructor(opts: SlackNotifierOptions) {
     if (!opts.webhookUrl) throw new Error('SlackNotifier requires a webhookUrl');
     this.webhookUrl = opts.webhookUrl;
-    this.fetch = opts.fetch ?? ((url, init) => fetch(url, init));
+    const timeoutMs = opts.timeoutMs ?? 10_000;
+    this.fetch = opts.fetch ?? ((url, init) => fetch(url, { ...init, signal: AbortSignal.timeout(timeoutMs) }));
   }
 
   async notify(n: Notification): Promise<void> {

--- a/packages/cloud/src/notify/slack.ts
+++ b/packages/cloud/src/notify/slack.ts
@@ -1,0 +1,47 @@
+import { FetchLike, Notification, Notifier } from './types';
+
+const EMOJI: Record<Notification['event'], string> = {
+  pr_opened: '\u{1F4DD}', // 📝
+  ci_green: '\u2705', // ✅
+  needs_human: '\u{1F6A8}', // 🚨
+  run_failed: '\u274C', // ❌
+  info: '\u2139\uFE0F', // ℹ️
+};
+
+/** Render a Notification as Slack message text. Pure + exported for tests. */
+export function formatSlackText(n: Notification): string {
+  const parts = [`${EMOJI[n.event] ?? ''} *${n.title}*`.trim()];
+  if (n.repo) parts.push(`_${n.repo}_`);
+  if (n.body) parts.push(n.body);
+  if (n.url) parts.push(n.url);
+  return parts.join('\n');
+}
+
+export interface SlackNotifierOptions {
+  webhookUrl: string;
+  fetch?: FetchLike;
+}
+
+/** Posts to a Slack incoming webhook (`{ text }`). Zero-dep (uses fetch). */
+export class SlackNotifier implements Notifier {
+  readonly id = 'slack';
+  private readonly webhookUrl: string;
+  private readonly fetch: FetchLike;
+
+  constructor(opts: SlackNotifierOptions) {
+    if (!opts.webhookUrl) throw new Error('SlackNotifier requires a webhookUrl');
+    this.webhookUrl = opts.webhookUrl;
+    this.fetch = opts.fetch ?? ((url, init) => fetch(url, init));
+  }
+
+  async notify(n: Notification): Promise<void> {
+    const res = await this.fetch(this.webhookUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text: formatSlackText(n) }),
+    });
+    if (!res.ok) {
+      throw new Error(`slack webhook failed (${res.status}): ${(await res.text()).slice(0, 200)}`);
+    }
+  }
+}

--- a/packages/cloud/src/notify/types.ts
+++ b/packages/cloud/src/notify/types.ts
@@ -1,0 +1,41 @@
+/**
+ * The notification seam — tell a human what a headless run did. Vendor-neutral:
+ * Slack (incoming webhook) and a generic webhook ship in-box; anything else is
+ * just another Notifier. Best-effort by design (a failed notification must never
+ * change a run's outcome), so callers wrap in try/catch or use MultiNotifier.
+ */
+
+export type NotifyEvent =
+  | 'pr_opened'
+  | 'ci_green'
+  | 'needs_human'
+  | 'run_failed'
+  | 'info';
+
+export interface Notification {
+  event: NotifyEvent;
+  /** One-line summary. */
+  title: string;
+  /** Optional detail (failing checks, error, …). */
+  body?: string;
+  /** Optional PR/run URL. */
+  url?: string;
+  /** Optional "owner/name". */
+  repo?: string;
+}
+
+export interface Notifier {
+  readonly id: string;
+  notify(n: Notification): Promise<void>;
+}
+
+/** Minimal fetch shape (injectable for tests; Node 22's global fetch satisfies it). */
+export interface FetchResponse {
+  ok: boolean;
+  status: number;
+  text(): Promise<string>;
+}
+export type FetchLike = (
+  url: string,
+  init: { method: string; headers: Record<string, string>; body: string },
+) => Promise<FetchResponse>;

--- a/packages/cloud/src/notify/webhook.ts
+++ b/packages/cloud/src/notify/webhook.ts
@@ -3,6 +3,8 @@ import { FetchLike, Notification, Notifier } from './types';
 export interface WebhookNotifierOptions {
   url: string;
   fetch?: FetchLike;
+  /** Abort the POST after this many ms so a hung endpoint can't stall a run (default 10_000). */
+  timeoutMs?: number;
 }
 
 /** Generic webhook: POSTs the raw Notification as JSON (Discord/custom sinks). */
@@ -14,7 +16,8 @@ export class WebhookNotifier implements Notifier {
   constructor(opts: WebhookNotifierOptions) {
     if (!opts.url) throw new Error('WebhookNotifier requires a url');
     this.url = opts.url;
-    this.fetch = opts.fetch ?? ((u, init) => fetch(u, init));
+    const timeoutMs = opts.timeoutMs ?? 10_000;
+    this.fetch = opts.fetch ?? ((u, init) => fetch(u, { ...init, signal: AbortSignal.timeout(timeoutMs) }));
   }
 
   async notify(n: Notification): Promise<void> {

--- a/packages/cloud/src/notify/webhook.ts
+++ b/packages/cloud/src/notify/webhook.ts
@@ -1,0 +1,49 @@
+import { FetchLike, Notification, Notifier } from './types';
+
+export interface WebhookNotifierOptions {
+  url: string;
+  fetch?: FetchLike;
+}
+
+/** Generic webhook: POSTs the raw Notification as JSON (Discord/custom sinks). */
+export class WebhookNotifier implements Notifier {
+  readonly id = 'webhook';
+  private readonly url: string;
+  private readonly fetch: FetchLike;
+
+  constructor(opts: WebhookNotifierOptions) {
+    if (!opts.url) throw new Error('WebhookNotifier requires a url');
+    this.url = opts.url;
+    this.fetch = opts.fetch ?? ((u, init) => fetch(u, init));
+  }
+
+  async notify(n: Notification): Promise<void> {
+    const res = await this.fetch(this.url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(n),
+    });
+    if (!res.ok) {
+      throw new Error(`webhook failed (${res.status}): ${(await res.text()).slice(0, 200)}`);
+    }
+  }
+}
+
+/** Fans a notification out to several notifiers, best-effort (one failure never
+ *  blocks the others, and never throws — notifications must not break a run). */
+export class MultiNotifier implements Notifier {
+  readonly id = 'multi';
+  constructor(private readonly children: Notifier[]) {}
+
+  async notify(n: Notification): Promise<void> {
+    await Promise.allSettled(this.children.map((c) => c.notify(n)));
+  }
+}
+
+/** A no-op notifier so callers can always `notify()` unconditionally. */
+export class NoopNotifier implements Notifier {
+  readonly id = 'noop';
+  async notify(): Promise<void> {
+    /* nothing configured */
+  }
+}


### PR DESCRIPTION
## What

**P4 — optional notifications**, as a vendor-neutral seam (dependency-free via `fetch`).

- **`Notifier`** interface + **`SlackNotifier`** (incoming webhook, `{ text }`), **`WebhookNotifier`** (generic JSON sink), **`MultiNotifier`** (best-effort fan-out, never throws), **`NoopNotifier`**, and **`notifierFromEnv`** (`SLACK_WEBHOOK_URL` / `NEMUS_WEBHOOK_URL` → Noop | one | Multi). `fetch` injected → fully unit-tested.
- **Wired into `runCiLoop`** as an *optional* out-of-band report-back: `ci_green` on success, `needs_human` on give-up — best-effort (never changes the verdict), silent on `no_checks`.

## Why not Fly (the other P4 provider) — a real finding

I set out to add a **Fly.io** runner/provisioner and installed `flyctl` to verify flags. But **`fly machine run` and `fly machine status` have no `--json`** (only `fly machine list` does), so a robust runner would need to scrape the machine id from `run`'s human text and correlate via a racy `list` — brittle, and below the bar the Fargate runner set. **Deferred** (documented in the plan): revisit if flyctl adds machine-run JSON, or via the Machines REST API. Verified against real `flyctl v0.4.94`.

## Verification (self-reviewed)

- **119 cloud tests** (+34: Slack format/post/error, webhook JSON, multi best-effort fan-out, `notifierFromEnv` matrix, and CI-loop `ci_green`/`needs_human` notifications + `no_checks` silence).
- typecheck + build clean; core untouched; no version bump.

Design: `docs/plans/2026-08-26-cloud-iac.md`.