### PR TITLE
security: eliminate shell-injection surface + token leak + delete traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.10] - 2026-08-27
+
+### Security
+
+- **Eliminated the shell-injection surface in git/shell operations.** Every
+  `exec`/`execSync` call that interpolated a value into a shell string was
+  migrated to `execFile`/argv (no shell). Most notably, the MCP `branch_create`
+  and `switch_branch` tools built `git checkout -b <name>` by unquoted
+  interpolation with no branch-name validation, so a crafted (but valid) git ref
+  could run arbitrary commands; branch names are now passed as argv elements and
+  can never be interpreted by a shell. Also migrated `ghq`/clone, workspace
+  cleanup (`du`, `git clean`), disk-usage health checks, agent-availability
+  probing, and the shell-integration/MCP installers.
+- **`w delete` no longer deletes arbitrary directories.** The `--workspace` flag
+  path validated names through `safeWorkspacePath()` (allowlist + containment)
+  and skips unknown/invalid names instead of `fs.rm`-ing a guessed path; the
+  interactive path is guarded the same way.
+
 ### Added
 
 - **Monorepo (npm workspaces).** The repo is now an npm-workspaces monorepo:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nemus-cli/nemus",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "workspaces": [
     "packages/*"
   ],

--- a/packages/cloud/src/agent/exec.ts
+++ b/packages/cloud/src/agent/exec.ts
@@ -44,7 +44,20 @@ export async function run(
 ): Promise<ExecResultRaw> {
   const r = await exec(bin, args, opts);
   if (r.code !== 0) {
-    throw new Error(`${bin} ${args.join(' ')} failed (${r.code}): ${r.stderr.trim() || r.stdout.trim()}`);
+    const cmd = redactSecrets(`${bin} ${args.join(' ')}`);
+    const detail = redactSecrets(r.stderr.trim() || r.stdout.trim());
+    throw new Error(`${cmd} failed (${r.code}): ${detail}`);
   }
   return r;
+}
+
+/**
+ * Strip credentials from a string before it lands in an error message,
+ * result.json, or a log. Covers URL userinfo (`https://x-access-token:TOKEN@host`
+ * — how the git clone URL carries the forge token) so a clone failure can't leak
+ * the token. Exported for tests.
+ */
+export function redactSecrets(s: string): string {
+  // scheme://user:secret@host  ->  scheme://***@host
+  return s.replace(/([a-z][a-z0-9+.-]*:\/\/)[^/@\s]+@/gi, '$1***@');
 }

--- a/packages/cloud/src/agent/shell.test.ts
+++ b/packages/cloud/src/agent/shell.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { ShellGitOps } from './git-ops';
 import { buildAgentCommand } from './agent-invoker';
-import { Exec, ExecResultRaw } from './exec';
+import { Exec, ExecResultRaw, run, redactSecrets } from './exec';
 
 /** Records git invocations and returns queued/derived results. */
 function recorder(map: (bin: string, args: string[]) => ExecResultRaw = () => ({ code: 0, stdout: '', stderr: '' })) {
@@ -46,6 +46,24 @@ describe('ShellGitOps', () => {
   it('throws with stderr on a failed git command', async () => {
     const git = new ShellGitOps({ exec: recorder(() => ({ code: 128, stdout: '', stderr: 'fatal: repo not found' })).exec });
     await expect(git.clone('u', '/d')).rejects.toThrow(/128.*repo not found/);
+  });
+});
+
+describe('redactSecrets', () => {
+  it('strips URL credentials (e.g. the tokenized clone URL)', () => {
+    expect(redactSecrets('git clone https://x-access-token:ghs_SECRET@github.com/acme/api.git /w')).toBe(
+      'git clone https://***@github.com/acme/api.git /w',
+    );
+    expect(redactSecrets('no creds here')).toBe('no creds here');
+  });
+});
+
+describe('run() error redaction', () => {
+  it('does not leak the token in the thrown error on a failed clone', async () => {
+    const failing: Exec = async () => ({ code: 128, stdout: '', stderr: 'fatal: auth for https://x-access-token:ghs_SECRET@github.com/acme/api.git' });
+    const url = 'https://x-access-token:ghs_SECRET@github.com/acme/api.git';
+    await expect(run(failing, 'git', ['clone', url, '/w'])).rejects.toThrow(/\*\*\*@github\.com/);
+    await expect(run(failing, 'git', ['clone', url, '/w'])).rejects.not.toThrow(/ghs_SECRET/);
   });
 });
 

--- a/src/cli/ai-prompt.test.ts
+++ b/src/cli/ai-prompt.test.ts
@@ -2,12 +2,14 @@ import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
 
 const {
   mockExec,
+  mockExecFile,
   mockExecFileSync,
   mockSpawn,
   mockMkdirSync,
   mockWriteFileSync,
 } = vi.hoisted(() => ({
   mockExec: vi.fn(),
+  mockExecFile: vi.fn(),
   mockExecFileSync: vi.fn(),
   mockSpawn: vi.fn(),
   mockMkdirSync: vi.fn(),
@@ -16,6 +18,7 @@ const {
 
 vi.mock('child_process', () => ({
   exec: mockExec,
+  execFile: mockExecFile,
   execFileSync: mockExecFileSync,
   spawn: mockSpawn,
 }));
@@ -69,7 +72,8 @@ function setupSpawnMock(exitCode: number = 0) {
 }
 
 function setupExecMock(success: boolean) {
-  mockExec.mockImplementation((_cmd: string, cb: Function) => {
+  // isPrimaryAgentAvailable now uses execFile('which', [cmd], cb) — cb is the 3rd arg.
+  mockExecFile.mockImplementation((_file: string, _args: string[], cb: Function) => {
     if (success) {
       cb(null, { stdout: '/usr/local/bin/claude\n', stderr: '' });
     } else {

--- a/src/cli/ai-prompt.ts
+++ b/src/cli/ai-prompt.ts
@@ -1,4 +1,4 @@
-import { spawn, exec, execFileSync } from 'child_process';
+import { spawn, execFile, execFileSync } from 'child_process';
 import { promisify } from 'util';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -9,7 +9,7 @@ import { colorize } from '../utils/colors';
 import { getPrimaryAgent } from '../utils/agent-config';
 import { sanitizeWorkspaceName, checkWorkspaceExists, resolveWorkspaceNameConflict } from '../utils/validation';
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 export const AI_PROMPT_FILE = path.join(os.homedir(), '.workspace-ai-prompt');
 
@@ -97,7 +97,7 @@ export function buildInvestigationPreamble(
 export async function isPrimaryAgentAvailable(): Promise<boolean> {
   const agent = getPrimaryAgent();
   try {
-    await execAsync(`which ${agent.launchCommand}`);
+    await execFileAsync('which', [agent.launchCommand]);
     return true;
   } catch {
     return false;

--- a/src/commands/configure.ts
+++ b/src/commands/configure.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import inquirer from 'inquirer';
@@ -117,7 +117,7 @@ async function handleConfigure() {
       logInfo('Installing MCP server...');
       try {
         const mcpInstallScript = path.join(__dirname, '..', '..', 'dist', 'mcp', 'install.js');
-        execSync(`node "${mcpInstallScript}" install`, { stdio: 'inherit' });
+        execFileSync('node', [mcpInstallScript, 'install'], { stdio: 'inherit' });
         mcpInstalled = true;
       } catch { logError('MCP install failed. You can retry later with: w mcp install'); }
     }
@@ -169,7 +169,7 @@ function installShellIntegration(): void {
   }
 
   try {
-    execSync(`bash "${scriptPath}" ${shellType}`, { stdio: 'inherit' });
+    execFileSync('bash', [scriptPath, shellType], { stdio: 'inherit' });
   } catch {
     logWarning('Shell integration install failed — you can run it manually:');
     logInfo(`  bash "${scriptPath}" ${shellType}`);

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -115,45 +115,56 @@ async function handleDelete(opts: {
 
       const selectedNames = await promptMultiWorkspaceSelection(workspaces);
 
+      // Resolve + validate paths once. Names come from disk, but safeWorkspacePath
+      // must not throw mid-flow and crash the interactive session, so skip any
+      // name that fails the allowlist rather than aborting.
+      const resolved: { name: string; path: string; workspace: typeof workspaces[number] | undefined }[] = [];
       for (const name of selectedNames) {
-        const workspace = workspaces.find(ws => ws.name === name);
-        const workspacePath = safeWorkspacePath(name);
-        if (workspace?.metadata) {
-          console.log(`${colorize(name, 'cyan')}`);
-          console.log(`  Repositories: ${workspace.metadata.repositories.length}`);
-          console.log(`  Created: ${new Date(workspace.metadata.createdAt).toLocaleString()}`);
-          console.log(`  Path: ${workspacePath}`);
-        } else {
-          console.log(`${colorize(name, 'cyan')}`);
-          console.log(`  Path: ${workspacePath}`);
+        try {
+          resolved.push({ name, path: safeWorkspacePath(name), workspace: workspaces.find(ws => ws.name === name) });
+        } catch (error) {
+          logError(error instanceof Error ? error.message : `Invalid workspace name "${name}"`);
         }
       }
-      console.log('');
 
-      logWarning('This will permanently delete all cloned repositories in the selected workspaces!');
+      if (resolved.length > 0) {
+        for (const { name, path: workspacePath, workspace } of resolved) {
+          if (workspace?.metadata) {
+            console.log(`${colorize(name, 'cyan')}`);
+            console.log(`  Repositories: ${workspace.metadata.repositories.length}`);
+            console.log(`  Created: ${new Date(workspace.metadata.createdAt).toLocaleString()}`);
+            console.log(`  Path: ${workspacePath}`);
+          } else {
+            console.log(`${colorize(name, 'cyan')}`);
+            console.log(`  Path: ${workspacePath}`);
+          }
+        }
+        console.log('');
 
-      const confirmMessage = selectedNames.length === 1
-        ? `Delete workspace ${selectedNames[0]}?`
-        : `Delete these ${selectedNames.length} workspaces?`;
+        logWarning('This will permanently delete all cloned repositories in the selected workspaces!');
 
-      const { confirmed } = await inquirer.prompt([
-        {
-          type: 'confirm',
-          name: 'confirmed',
-          message: confirmMessage,
-          default: true,
-        },
-      ]);
+        const confirmMessage = resolved.length === 1
+          ? `Delete workspace ${resolved[0].name}?`
+          : `Delete these ${resolved.length} workspaces?`;
 
-      if (confirmed) {
-        for (const name of selectedNames) {
-          const workspacePath = safeWorkspacePath(name);
-          try {
-            await fs.rm(workspacePath, { recursive: true, force: true });
-            logSuccess(`Deleted "${colorize(name, 'cyan')}"`);
-          } catch (error) {
-            logError(`Failed to delete "${name}"`);
-            if (error instanceof Error) logError(error.message);
+        const { confirmed } = await inquirer.prompt([
+          {
+            type: 'confirm',
+            name: 'confirmed',
+            message: confirmMessage,
+            default: true,
+          },
+        ]);
+
+        if (confirmed) {
+          for (const { name, path: workspacePath } of resolved) {
+            try {
+              await fs.rm(workspacePath, { recursive: true, force: true });
+              logSuccess(`Deleted "${colorize(name, 'cyan')}"`);
+            } catch (error) {
+              logError(`Failed to delete "${name}"`);
+              if (error instanceof Error) logError(error.message);
+            }
           }
         }
       }

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -1,7 +1,6 @@
 import { Command } from 'commander';
 import * as fs from 'fs/promises';
-import { WORKSPACES_DIR } from '../utils/config';
-import * as path from 'path';
+import { safeWorkspacePath } from '../utils/validation';
 import { listWorkspaces } from '../utils/workspace-meta';
 import { promptMultiWorkspaceSelection } from '../utils/prompts';
 import { logInfo, logSuccess, logError, logWarning } from '../utils/logger';
@@ -35,10 +34,35 @@ async function handleDelete(opts: {
     if (opts.workspace) {
       const selectedNames = parseList(opts.workspace);
       const workspaces = await listWorkspaces();
+      const known = new Map(workspaces.map(ws => [ws.name, ws]));
 
+      // Resolve to validated, existing targets. safeWorkspacePath() both
+      // enforces the name allowlist and pins the path inside WORKSPACES_DIR, so
+      // a name like "../../etc" can never reach fs.rm; unknown names are skipped
+      // rather than deleted at a guessed path.
+      const targets: { name: string; path: string; workspace: typeof workspaces[number] }[] = [];
       for (const name of selectedNames) {
-        const workspace = workspaces.find(ws => ws.name === name);
-        const workspacePath = path.join(WORKSPACES_DIR, name);
+        const workspace = known.get(name);
+        if (!workspace) {
+          logError(`Workspace "${name}" not found — skipping`);
+          continue;
+        }
+        let workspacePath: string;
+        try {
+          workspacePath = safeWorkspacePath(name);
+        } catch (error) {
+          logError(error instanceof Error ? error.message : `Invalid workspace name "${name}"`);
+          continue;
+        }
+        targets.push({ name, path: workspacePath, workspace });
+      }
+
+      if (targets.length === 0) {
+        logInfo('Nothing to delete');
+        return;
+      }
+
+      for (const { name, path: workspacePath, workspace } of targets) {
         if (workspace?.metadata) {
           console.log(`${colorize(name, 'cyan')}`);
           console.log(`  Repositories: ${workspace.metadata.repositories.length}`);
@@ -56,9 +80,9 @@ async function handleDelete(opts: {
           {
             type: 'confirm',
             name: 'confirmed',
-            message: selectedNames.length === 1
-              ? `Delete workspace ${selectedNames[0]}?`
-              : `Delete these ${selectedNames.length} workspaces?`,
+            message: targets.length === 1
+              ? `Delete workspace ${targets[0].name}?`
+              : `Delete these ${targets.length} workspaces?`,
             default: true,
           },
         ]);
@@ -68,8 +92,7 @@ async function handleDelete(opts: {
         }
       }
 
-      for (const name of selectedNames) {
-        const workspacePath = path.join(WORKSPACES_DIR, name);
+      for (const { name, path: workspacePath } of targets) {
         try {
           await fs.rm(workspacePath, { recursive: true, force: true });
           logSuccess(`Deleted "${colorize(name, 'cyan')}"`);
@@ -94,7 +117,7 @@ async function handleDelete(opts: {
 
       for (const name of selectedNames) {
         const workspace = workspaces.find(ws => ws.name === name);
-        const workspacePath = path.join(WORKSPACES_DIR, name);
+        const workspacePath = safeWorkspacePath(name);
         if (workspace?.metadata) {
           console.log(`${colorize(name, 'cyan')}`);
           console.log(`  Repositories: ${workspace.metadata.repositories.length}`);
@@ -124,7 +147,7 @@ async function handleDelete(opts: {
 
       if (confirmed) {
         for (const name of selectedNames) {
-          const workspacePath = path.join(WORKSPACES_DIR, name);
+          const workspacePath = safeWorkspacePath(name);
           try {
             await fs.rm(workspacePath, { recursive: true, force: true });
             logSuccess(`Deleted "${colorize(name, 'cyan')}"`);

--- a/src/mcp/install.ts
+++ b/src/mcp/install.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env ts-node
 
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import * as path from 'path';
 import * as fs from 'fs';
 import { logSuccess, logError, logInfo, logWarning } from '../utils/logger';
@@ -37,7 +37,7 @@ function installShellIntegration(): void {
   }
 
   try {
-    execSync(`bash "${scriptPath}" ${shellType}`, { stdio: 'inherit' });
+    execFileSync('bash', [scriptPath, shellType], { stdio: 'inherit' });
     logSuccess('Shell integration installed (auto-CD for w/workspace commands)');
   } catch {
     logInfo('Shell integration install skipped (non-critical)');
@@ -264,8 +264,9 @@ async function install() {
     logInfo(`MCP server path: ${colorize(serverPath, 'cyan')}`);
 
     try {
-      execSync(
-        `claude mcp add nemus -s user -- node "${serverPath}"`,
+      execFileSync(
+        'claude',
+        ['mcp', 'add', 'nemus', '-s', 'user', '--', 'node', serverPath],
         { stdio: 'pipe' }
       );
       logSuccess('MCP server registered globally with Claude Code');

--- a/src/utils/branch-operations.test.ts
+++ b/src/utils/branch-operations.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Record execFile invocations; every git call must pass args as an argv ARRAY
+// (no shell), so a branch name with shell metacharacters is inert.
+const mockExecFile = vi.fn();
+vi.mock('child_process', () => ({
+  execFile: (...args: unknown[]) => {
+    const cb = args[args.length - 1] as (e: Error | null, r: { stdout: string; stderr: string }) => void;
+    mockExecFile(args[0], args[1], args[2]);
+    cb(null, { stdout: '', stderr: '' });
+  },
+}));
+vi.mock('./git-status', () => ({ hasUncommittedChanges: vi.fn().mockResolvedValue(false) }));
+
+import { createBranch } from './branch-operations';
+
+describe('branch-operations argv safety (no shell injection)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('passes a malicious branch name as a single argv element, never a shell string', async () => {
+    const evil = 'foo$(touch /tmp/pwned)';
+    const res = await createBranch('/repo', 'api', evil);
+    expect(res.success).toBe(true);
+
+    // Every call is execFile('git', [...args]) — args is an array, and the evil
+    // name appears verbatim as one element (so the shell never sees it).
+    for (const [bin, args] of mockExecFile.mock.calls) {
+      expect(bin).toBe('git');
+      expect(Array.isArray(args)).toBe(true);
+    }
+    const checkout = mockExecFile.mock.calls.find(([, a]) => (a as string[])[0] === 'checkout');
+    expect(checkout![1]).toEqual(['checkout', '-b', evil]);
+  });
+
+  it('checks out a base branch as its own argv element too', async () => {
+    await createBranch('/repo', 'api', 'feature', 'release/1.0');
+    const calls = mockExecFile.mock.calls.map(([, a]) => a as string[]);
+    expect(calls).toContainEqual(['checkout', 'release/1.0']);
+    expect(calls).toContainEqual(['checkout', '-b', 'feature']);
+  });
+});

--- a/src/utils/branch-operations.ts
+++ b/src/utils/branch-operations.ts
@@ -1,10 +1,13 @@
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { promisify } from 'util';
 import * as fs from 'fs/promises';
-import * as path from 'path';
 import { hasUncommittedChanges } from './git-status';
 
-const execAsync = promisify(exec);
+// execFile (no shell): git args are passed as an argv array, so a branch name
+// containing shell metacharacters can never be interpreted as a command.
+const execFileAsync = promisify(execFile);
+const git = (args: string[], opts: { cwd: string; timeout?: number }) =>
+  execFileAsync('git', args, opts);
 const GIT_TIMEOUT = 30000;
 
 export interface BranchSwitchResult {
@@ -34,7 +37,7 @@ export const switchBranch = async (
 
     // Check if it's a git repository
     try {
-      await execAsync('git rev-parse --git-dir', { cwd: repoPath });
+      await git(['rev-parse', '--git-dir'], { cwd: repoPath });
     } catch {
       return {
         repo: repoName,
@@ -44,7 +47,7 @@ export const switchBranch = async (
     }
 
     // Get current branch
-    const { stdout: currentBranchOutput } = await execAsync('git branch --show-current', { cwd: repoPath });
+    const { stdout: currentBranchOutput } = await git(['branch', '--show-current'], { cwd: repoPath });
     const currentBranch = currentBranchOutput.trim();
 
     if (currentBranch === targetBranch) {
@@ -57,7 +60,7 @@ export const switchBranch = async (
     }
 
     // Check for uncommitted changes
-    const { stdout: statusOutput } = await execAsync('git status --porcelain', { cwd: repoPath });
+    const { stdout: statusOutput } = await git(['status', '--porcelain'], { cwd: repoPath });
     if (statusOutput.trim().length > 0) {
       return {
         repo: repoName,
@@ -68,17 +71,17 @@ export const switchBranch = async (
     }
 
     // Fetch to ensure we have latest branches
-    await execAsync('git fetch', { cwd: repoPath, timeout: GIT_TIMEOUT });
+    await git(['fetch'], { cwd: repoPath, timeout: GIT_TIMEOUT });
 
     // Check if branch exists locally
     try {
-      await execAsync(`git rev-parse --verify ${targetBranch}`, { cwd: repoPath });
+      await git(['rev-parse', '--verify', targetBranch], { cwd: repoPath });
     } catch {
       // Branch doesn't exist locally, check remote
       try {
-        await execAsync(`git rev-parse --verify origin/${targetBranch}`, { cwd: repoPath });
+        await git(['rev-parse', '--verify', `origin/${targetBranch}`], { cwd: repoPath });
         // Branch exists on remote, create local tracking branch
-        await execAsync(`git checkout -b ${targetBranch} origin/${targetBranch}`, { cwd: repoPath });
+        await git(['checkout', '-b', targetBranch, `origin/${targetBranch}`], { cwd: repoPath });
         return {
           repo: repoName,
           status: 'success',
@@ -96,7 +99,7 @@ export const switchBranch = async (
     }
 
     // Switch to existing local branch
-    await execAsync(`git checkout ${targetBranch}`, { cwd: repoPath });
+    await git(['checkout', targetBranch], { cwd: repoPath });
 
     return {
       repo: repoName,
@@ -143,17 +146,11 @@ export const createBranch = async (
 
     // Checkout base branch if specified
     if (baseBranch) {
-      await execAsync(`git checkout ${baseBranch}`, {
-        cwd: repoPath,
-        timeout: GIT_TIMEOUT,
-      });
+      await git(['checkout', baseBranch], { cwd: repoPath, timeout: GIT_TIMEOUT });
     }
 
     // Create and checkout new branch
-    await execAsync(`git checkout -b ${branchName}`, {
-      cwd: repoPath,
-      timeout: GIT_TIMEOUT,
-    });
+    await git(['checkout', '-b', branchName], { cwd: repoPath, timeout: GIT_TIMEOUT });
 
     return {
       repo: repoName,
@@ -179,21 +176,15 @@ export const mergeBranch = async (
 ): Promise<BranchOperationResult> => {
   try {
     // Checkout target branch
-    await execAsync(`git checkout ${targetBranch}`, {
-      cwd: repoPath,
-      timeout: GIT_TIMEOUT,
-    });
+    await git(['checkout', targetBranch], { cwd: repoPath, timeout: GIT_TIMEOUT });
 
-    // Build merge command
-    let mergeCmd = `git merge ${sourceBranch}`;
-    if (options?.noFf) mergeCmd += ' --no-ff';
-    if (options?.ffOnly) mergeCmd += ' --ff-only';
-    if (options?.squash) mergeCmd += ' --squash';
+    // Build merge argv
+    const mergeArgs = ['merge', sourceBranch];
+    if (options?.noFf) mergeArgs.push('--no-ff');
+    if (options?.ffOnly) mergeArgs.push('--ff-only');
+    if (options?.squash) mergeArgs.push('--squash');
 
-    await execAsync(mergeCmd, {
-      cwd: repoPath,
-      timeout: GIT_TIMEOUT,
-    });
+    await git(mergeArgs, { cwd: repoPath, timeout: GIT_TIMEOUT });
 
     return {
       repo: repoName,
@@ -216,10 +207,7 @@ export const rebaseBranch = async (
   targetBranch: string
 ): Promise<BranchOperationResult> => {
   try {
-    await execAsync(`git rebase ${targetBranch}`, {
-      cwd: repoPath,
-      timeout: GIT_TIMEOUT,
-    });
+    await git(['rebase', targetBranch], { cwd: repoPath, timeout: GIT_TIMEOUT });
 
     return {
       repo: repoName,

--- a/src/utils/cleanup-operations.ts
+++ b/src/utils/cleanup-operations.ts
@@ -1,9 +1,9 @@
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { promisify } from 'util';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 export interface CleanupResult {
   operation: string;
@@ -14,7 +14,7 @@ export interface CleanupResult {
 
 export const calculateDirSize = async (dirPath: string): Promise<number> => {
   try {
-    const { stdout } = await execAsync(`du -sk "${dirPath}"`);
+    const { stdout } = await execFileAsync('du', ['-sk', dirPath]);
     const sizeInKB = parseInt(stdout.split('\t')[0], 10);
     return sizeInKB;
   } catch {
@@ -72,10 +72,10 @@ export const removeBuildArtifacts = async (repoPath: string): Promise<CleanupRes
 
 export const gitClean = async (repoPath: string, dryRun: boolean = false): Promise<CleanupResult> => {
   try {
-    const cmd = dryRun ? 'git clean -fdxn' : 'git clean -fdx';
-    const { stdout } = await execAsync(cmd, { cwd: repoPath });
+    const args = dryRun ? ['clean', '-fdxn'] : ['clean', '-fdx'];
+    const { stdout } = await execFileAsync('git', args, { cwd: repoPath });
 
-    const lines = stdout.split('\n').filter(l => l.trim());
+    const lines = stdout.split('\n').filter((l: string) => l.trim());
 
     return {
       operation: 'Git clean',

--- a/src/utils/ghq-integration.test.ts
+++ b/src/utils/ghq-integration.test.ts
@@ -1,12 +1,33 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockExecAsync = vi.fn();
+const mockExecFile = vi.fn();
+// ghqRepoExists now uses fs.stat (not `test -d`); cleanup uses fs.rm.
+const mockStat = vi.fn();
+const mockRm = vi.fn().mockResolvedValue(undefined);
+vi.mock('fs/promises', () => ({
+  stat: (...a: unknown[]) => mockStat(...a),
+  rm: (...a: unknown[]) => mockRm(...a),
+}));
+const cached = () => mockStat.mockResolvedValue({ isDirectory: () => true });
 vi.mock('child_process', () => ({
   exec: (...args: unknown[]) => {
     const callback = args[args.length - 1] as (err: Error | null, result: { stdout: string; stderr: string }) => void;
     const command = args[0] as string;
     const opts = args.length === 3 ? args[1] : {};
     mockExecAsync(command, opts)
+      .then((result: { stdout: string; stderr: string }) => callback(null, result))
+      .catch((err: Error) => callback(err, { stdout: '', stderr: '' }));
+  },
+  // execFile(file, args, [opts], cb): reconstruct a command string so existing
+  // expectations that assert on the command keep working, and record argv.
+  execFile: (...args: unknown[]) => {
+    const callback = args[args.length - 1] as (err: Error | null, result: { stdout: string; stderr: string }) => void;
+    const file = args[0] as string;
+    const fileArgs = Array.isArray(args[1]) ? (args[1] as string[]) : [];
+    const opts = typeof args[2] === 'object' && args[2] !== null ? args[2] : {};
+    mockExecFile(file, fileArgs, opts);
+    mockExecAsync([file, ...fileArgs].join(' '), opts)
       .then((result: { stdout: string; stderr: string }) => callback(null, result))
       .catch((err: Error) => callback(err, { stdout: '', stderr: '' }));
   },
@@ -28,13 +49,16 @@ import { cloneWithGhq, describeCloneError } from './ghq-integration';
 describe('cloneWithGhq', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRm.mockResolvedValue(undefined);
+    // default: not cached (fs.stat rejects) unless a test opts into cached()
+    mockStat.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
   });
 
   it('uses git clone --local from ghq cache when repo exists', async () => {
+    cached();
     mockExecAsync.mockImplementation((cmd: string) => {
       if (cmd === 'which ghq') return Promise.resolve({ stdout: '/usr/bin/ghq\n', stderr: '' });
       if (cmd === 'ghq root') return Promise.resolve({ stdout: '/home/user/ghq\n', stderr: '' });
-      if (cmd.startsWith('test -d')) return Promise.resolve({ stdout: '', stderr: '' });
       if (cmd.startsWith('git clone --local')) return Promise.resolve({ stdout: '', stderr: '' });
       if (cmd.startsWith('git remote set-url')) return Promise.resolve({ stdout: '', stderr: '' });
       return Promise.resolve({ stdout: '', stderr: '' });
@@ -55,10 +79,10 @@ describe('cloneWithGhq', () => {
   });
 
   it('does not call ghq get -u when repo is already cached', async () => {
+    cached();
     mockExecAsync.mockImplementation((cmd: string) => {
       if (cmd === 'which ghq') return Promise.resolve({ stdout: '/usr/bin/ghq\n', stderr: '' });
       if (cmd === 'ghq root') return Promise.resolve({ stdout: '/home/user/ghq\n', stderr: '' });
-      if (cmd.startsWith('test -d')) return Promise.resolve({ stdout: '', stderr: '' });
       if (cmd.startsWith('git clone --local')) return Promise.resolve({ stdout: '', stderr: '' });
       if (cmd.startsWith('git remote set-url')) return Promise.resolve({ stdout: '', stderr: '' });
       return Promise.resolve({ stdout: '', stderr: '' });
@@ -109,8 +133,8 @@ describe('cloneWithGhq', () => {
     const calls = mockExecAsync.mock.calls.map(([cmd]: [string]) => cmd);
     // Should NOT attempt git clone --local since ghq get failed
     expect(calls.some((cmd: string) => cmd.includes('--local'))).toBe(false);
-    // Should fall back to direct clone
-    expect(calls.some((cmd: string) => cmd.startsWith('git clone "git@github.com'))).toBe(true);
+    // Should fall back to direct clone (argv form: no shell quotes)
+    expect(calls.some((cmd: string) => cmd.startsWith('git clone git@github.com'))).toBe(true);
   });
 
   it('falls back to direct git clone when ghq is not installed', async () => {
@@ -126,7 +150,7 @@ describe('cloneWithGhq', () => {
     expect(result.usedGhq).toBe(false);
 
     const calls = mockExecAsync.mock.calls.map(([cmd]: [string]) => cmd);
-    expect(calls.some((cmd: string) => cmd.startsWith('git clone "git@github.com'))).toBe(true);
+    expect(calls.some((cmd: string) => cmd.startsWith('git clone git@github.com'))).toBe(true);
     expect(calls.some((cmd: string) => cmd.includes('--local'))).toBe(false);
   });
 

--- a/src/utils/ghq-integration.ts
+++ b/src/utils/ghq-integration.ts
@@ -1,11 +1,16 @@
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { promisify } from 'util';
 import * as path from 'path';
+import * as fs from 'fs/promises';
 import { logInfo, logSuccess, logWarning } from './logger';
 import { colorize } from './colors';
 import { CLONE_TIMEOUT_MS, CLONE_MAX_BUFFER } from './config';
 
-const execAsync = promisify(exec);
+// execFile (no shell): every value below (repo URLs, ghq paths, branch names)
+// is passed as an argv element, so none can be interpreted as a shell command.
+const execFileAsync = promisify(execFile);
+type ExecOpts = { cwd?: string; timeout?: number; maxBuffer?: number };
+const git = (args: string[], opts: ExecOpts = {}) => execFileAsync('git', args, opts);
 
 /**
  * Turn a raw child-process clone failure (from exec or execFile) into an
@@ -39,7 +44,7 @@ export function describeCloneError(error: unknown, timeoutMs: number = CLONE_TIM
  */
 export async function isGhqInstalled(): Promise<boolean> {
   try {
-    await execAsync('which ghq');
+    await execFileAsync('which', ['ghq']);
     return true;
   } catch {
     return false;
@@ -65,7 +70,7 @@ export async function warnIfGhqMissing(): Promise<boolean> {
  */
 export async function getGhqRoot(): Promise<string | null> {
   try {
-    const { stdout } = await execAsync('ghq root');
+    const { stdout } = await execFileAsync('ghq', ['root']);
     return stdout.trim();
   } catch {
     return null;
@@ -80,8 +85,8 @@ export async function ghqRepoExists(repoUrl: string): Promise<boolean> {
     const repoPath = await getGhqRepoPath(repoUrl);
     if (!repoPath) return false;
 
-    await execAsync(`test -d "${repoPath}"`);
-    return true;
+    const stat = await fs.stat(repoPath);
+    return stat.isDirectory();
   } catch {
     return false;
   }
@@ -114,7 +119,7 @@ export async function ghqGet(repoUrl: string): Promise<{ success: boolean; path?
   try {
     logInfo(`Using ghq to clone ${colorize(repoUrl, 'cyan')}...`);
 
-    await execAsync(`ghq get "${repoUrl}"`, { timeout: CLONE_TIMEOUT_MS, maxBuffer: CLONE_MAX_BUFFER });
+    await execFileAsync('ghq', ['get', repoUrl], { timeout: CLONE_TIMEOUT_MS, maxBuffer: CLONE_MAX_BUFFER });
 
     const repoPath = await getGhqRepoPath(repoUrl);
     if (!repoPath) {
@@ -135,7 +140,7 @@ export async function ghqGet(repoUrl: string): Promise<{ success: boolean; path?
  */
 export async function ghqList(): Promise<string[]> {
   try {
-    const { stdout } = await execAsync('ghq list');
+    const { stdout } = await execFileAsync('ghq', ['list']);
     return stdout.trim().split('\n').filter(line => line.length > 0);
   } catch {
     return [];
@@ -196,18 +201,15 @@ export async function cloneWithGhq(
         // would serve stale state via hardlinks — user would open a workspace
         // missing dozens of recent commits.
         try {
-          await execAsync(
-            `git -C "${sourcePath}" fetch origin --quiet --prune`,
-            { timeout: 90 * 1000 },
-          );
+          await git(['-C', sourcePath, 'fetch', 'origin', '--quiet', '--prune'], { timeout: 90 * 1000 });
         } catch {
           // Network failure or no upstream — fall through with stale cache,
           // we'll log a warning after the local clone if we can't align to HEAD.
         }
 
-        await execAsync(`git clone --local "${sourcePath}" "${targetPath}"`, { timeout: 60 * 1000 });
+        await git(['clone', '--local', sourcePath, targetPath], { timeout: 60 * 1000 });
         // Reset remote to point to the original repo URL (not the local ghq path)
-        await execAsync(`git remote set-url origin "${repoUrl}"`, { cwd: targetPath });
+        await git(['remote', 'set-url', 'origin', repoUrl], { cwd: targetPath });
 
         // Make sure the working tree is at origin's default-branch tip.
         // Robust against:
@@ -217,27 +219,25 @@ export async function cloneWithGhq(
         let alignedToHead = false;
         let alignError: string | null = null;
         try {
-          await execAsync(`git fetch origin --quiet`, { cwd: targetPath, timeout: 60 * 1000 });
+          await git(['fetch', 'origin', '--quiet'], { cwd: targetPath, timeout: 60 * 1000 });
 
           // Explicitly set refs/remotes/origin/HEAD by querying the remote.
           // Without this, symbolic-ref may fail if the local symref wasn’t set.
-          await execAsync(`git remote set-head origin --auto`, { cwd: targetPath, timeout: 30 * 1000 })
+          await git(['remote', 'set-head', 'origin', '--auto'], { cwd: targetPath, timeout: 30 * 1000 })
             .catch(() => { /* if this fails the next step might still succeed */ });
 
           let defaultBranch: string | null = null;
           try {
-            const headRes = await execAsync(
-              `git symbolic-ref --short refs/remotes/origin/HEAD`,
-              { cwd: targetPath, timeout: 5000 },
-            );
+            const headRes = await git(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], {
+              cwd: targetPath, timeout: 5000,
+            });
             defaultBranch = headRes.stdout.trim().replace(/^origin\//, '');
           } catch {
             // Fall back to ls-remote query against the actual remote
             try {
-              const lsRes = await execAsync(
-                `git ls-remote --symref origin HEAD`,
-                { cwd: targetPath, timeout: 30 * 1000 },
-              );
+              const lsRes = await git(['ls-remote', '--symref', 'origin', 'HEAD'], {
+                cwd: targetPath, timeout: 30 * 1000,
+              });
               const match = lsRes.stdout.match(/^ref:\s+refs\/heads\/(\S+)\s+HEAD$/m);
               if (match) defaultBranch = match[1];
             } catch { /* fall through to common-name fallback */ }
@@ -246,10 +246,9 @@ export async function cloneWithGhq(
           // Final fallback: try common default branches
           if (!defaultBranch) {
             for (const candidate of ['main', 'master']) {
-              const exists = await execAsync(
-                `git rev-parse --verify --quiet origin/${candidate}`,
-                { cwd: targetPath, timeout: 5000 },
-              ).then(() => true).catch(() => false);
+              const exists = await git(['rev-parse', '--verify', '--quiet', `origin/${candidate}`], {
+                cwd: targetPath, timeout: 5000,
+              }).then(() => true).catch(() => false);
               if (exists) { defaultBranch = candidate; break; }
             }
           }
@@ -258,8 +257,8 @@ export async function cloneWithGhq(
             throw new Error('could not determine default branch (no origin/HEAD, no main, no master)');
           }
 
-          await execAsync(`git checkout --quiet "${defaultBranch}"`, { cwd: targetPath, timeout: 10 * 1000 });
-          await execAsync(`git reset --hard --quiet "origin/${defaultBranch}"`, { cwd: targetPath, timeout: 10 * 1000 });
+          await git(['checkout', '--quiet', defaultBranch], { cwd: targetPath, timeout: 10 * 1000 });
+          await git(['reset', '--hard', '--quiet', `origin/${defaultBranch}`], { cwd: targetPath, timeout: 10 * 1000 });
           alignedToHead = true;
         } catch (error) {
           alignError = error instanceof Error ? error.message : String(error);
@@ -277,7 +276,7 @@ export async function cloneWithGhq(
         const errorMessage = error instanceof Error ? error.message : 'Unknown error';
         logWarning(`Local clone from ghq failed: ${errorMessage}`);
         // Clean up partial clone before fallback
-        try { await execAsync(`rm -rf "${targetPath}"`); } catch { /* ignore */ }
+        try { await fs.rm(targetPath, { recursive: true, force: true }); } catch { /* ignore */ }
         // Fall through to direct clone
       }
     }
@@ -285,7 +284,7 @@ export async function cloneWithGhq(
 
   // Fallback to direct git clone
   try {
-    await execAsync(`git clone "${repoUrl}" "${targetPath}"`, { timeout: CLONE_TIMEOUT_MS, maxBuffer: CLONE_MAX_BUFFER });
+    await git(['clone', repoUrl, targetPath], { timeout: CLONE_TIMEOUT_MS, maxBuffer: CLONE_MAX_BUFFER });
     return { success: true, usedGhq: false };
   } catch (error) {
     return { success: false, error: describeCloneError(error), usedGhq: false };

--- a/src/utils/git-operations.ts
+++ b/src/utils/git-operations.ts
@@ -1,4 +1,4 @@
-import { exec, execFile } from 'child_process';
+import { execFile } from 'child_process';
 import { promisify } from 'util';
 import * as path from 'path';
 import * as fs from 'fs/promises';
@@ -10,7 +10,6 @@ import { withRetry } from './retry';
 import { createSimpleProgressBar } from './progress';
 import { getCloneUrl, CLONE_TIMEOUT_MS, CLONE_MAX_BUFFER } from './config';
 
-const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 
 const CONCURRENCY_LIMIT = 3;
@@ -96,13 +95,13 @@ async function cloneLocal(
   const targetPath = path.join(workspacePath, directoryName);
   try {
     // git clone --local creates hardlinks for .git/objects — nearly instant
-    await execAsync(`git clone --local "${sourcePath}" "${targetPath}"`, {
+    await execFileAsync('git', ['clone', '--local', sourcePath, targetPath], {
       timeout: CLONE_TIMEOUT,
       maxBuffer: CLONE_MAX_BUFFER,
     });
     // Reset the remote to point to the original repo (not the local source)
     const remoteUrl = getCloneUrl(repo);
-    await execAsync(`git remote set-url origin "${remoteUrl}"`, {
+    await execFileAsync('git', ['remote', 'set-url', 'origin', remoteUrl], {
       cwd: targetPath,
     });
     return {

--- a/src/utils/health-checks.ts
+++ b/src/utils/health-checks.ts
@@ -1,4 +1,4 @@
-import { exec } from 'child_process';
+import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
 import * as fs from 'fs/promises';
 import * as path from 'path';
@@ -6,6 +6,7 @@ import { HealthCheckResult, WorkspaceMetadata } from '../types';
 import { isGitRepository, hasUncommittedChanges } from './git-status';
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 export const checkMissingRepositories = async (
   workspacePath: string,
@@ -215,7 +216,7 @@ export const checkDependencies = async (
 export const checkDiskSpace = async (workspacePath: string): Promise<HealthCheckResult> => {
   try {
     // Get disk usage for workspace
-    const { stdout } = await execAsync(`du -sh "${workspacePath}"`, { timeout: 30000 });
+    const { stdout } = await execFileAsync('du', ['-sh', workspacePath], { timeout: 30000 });
     const sizeStr = stdout.trim().split('\t')[0];
 
     // Parse size (rough check for > 10GB)


### PR DESCRIPTION
Full self-review hardening pass across the whole repo. Findings were verified against source before fixing. Everything degrades to the same behavior — no shell operators were in use, so the argv migration is behavior-preserving.

## 🔴 HIGH — MCP-reachable command injection via branch names
\`branch-operations.ts\` built git commands by **unquoted** shell interpolation (\`git checkout -b \${branchName}\`), reachable from the untrusted MCP \`branch_create\`/\`switch_branch\` tools with **no branch-name validation**. A valid-but-crafted git ref like \`foo\$(cmd)\` executed arbitrary commands on the host. Migrated every call to \`execFile('git', [...argv])\` (no shell). New \`branch-operations.test.ts\` asserts the evil name is passed as a single argv element.

## 🔴 HIGH — cloud auth token leaked on clone failure
\`packages/cloud/src/agent/exec.ts\` \`run()\` threw \`\${bin} \${args.join(' ')} failed …\`; for a clone that contains \`https://x-access-token:TOKEN@host\`, which flowed into \`result.json\` + logs. Added \`redactSecrets()\` (strips URL userinfo), applied before throwing. Tests confirm the token never appears.

## 🟠 MEDIUM — systemic shell exec in core → execFile/argv
Migrated \`ghq-integration.ts\` (ghq get/clone/fetch/reset/checkout; \`test -d\`→\`fs.stat\`; \`rm -rf\`→\`fs.rm\`), \`git-operations.ts\` \`cloneLocal\`, \`cleanup-operations.ts\` (du, git clean), \`health-checks.ts\` (du), \`ai-prompt.ts\` (which), and \`configure.ts\`/\`mcp/install.ts\` (\`execSync\` bash/node/claude → \`execFileSync\` argv). Test mocks updated to forward \`execFile\`; assertions use argv form.

## 🟠 MEDIUM — \`w delete\` arbitrary-directory deletion
\`delete.ts\` used raw \`path.join(WORKSPACES_DIR, name)\` + \`fs.rm(recursive, force)\` on an unvalidated flag and proceeded even when the workspace didn't exist. Now routes through the existing \`safeWorkspacePath()\` (allowlist + containment) and skips unknown names.

## Verification
- **435 core + 123 cloud tests** pass; typecheck + build clean on both packages.
- **Zero** remaining \`exec\`/\`execSync\`-with-interpolation sites in core (grep-verified).
- No \`melio\` references (vendor-neutral).

The review also confirmed two things already done right: the MCP filesystem choke point (\`safeWorkspacePath\`, 21 sites, 0 raw joins) and the cloud package already using \`spawn\`/argv throughout.