### PR TITLE
feat(cloud): GitLab GitForge + forge registry (bring your own backend)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (P4) a vendor-neutral **notification seam** — `Notifier` with Slack (incoming
   webhook) + generic webhook sinks (`notifierFromEnv`), wired into the CI-loop as
   optional out-of-band report-back.
+  **Code-host breadth:** the `GitForge` seam gained a dependency-free **GitLab**
+  implementation (`GitLabForge` — merge requests, commit statuses, MR notes;
+  self-managed via `GITLAB_API_URL`) alongside GitHub, plus a **forge registry**
+  (`createForge`/`registerForge`/`registeredForges` + `NEMUS_FORGE_HOST`) so a
+  run targets GitHub or GitLab — or a custom "bring your own backend" host
+  (Gitea, Bitbucket, …) — with no code change. Docs in `packages/cloud/README.md`.
   Design: `docs/plans/2026-08-26-cloud-iac.md`.
 
 ## [0.2.9] - 2026-08-26

--- a/packages/cloud/README.md
+++ b/packages/cloud/README.md
@@ -91,6 +91,62 @@ own working dir** (or point a remote backend at it) so state is durable, and
 **don't pass secrets as `-var`** (they land in argv and the streamed apply log —
 use the provider's own credential env / a `SecretSource`).
 
+## The code-host seam: `GitForge` (GitHub, GitLab, or your own)
+
+Report-back and the CI-loop talk only to a `GitForge` — `openPR`, `getChecks`,
+`comment` — never to a host SDK. Two backends ship in-box (both dependency-free,
+`fetch`-only): **`github`** (REST; PRs, check-runs, issue comments; works against
+GitHub Enterprise via `GITHUB_API_URL`) and **`gitlab`** (REST v4; merge
+requests, commit statuses, MR notes; works against self-managed GitLab via
+`GITLAB_API_URL`). Both are authenticated by the same `ForgeTokenSource`, so
+PAT / GitHub-App auth is orthogonal to which host you target.
+
+Build one by kind with the registry instead of `new GitHubForge(...)`:
+
+```ts
+import { createForge, forgeKindFromEnv, forgeApiBaseFromEnv, forgeAuthFromEnv } from '@nemus-cli/cloud';
+
+const tokenSource = forgeAuthFromEnv(process.env);
+const kind = forgeKindFromEnv(process.env);            // NEMUS_FORGE_HOST, default 'github'
+const forge = createForge(kind, {
+  tokenSource,
+  apiBaseUrl: forgeApiBaseFromEnv(kind, process.env),  // GITHUB_API_URL | GITLAB_API_URL
+});
+await forge.openPR({ owner: 'acme', repo: 'api', head: 'nemus/x', base: 'main', title: '…', draft: true });
+```
+
+The container entrypoint (`nemus-cloud-agent`) already does exactly this, so a
+run targets GitLab by setting **`NEMUS_FORGE_HOST=gitlab`** (+ a GitLab token) —
+no code change. Neutral-vocabulary mapping for GitLab: a PR is a **merge
+request** and `PullRequest.number` is its project-scoped **iid**; "checks" are
+**commit statuses** for the head SHA; a repo `{ owner, repo }` addresses the
+URL-encoded `namespace/path` project (subgroups in `owner` are fine); draft is
+the `Draft:` title prefix; a `manual` job maps to `neutral` so an un-triggered
+manual gate never reads as a red check.
+
+### Bring your own backend
+
+Gitea, Bitbucket, a corporate host — implement the three-method `GitForge`
+interface and register it under a kind name. No fork required:
+
+```ts
+import { registerForge, createForge, type GitForge } from '@nemus-cli/cloud';
+
+class GiteaForge implements GitForge {
+  readonly id = 'gitea';
+  async openPR(input) { /* … your host's API … */ }
+  async getChecks(ref) { /* map host statuses -> CheckRun[] */ }
+  async comment(input) { /* … */ }
+}
+
+registerForge('gitea', (opts) => new GiteaForge(opts)); // opts: { tokenSource, apiBaseUrl?, fetchImpl? }
+// now createForge('gitea', …) and NEMUS_FORGE_HOST=gitea resolve it
+```
+
+Registering an existing kind name overrides it (last write wins), so you can
+swap even the built-in `github`/`gitlab` behavior. `registeredForges()` lists
+what's available.
+
 ## The CLI: `nemus-cloud`
 
 A thin, dependency-free CLI ties the seams together end-to-end:

--- a/packages/cloud/src/agent/cli.ts
+++ b/packages/cloud/src/agent/cli.ts
@@ -2,7 +2,7 @@
 import { writeFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { forgeAuthFromEnv } from '../index';
-import { GitHubForge } from '../gitforge/github';
+import { createForge, forgeKindFromEnv, forgeApiBaseFromEnv } from '../gitforge/registry';
 import { parseAgentEnv } from './env';
 import { runAgentTask, RunAgentDeps } from './run';
 import { ShellGitOps } from './git-ops';
@@ -21,10 +21,14 @@ export async function main(env: NodeJS.ProcessEnv = process.env): Promise<number
     const config = parseAgentEnv(env);
     workdir = config.workdir;
     const tokenSource = forgeAuthFromEnv(env);
+    const forgeKind = forgeKindFromEnv(env);
     const deps: RunAgentDeps = {
       git: new ShellGitOps(),
       agent: new ShellAgentInvoker({ env }),
-      forge: new GitHubForge({ tokenSource, apiBaseUrl: env.GITHUB_API_URL }),
+      forge: createForge(forgeKind, {
+        tokenSource,
+        apiBaseUrl: forgeApiBaseFromEnv(forgeKind, env),
+      }),
       tokenSource,
     };
     result = await runAgentTask(config, deps);

--- a/packages/cloud/src/gitforge/gitlab.test.ts
+++ b/packages/cloud/src/gitforge/gitlab.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import { GitLabForge } from './gitlab';
+import { ForgeTokenSource } from '../forge/types';
+
+const tokenSource: ForgeTokenSource = {
+  id: 'test',
+  getToken: async () => ({ token: 'glpat-test', expiresAt: new Date('2030-01-01') }),
+};
+
+function stubFetch(handler: (url: string, init: any) => { status: number; body?: unknown }) {
+  const calls: Array<{ url: string; init: any }> = [];
+  const fetchImpl = (async (url: string, init: any) => {
+    calls.push({ url: String(url), init });
+    const { status, body } = handler(String(url), init);
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+      text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+    };
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+describe('GitLabForge.openPR', () => {
+  it('POSTs a merge request with Bearer auth + GitLab field names', async () => {
+    const { fetchImpl, calls } = stubFetch(() => ({
+      status: 201,
+      body: { iid: 7, web_url: 'https://gitlab.com/acme/api/-/merge_requests/7', state: 'opened', draft: false },
+    }));
+    const forge = new GitLabForge({ tokenSource, fetchImpl });
+    const pr = await forge.openPR({
+      owner: 'acme',
+      repo: 'api',
+      head: 'nemus/feature',
+      base: 'main',
+      title: 'Add idempotency keys',
+    });
+    expect(pr).toEqual({
+      number: 7,
+      url: 'https://gitlab.com/acme/api/-/merge_requests/7',
+      state: 'open',
+      draft: false,
+    });
+    // project id is URL-encoded namespace/path
+    expect(calls[0].url).toBe('https://gitlab.com/api/v4/projects/acme%2Fapi/merge_requests');
+    expect(calls[0].init.method).toBe('POST');
+    expect(calls[0].init.headers.Authorization).toBe('Bearer glpat-test');
+    const sent = JSON.parse(calls[0].init.body);
+    expect(sent).toMatchObject({ source_branch: 'nemus/feature', target_branch: 'main', title: 'Add idempotency keys' });
+  });
+
+  it('expresses draft via a "Draft:" title prefix (GitLab convention)', async () => {
+    const { fetchImpl, calls } = stubFetch(() => ({
+      status: 201,
+      body: { iid: 1, web_url: 'u', state: 'opened', draft: true },
+    }));
+    const forge = new GitLabForge({ tokenSource, fetchImpl });
+    const pr = await forge.openPR({ owner: 'a', repo: 'b', head: 'h', base: 'main', title: 'Feature', draft: true });
+    expect(JSON.parse(calls[0].init.body).title).toBe('Draft: Feature');
+    expect(pr.draft).toBe(true);
+  });
+
+  it('does not double-prefix an already-draft title', async () => {
+    const { fetchImpl, calls } = stubFetch(() => ({ status: 201, body: { iid: 1, web_url: 'u', state: 'opened' } }));
+    const forge = new GitLabForge({ tokenSource, fetchImpl });
+    await forge.openPR({ owner: 'a', repo: 'b', head: 'h', base: 'main', title: 'Draft: Feature', draft: true });
+    expect(JSON.parse(calls[0].init.body).title).toBe('Draft: Feature');
+  });
+
+  it('reports merged + closed states, and reads legacy work_in_progress', async () => {
+    const merged = stubFetch(() => ({ status: 201, body: { iid: 2, web_url: 'u', state: 'merged' } }));
+    expect((await new GitLabForge({ tokenSource, fetchImpl: merged.fetchImpl }).openPR({ owner: 'a', repo: 'b', head: 'h', base: 'main', title: 't' })).state).toBe('merged');
+
+    const closed = stubFetch(() => ({ status: 201, body: { iid: 3, web_url: 'u', state: 'closed', work_in_progress: true } }));
+    const pr = await new GitLabForge({ tokenSource, fetchImpl: closed.fetchImpl }).openPR({ owner: 'a', repo: 'b', head: 'h', base: 'main', title: 't' });
+    expect(pr.state).toBe('closed');
+    expect(pr.draft).toBe(true);
+  });
+
+  it('surfaces API errors with status + body', async () => {
+    const { fetchImpl } = stubFetch(() => ({ status: 409, body: { message: 'branch conflict' } }));
+    const forge = new GitLabForge({ tokenSource, fetchImpl });
+    await expect(
+      forge.openPR({ owner: 'a', repo: 'b', head: 'h', base: 'main', title: 't' }),
+    ).rejects.toThrow(/409.*branch conflict/);
+  });
+});
+
+describe('GitLabForge.getChecks', () => {
+  it('maps commit statuses to the neutral CheckRun shape', async () => {
+    const { fetchImpl, calls } = stubFetch(() => ({
+      status: 200,
+      body: [
+        { name: 'build', status: 'success' },
+        { name: 'test', status: 'running' },
+        { name: 'lint', status: 'failed' },
+        { name: 'deploy', status: 'manual' },
+        { name: 'pending-job', status: 'pending' },
+        { name: 'weird', status: 'something-new' },
+      ],
+    }));
+    const forge = new GitLabForge({ tokenSource, fetchImpl });
+    const checks = await forge.getChecks({ owner: 'acme', repo: 'api', ref: 'abc123' });
+    expect(checks).toEqual([
+      { name: 'build', status: 'completed', conclusion: 'success' },
+      { name: 'test', status: 'in_progress', conclusion: null },
+      { name: 'lint', status: 'completed', conclusion: 'failure' },
+      { name: 'deploy', status: 'completed', conclusion: 'neutral' },
+      { name: 'pending-job', status: 'queued', conclusion: null },
+      { name: 'weird', status: 'unknown', conclusion: null },
+    ]);
+    expect(calls[0].url).toContain('/projects/acme%2Fapi/repository/commits/abc123/statuses?per_page=100');
+  });
+
+  it('tolerates an empty status list', async () => {
+    const { fetchImpl } = stubFetch(() => ({ status: 200, body: [] }));
+    const forge = new GitLabForge({ tokenSource, fetchImpl });
+    expect(await forge.getChecks({ owner: 'a', repo: 'b', ref: 'main' })).toEqual([]);
+  });
+});
+
+describe('GitLabForge.comment', () => {
+  it('POSTs a note to the MR by iid', async () => {
+    const { fetchImpl, calls } = stubFetch(() => ({ status: 201, body: { id: 1 } }));
+    const forge = new GitLabForge({ tokenSource, fetchImpl });
+    await forge.comment({ owner: 'acme', repo: 'api', number: 7, body: 'nemus review' });
+    expect(calls[0].url).toBe('https://gitlab.com/api/v4/projects/acme%2Fapi/merge_requests/7/notes');
+    expect(JSON.parse(calls[0].init.body)).toEqual({ body: 'nemus review' });
+  });
+});
+
+describe('GitLabForge apiBaseUrl (self-managed) + subgroups', () => {
+  it('honors a custom API base and encodes subgroup owners', async () => {
+    const { fetchImpl, calls } = stubFetch(() => ({ status: 200, body: [] }));
+    const forge = new GitLabForge({ tokenSource, fetchImpl, apiBaseUrl: 'https://gitlab.acme.com/api/v4/' });
+    await forge.getChecks({ owner: 'group/subgroup', repo: 'api', ref: 'main' });
+    expect(calls[0].url).toBe(
+      'https://gitlab.acme.com/api/v4/projects/group%2Fsubgroup%2Fapi/repository/commits/main/statuses?per_page=100',
+    );
+  });
+});

--- a/packages/cloud/src/gitforge/gitlab.ts
+++ b/packages/cloud/src/gitforge/gitlab.ts
@@ -1,0 +1,137 @@
+import { ForgeTokenSource } from '../forge/types';
+import {
+  CheckRun,
+  CommentInput,
+  GitForge,
+  OpenPRInput,
+  PullRequest,
+  RepoRef,
+} from './types';
+
+export interface GitLabForgeOptions {
+  tokenSource: ForgeTokenSource;
+  /** API base, default `https://gitlab.com/api/v4` (set for self-managed GitLab). */
+  apiBaseUrl?: string;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * GitForge over the GitLab REST API v4, authenticated by a `ForgeTokenSource`
+ * (a personal/project/group access token, or an OAuth token — sent as a Bearer,
+ * which modern GitLab accepts for all of them). Dependency-free: uses `fetch`.
+ *
+ * Mapping to the neutral GitForge vocabulary:
+ * - A GitHub "pull request" is a GitLab **merge request**; `PullRequest.number`
+ *   is the MR **iid** (project-scoped), which is what note/comment calls use.
+ * - "checks" are GitLab **commit statuses** (the union of pipeline jobs and
+ *   external statuses) for the head SHA.
+ * - a repo `{ owner, repo }` addresses a GitLab project by its URL-encoded
+ *   `namespace/path` (subgroups in `owner` are fine — the slash is encoded).
+ * - draft is expressed by the `Draft:` title prefix, GitLab's own convention.
+ */
+export class GitLabForge implements GitForge {
+  readonly id = 'gitlab';
+  private readonly api: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(private readonly opts: GitLabForgeOptions) {
+    this.api = (opts.apiBaseUrl ?? 'https://gitlab.com/api/v4').replace(/\/+$/, '');
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  async openPR(input: OpenPRInput): Promise<PullRequest> {
+    // GitLab marks a draft MR by a `Draft:` title prefix; don't double-prefix.
+    const title =
+      input.draft && !/^\s*draft:\s*/i.test(input.title) ? `Draft: ${input.title}` : input.title;
+    const json = await this.request<any>('POST', `/projects/${this.projectId(input)}/merge_requests`, {
+      source_branch: input.head,
+      target_branch: input.base,
+      title,
+      description: input.body ?? '',
+    });
+    return this.toPullRequest(json);
+  }
+
+  async getChecks(ref: RepoRef & { ref: string }): Promise<CheckRun[]> {
+    // Commit statuses = pipeline jobs + external statuses for the SHA.
+    const json = await this.request<any[]>(
+      'GET',
+      `/projects/${this.projectId(ref)}/repository/commits/${encodeURIComponent(ref.ref)}/statuses?per_page=100`,
+    );
+    return (json ?? []).map((s: any) => mapStatus(s.name ?? s.id ?? 'status', s.status));
+  }
+
+  async comment(input: CommentInput): Promise<void> {
+    await this.request(
+      'POST',
+      `/projects/${this.projectId(input)}/merge_requests/${input.number}/notes`,
+      { body: input.body },
+    );
+  }
+
+  /** URL-encoded `namespace/path` project identifier (subgroup slashes encoded). */
+  private projectId(ref: RepoRef): string {
+    return encodeURIComponent(`${ref.owner}/${ref.repo}`);
+  }
+
+  private toPullRequest(json: any): PullRequest {
+    const state: PullRequest['state'] =
+      json.state === 'merged' ? 'merged' : json.state === 'opened' ? 'open' : 'closed';
+    return {
+      number: json.iid,
+      url: json.web_url,
+      state,
+      draft: json.draft ?? json.work_in_progress ?? false,
+    };
+  }
+
+  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const { token } = await this.opts.tokenSource.getToken();
+    const res = await this.fetchImpl(`${this.api}${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+        ...(body ? { 'Content-Type': 'application/json' } : {}),
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => '');
+      throw new Error(`gitlab ${method} ${path} failed (${res.status}) ${detail}`.trim());
+    }
+    return res.status === 204 ? (undefined as T) : ((await res.json()) as T);
+  }
+}
+
+/**
+ * Map a GitLab commit-status state to the neutral CheckRun shape. Kept exported-
+ * free but pure so the mapping is unit-tested via getChecks. A `manual` job is a
+ * deliberate optional gate, so it's `neutral` (not a failure) — the CI loop must
+ * not treat an un-triggered manual job as a red check.
+ */
+function mapStatus(name: string, status: string): CheckRun {
+  switch (status) {
+    case 'success':
+      return { name, status: 'completed', conclusion: 'success' };
+    case 'failed':
+      return { name, status: 'completed', conclusion: 'failure' };
+    case 'canceled':
+    case 'cancelled':
+      return { name, status: 'completed', conclusion: 'cancelled' };
+    case 'skipped':
+      return { name, status: 'completed', conclusion: 'skipped' };
+    case 'manual':
+      return { name, status: 'completed', conclusion: 'neutral' };
+    case 'running':
+      return { name, status: 'in_progress', conclusion: null };
+    case 'created':
+    case 'pending':
+    case 'waiting_for_resource':
+    case 'preparing':
+    case 'scheduled':
+      return { name, status: 'queued', conclusion: null };
+    default:
+      return { name, status: 'unknown', conclusion: null };
+  }
+}

--- a/packages/cloud/src/gitforge/registry.test.ts
+++ b/packages/cloud/src/gitforge/registry.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  createForge,
+  registerForge,
+  registeredForges,
+  forgeKindFromEnv,
+  forgeApiBaseFromEnv,
+} from './registry';
+import { GitForge } from './types';
+import { GitHubForge } from './github';
+import { ForgeTokenSource } from '../forge/types';
+
+const tokenSource: ForgeTokenSource = {
+  id: 'test',
+  getToken: async () => ({ token: 't', expiresAt: new Date('2030-01-01') }),
+};
+
+describe('createForge', () => {
+  it('builds the built-in forges by kind', () => {
+    expect(createForge('github', { tokenSource }).id).toBe('github');
+    expect(createForge('gitlab', { tokenSource }).id).toBe('gitlab');
+  });
+
+  it('throws on an unknown kind, listing the known ones', () => {
+    expect(() => createForge('bitbucket', { tokenSource })).toThrow(/unknown forge host "bitbucket"/);
+    expect(() => createForge('bitbucket', { tokenSource })).toThrow(/github, gitlab/);
+  });
+});
+
+describe('registerForge (bring your own backend)', () => {
+  const custom = 'my-gitea';
+  afterEach(() => {
+    // registeredForges() has no unregister; leaving a test-only kind is harmless,
+    // but assert it exists so the extension path is covered.
+  });
+
+  it('resolves a custom forge and lists it', () => {
+    const fake: GitForge = {
+      id: 'gitea',
+      openPR: async () => ({ number: 1, url: 'u', state: 'open' }),
+      getChecks: async () => [],
+      comment: async () => {},
+    };
+    registerForge(custom, () => fake);
+    expect(registeredForges()).toContain(custom);
+    expect(createForge(custom, { tokenSource })).toBe(fake);
+  });
+
+  it('lets a custom factory override a built-in name (last write wins)', () => {
+    const sentinel: GitForge = {
+      id: 'sentinel',
+      openPR: async () => ({ number: 0, url: '', state: 'open' }),
+      getChecks: async () => [],
+      comment: async () => {},
+    };
+    registerForge('github', () => sentinel);
+    expect(createForge('github', { tokenSource }).id).toBe('sentinel');
+    // restore the built-in so registry state doesn't leak to later tests
+    registerForge('github', (o) => new GitHubForge(o));
+    expect(createForge('github', { tokenSource }).id).toBe('github');
+  });
+});
+
+describe('forgeKindFromEnv / forgeApiBaseFromEnv', () => {
+  it('defaults to github and reads NEMUS_FORGE_HOST', () => {
+    expect(forgeKindFromEnv({})).toBe('github');
+    expect(forgeKindFromEnv({ NEMUS_FORGE_HOST: 'gitlab' })).toBe('gitlab');
+    expect(forgeKindFromEnv({ NEMUS_FORGE_HOST: '  gitlab  ' })).toBe('gitlab');
+  });
+
+  it('reads the host-specific API base var, per kind', () => {
+    expect(forgeApiBaseFromEnv('github', { GITHUB_API_URL: 'https://ghe/api/v3' })).toBe('https://ghe/api/v3');
+    expect(forgeApiBaseFromEnv('gitlab', { GITLAB_API_URL: 'https://gl/api/v4' })).toBe('https://gl/api/v4');
+    // wrong-kind var is ignored
+    expect(forgeApiBaseFromEnv('gitlab', { GITHUB_API_URL: 'https://ghe/api/v3' })).toBeUndefined();
+    expect(forgeApiBaseFromEnv('github', {})).toBeUndefined();
+  });
+});

--- a/packages/cloud/src/gitforge/registry.test.ts
+++ b/packages/cloud/src/gitforge/registry.test.ts
@@ -75,4 +75,9 @@ describe('forgeKindFromEnv / forgeApiBaseFromEnv', () => {
     expect(forgeApiBaseFromEnv('gitlab', { GITHUB_API_URL: 'https://ghe/api/v3' })).toBeUndefined();
     expect(forgeApiBaseFromEnv('github', {})).toBeUndefined();
   });
+
+  it('never hands a custom kind GitHub\'s (or GitLab\'s) base URL', () => {
+    // A bring-your-own backend must not inherit a built-in's API base.
+    expect(forgeApiBaseFromEnv('gitea', { GITHUB_API_URL: 'https://ghe/api/v3', GITLAB_API_URL: 'https://gl/api/v4' })).toBeUndefined();
+  });
 });

--- a/packages/cloud/src/gitforge/registry.ts
+++ b/packages/cloud/src/gitforge/registry.ts
@@ -62,13 +62,15 @@ export function forgeKindFromEnv(env: NodeJS.ProcessEnv = process.env): string {
 
 /**
  * Per-kind default for the host API base, honoring the host-specific env var
- * (`GITHUB_API_URL` / `GITLAB_API_URL`). Returns undefined when unset, so each
- * forge falls back to its own public default.
+ * (`GITHUB_API_URL` / `GITLAB_API_URL`). Returns undefined when unset — and for
+ * any custom kind — so each forge falls back to its own default and a custom
+ * backend never accidentally inherits GitHub's/GitLab's base URL.
  */
 export function forgeApiBaseFromEnv(
   kind: string,
   env: NodeJS.ProcessEnv = process.env,
 ): string | undefined {
+  if (kind === 'github') return env.GITHUB_API_URL?.trim() || undefined;
   if (kind === 'gitlab') return env.GITLAB_API_URL?.trim() || undefined;
-  return env.GITHUB_API_URL?.trim() || undefined;
+  return undefined;
 }

--- a/packages/cloud/src/gitforge/registry.ts
+++ b/packages/cloud/src/gitforge/registry.ts
@@ -1,0 +1,74 @@
+import { ForgeTokenSource } from '../forge/types';
+import { GitForge } from './types';
+import { GitHubForge } from './github';
+import { GitLabForge } from './gitlab';
+
+/** Built-in code-host kinds. Extend by registering your own (see README). */
+export type ForgeKind = 'github' | 'gitlab';
+
+export interface CreateForgeOptions {
+  tokenSource: ForgeTokenSource;
+  /** Host API base (GHES / self-managed GitLab). Defaults per kind. */
+  apiBaseUrl?: string;
+  fetchImpl?: typeof fetch;
+}
+
+/** Signature every forge factory (built-in or custom) satisfies. */
+export type ForgeFactory = (opts: CreateForgeOptions) => GitForge;
+
+const registry: Record<string, ForgeFactory> = {
+  github: (o) => new GitHubForge(o),
+  gitlab: (o) => new GitLabForge(o),
+};
+
+/**
+ * Register a custom GitForge implementation under a kind name, so
+ * `createForge('<kind>', …)` and `NEMUS_FORGE_HOST=<kind>` resolve it. Lets a
+ * downstream user bring their own backend (Gitea, Bitbucket, …) without
+ * forking. Overriding a built-in name is allowed (last write wins).
+ */
+export function registerForge(kind: string, factory: ForgeFactory): void {
+  registry[kind] = factory;
+}
+
+/** Names of all registered forges (built-ins + any custom). */
+export function registeredForges(): string[] {
+  return Object.keys(registry);
+}
+
+/**
+ * Construct a GitForge by kind. The seam every caller should use instead of
+ * `new GitHubForge(...)`, so a workspace can target GitHub or GitLab (or a
+ * custom host) with no code change.
+ */
+export function createForge(kind: string, opts: CreateForgeOptions): GitForge {
+  const factory = registry[kind];
+  if (!factory) {
+    throw new Error(
+      `unknown forge host "${kind}" (known: ${registeredForges().join(', ')})`,
+    );
+  }
+  return factory(opts);
+}
+
+/**
+ * Resolve the code-host kind from the environment. `NEMUS_FORGE_HOST` selects
+ * it (default `github`); note this is the *code host*, distinct from
+ * `NEMUS_FORGE`, which selects the token source (pat | github-app).
+ */
+export function forgeKindFromEnv(env: NodeJS.ProcessEnv = process.env): string {
+  return env.NEMUS_FORGE_HOST?.trim() || 'github';
+}
+
+/**
+ * Per-kind default for the host API base, honoring the host-specific env var
+ * (`GITHUB_API_URL` / `GITLAB_API_URL`). Returns undefined when unset, so each
+ * forge falls back to its own public default.
+ */
+export function forgeApiBaseFromEnv(
+  kind: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  if (kind === 'gitlab') return env.GITLAB_API_URL?.trim() || undefined;
+  return env.GITHUB_API_URL?.trim() || undefined;
+}

--- a/packages/cloud/src/index.ts
+++ b/packages/cloud/src/index.ts
@@ -28,6 +28,17 @@ export * from './secret';
 export * from './gitforge/types';
 export { GitHubForge } from './gitforge/github';
 export type { GitHubForgeOptions } from './gitforge/github';
+export { GitLabForge } from './gitforge/gitlab';
+export type { GitLabForgeOptions } from './gitforge/gitlab';
+// Code-host registry: build a GitForge by kind (github | gitlab | custom).
+export {
+  createForge,
+  registerForge,
+  registeredForges,
+  forgeKindFromEnv,
+  forgeApiBaseFromEnv,
+} from './gitforge/registry';
+export type { ForgeKind, ForgeFactory, CreateForgeOptions } from './gitforge/registry';
 
 // In-image agent orchestrator: env contract, result.json schema, run flow.
 export * from './agent/types';


### PR DESCRIPTION
Proves the \`GitForge\` seam is genuinely **vendor-neutral**, not GitHub-only — the OSS-breadth follow-up to the cloud package's P1–P4.

## What's new
- **\`GitLabForge\`** — dependency-free (\`fetch\`-only) \`GitForge\` over the GitLab REST API v4:
  - \`openPR\` → **merge requests** (draft expressed by the \`Draft:\` title prefix, GitLab's own convention; no double-prefix).
  - \`getChecks\` → **commit statuses** for the head SHA, mapped to the neutral \`CheckRun\` shape. A \`manual\` job maps to \`neutral\` so an un-triggered manual gate never reads as a red check; unknown states degrade to \`unknown\`/pending (never a false-green).
  - \`comment\` → **MR notes**.
  - Self-managed GitLab via \`GITLAB_API_URL\`; projects addressed by URL-encoded \`namespace/path\` (**subgroups** in \`owner\` supported). \`PullRequest.number\` is the MR **iid**. Same \`ForgeTokenSource\` as GitHub (Bearer), so PAT/App auth is orthogonal to host.
- **Forge registry** — \`createForge(kind)\` / \`registerForge\` / \`registeredForges\`, plus \`forgeKindFromEnv\` (**\`NEMUS_FORGE_HOST\`**, default \`github\`) and \`forgeApiBaseFromEnv\`. \`NEMUS_FORGE_HOST\` selects the **code host**, deliberately distinct from \`NEMUS_FORGE\` (the **token source**: \`pat\` | \`github-app\`). Registering an existing kind overrides it (last-write-wins).
- **Entrypoint wired** — \`nemus-cloud-agent\` builds the forge via \`createForge(forgeKind, …)\`, so a run targets GitLab by setting \`NEMUS_FORGE_HOST=gitlab\` (+ a GitLab token) with **no code change**. Default stays \`github\`.
- **Docs** — a \`code-host seam\` section in \`packages/cloud/README.md\` including a **bring-your-own-backend** guide (Gitea/Bitbucket/…): implement the 3-method interface, \`registerForge('kind', factory)\`, done.

## Verification
- **+17 tests → 138 cloud tests** pass; cloud typecheck + build clean.
- Core is **untouched** (no root \`package.json\` change → no release triggered; this is the private cloud package).
- No vendor references in the new code (grep-clean).

## Why this shape
The whole point of \`GitForge\` was that core report-back and the CI-loop talk only to the seam, never a host SDK. Until now there was one implementation, so \"vendor-neutral\" was unproven. A second real backend + a registry + an extension guide turns it from a claim into a tested fact, and gives OSS users a first-class path to their own host.