### PR TITLE
feat(cloud): fix-pr entry mode — wire CI-loop + notifier into the agent image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`createForge`/`registerForge`/`registeredForges` + `NEMUS_FORGE_HOST`) so a
   run targets GitHub or GitLab — or a custom "bring your own backend" host
   (Gitea, Bitbucket, …) — with no code change. Docs in `packages/cloud/README.md`.
+  **CI-loop + notifier wired into the agent image:** a second container entry
+  mode `NEMUS_MODE=fix-pr` (`runFixPr`/`parseFixPrEnv`, CLI `nemus-cloud fix-pr
+  --repo --pr --branch`) drives an *existing* PR to green with the bounded
+  CI-loop (P3) + optional Slack/webhook notifications (P4) — clone, checkout PR
+  head, `runCiLoop`, then write the same versioned `result.json` with
+  `mode: 'fix-pr'` + a compact `ci` summary. So P3+P4 are usable end-to-end in a
+  container, on GitHub or GitLab.
   Design: `docs/plans/2026-08-26-cloud-iac.md`.
 
 ## [0.2.9] - 2026-08-26

--- a/docs/plans/2026-08-26-cloud-iac.md
+++ b/docs/plans/2026-08-26-cloud-iac.md
@@ -177,8 +177,12 @@ in log streams. PAT is always the zero-config fallback.
   read as pending (never a false green); a failure short-circuits waiting
   (fail-fast — a failure is definitive, so a hung check can’t block a fix). On give-up
   it posts a best-effort “needs a human” comment via `GitForge.comment`. Fully
-  unit-tested behind mocks. **Next:** wire it into the agent image (a `fix-pr`
-  entry mode) after `runAgentTask` opens the PR.
+  unit-tested behind mocks. **Wired into the agent image (done):** a second
+  container entry mode `NEMUS_MODE=fix-pr` (`runFixPr` + `parseFixPrEnv`) clones
+  the repo, checks out the PR head branch, and hands off to `runCiLoop`; it
+  writes the same versioned `result.json` with `mode: 'fix-pr'` + a compact `ci`
+  summary. Exposed as `nemus-cloud fix-pr --repo --pr --branch` (+ `--max-
+  iterations`/`--poll-interval-ms`/`--max-polls`).
 - **P4 — more providers (plugins), optional Slack, optional hosted UI.** _(in progress)_
   **Notification seam done:** a vendor-neutral `Notifier` (best-effort, zero-dep
   via `fetch`) with `SlackNotifier` (incoming webhook), `WebhookNotifier`
@@ -189,8 +193,10 @@ in log streams. PAT is always the zero-config fallback.
   status`** (only `machine list`), so a robust runner would need brittle
   stdout-scraping + racy list-correlation — not worth shipping below the bar the
   Fargate runner set. Revisit if flyctl adds machine-run JSON, or via the
-  Machines REST API. **Next:** wire `runCiLoop` + notifier into the agent image
-  (`fix-pr` mode); optional hosted UI remains out of scope for OSS core.
+  Machines REST API. **CI-loop + notifier now wired into the agent image**
+  (`fix-pr` mode; `notifierFromEnv` passes `SLACK_WEBHOOK_URL`/`NEMUS_WEBHOOK_URL`
+  through the CLI), so P3+P4 are usable end-to-end in a container. Optional
+  hosted UI remains out of scope for OSS core.
 
 ## Decisions (locked / open)
 

--- a/packages/cloud/README.md
+++ b/packages/cloud/README.md
@@ -159,7 +159,11 @@ nemus-cloud up --module fargate --var region=us-east-1 --var name=nemus
 nemus-cloud run --image ghcr.io/acme/agent:latest \
   --repos acme/api,acme/web --task "add idempotency keys" --owner acme --follow --wait
 
-# 3) tear it down
+# 3) drive an EXISTING PR to green (CI-loop + notifications, no new PR)
+nemus-cloud fix-pr --image ghcr.io/acme/agent:latest \
+  --repo acme/api --pr 42 --branch nemus/add-idempotency-keys --wait
+
+# 4) tear it down
 nemus-cloud down --module fargate
 ```
 
@@ -167,6 +171,23 @@ nemus-cloud down --module fargate
 + a tag-safe `TaskSpec` and launches it via the target's `Runner`, optionally
 streaming logs (`--follow`) and waiting for the exit code (`--wait`). Run
 `nemus-cloud help` for all flags.
+
+### `fix-pr`: make P3 + P4 usable end-to-end
+
+`fix-pr` is the second container entry mode (selected by `NEMUS_MODE=fix-pr`):
+instead of opening a **new** PR, it takes an **existing** one and drives it to
+green with the bounded **CI-loop** (P3) and optional **notifications** (P4). In
+the image it clones the repo, checks out the PR head branch, then hands off to
+`runCiLoop` — poll checks, run a fix pass on failure, commit, push, re-check,
+bounded so it can't spin; a give-up posts a best-effort "needs a human" comment
+and (if configured) a Slack/webhook alert. It writes the same versioned
+`result.json` as `run`, with an added `mode: 'fix-pr'` and a compact `ci`
+summary (`{ ok, state, iterations }`).
+
+Because it goes through the forge registry and notifier seam, it works against
+GitHub or GitLab (`NEMUS_FORGE_HOST=gitlab`) and reports out-of-band via
+`SLACK_WEBHOOK_URL` / `NEMUS_WEBHOOK_URL` — all opt-in, all vendor-neutral. Tune
+the loop with `--max-iterations` / `--poll-interval-ms` / `--max-polls`.
 
 ## Develop
 

--- a/packages/cloud/src/agent/cli.ts
+++ b/packages/cloud/src/agent/cli.ts
@@ -28,6 +28,11 @@ export async function main(env: NodeJS.ProcessEnv = process.env): Promise<number
       apiBaseUrl: forgeApiBaseFromEnv(forgeKind, env),
     });
     const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+    if (mode !== 'agent' && mode !== 'fix-pr') {
+      // Fail loudly on a typo rather than silently running the default flow
+      // (which would surface a misleading "NEMUS_TASK is required").
+      throw new Error(`unknown NEMUS_MODE "${mode}" (expected 'agent' or 'fix-pr')`);
+    }
     if (mode === 'fix-pr') {
       // Drive an EXISTING PR to green (CI-loop + notifications), no new PR.
       const cfg = parseFixPrEnv(env);

--- a/packages/cloud/src/agent/cli.ts
+++ b/packages/cloud/src/agent/cli.ts
@@ -3,7 +3,9 @@ import { writeFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { forgeAuthFromEnv } from '../index';
 import { createForge, forgeKindFromEnv, forgeApiBaseFromEnv } from '../gitforge/registry';
+import { notifierFromEnv } from '../notify/index';
 import { parseAgentEnv } from './env';
+import { parseFixPrEnv, runFixPr } from './fix-pr';
 import { runAgentTask, RunAgentDeps } from './run';
 import { ShellGitOps } from './git-ops';
 import { ShellAgentInvoker } from './agent-invoker';
@@ -16,27 +18,46 @@ import { RunResult } from './types';
  */
 export async function main(env: NodeJS.ProcessEnv = process.env): Promise<number> {
   let workdir = env.NEMUS_WORKDIR?.trim() || '/workspace';
+  const mode = env.NEMUS_MODE?.trim() || 'agent';
   let result: RunResult;
   try {
-    const config = parseAgentEnv(env);
-    workdir = config.workdir;
     const tokenSource = forgeAuthFromEnv(env);
     const forgeKind = forgeKindFromEnv(env);
-    const deps: RunAgentDeps = {
-      git: new ShellGitOps(),
-      agent: new ShellAgentInvoker({ env }),
-      forge: createForge(forgeKind, {
-        tokenSource,
-        apiBaseUrl: forgeApiBaseFromEnv(forgeKind, env),
-      }),
+    const forge = createForge(forgeKind, {
       tokenSource,
-    };
-    result = await runAgentTask(config, deps);
+      apiBaseUrl: forgeApiBaseFromEnv(forgeKind, env),
+    });
+    const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+    if (mode === 'fix-pr') {
+      // Drive an EXISTING PR to green (CI-loop + notifications), no new PR.
+      const cfg = parseFixPrEnv(env);
+      workdir = cfg.workdir;
+      result = await runFixPr(cfg, {
+        git: new ShellGitOps(),
+        agent: new ShellAgentInvoker({ env }),
+        forge,
+        tokenSource,
+        notifier: notifierFromEnv(env),
+        sleep,
+        log: (s) => process.stdout.write(`[nemus-cloud-agent] ${s}\n`),
+      });
+    } else {
+      const config = parseAgentEnv(env);
+      workdir = config.workdir;
+      const deps: RunAgentDeps = {
+        git: new ShellGitOps(),
+        agent: new ShellAgentInvoker({ env }),
+        forge,
+        tokenSource,
+      };
+      result = await runAgentTask(config, deps);
+    }
   } catch (e) {
     const now = new Date().toISOString();
     result = {
       schema: 1,
       ok: false,
+      mode: mode === 'fix-pr' ? 'fix-pr' : 'agent',
       agent: env.NEMUS_AGENT?.trim() || 'pi',
       task: env.NEMUS_TASK ?? '',
       startedAt: now,

--- a/packages/cloud/src/agent/fix-pr.test.ts
+++ b/packages/cloud/src/agent/fix-pr.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from 'vitest';
+import { parseFixPrEnv, runFixPr, FixPrDeps } from './fix-pr';
+import { CheckRun, GitForge } from '../gitforge/types';
+import { GitOps, AgentInvoker } from './types';
+import { ForgeTokenSource } from '../forge/types';
+import { Notifier } from '../notify/types';
+
+const tokenSource: ForgeTokenSource = {
+  id: 'test',
+  getToken: async () => ({ token: 'ghs_secret', expiresAt: new Date('2030-01-01') }),
+};
+
+function fakeGit(overrides: Partial<GitOps> = {}): GitOps & { calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    clone: async (url, dir) => { calls.push(`clone ${dir}`); },
+    checkout: async (dir, br) => { calls.push(`checkout ${br}`); },
+    checkoutNewBranch: async () => {},
+    hasChanges: async () => true,
+    commitAll: async () => { calls.push('commit'); },
+    push: async () => { calls.push('push'); },
+    ...overrides,
+  } as GitOps & { calls: string[] };
+}
+
+/** Forge whose getChecks returns a scripted sequence of check snapshots. */
+function scriptedForge(snapshots: CheckRun[][]): GitForge & { comments: any[] } {
+  let i = 0;
+  const comments: any[] = [];
+  return {
+    id: 'fake',
+    comments,
+    openPR: async () => ({ number: 1, url: 'u', state: 'open' }),
+    getChecks: async () => snapshots[Math.min(i++, snapshots.length - 1)],
+    comment: async (c) => { comments.push(c); },
+  } as GitForge & { comments: any[] };
+}
+
+const noSleep = async () => {};
+
+describe('parseFixPrEnv', () => {
+  const base = { NEMUS_REPOS: 'acme/api', NEMUS_PR_NUMBER: '42', NEMUS_PR_BRANCH: 'nemus/fix' };
+
+  it('parses the required fields', () => {
+    const c = parseFixPrEnv(base);
+    expect(c.repo.full).toBe('acme/api');
+    expect(c.prNumber).toBe(42);
+    expect(c.branch).toBe('nemus/fix');
+    expect(c.agent).toBe('pi');
+    expect(c.workdir).toBe('/workspace');
+  });
+
+  it('fills a bare repo name from NEMUS_OWNER', () => {
+    expect(parseFixPrEnv({ ...base, NEMUS_REPOS: 'api', NEMUS_OWNER: 'acme' }).repo.full).toBe('acme/api');
+  });
+
+  it('rejects missing/invalid inputs', () => {
+    expect(() => parseFixPrEnv({ NEMUS_PR_NUMBER: '1', NEMUS_PR_BRANCH: 'b' })).toThrow(/NEMUS_REPOS is required/);
+    expect(() => parseFixPrEnv({ ...base, NEMUS_REPOS: 'a/b,c/d' })).toThrow(/single repo/);
+    expect(() => parseFixPrEnv({ ...base, NEMUS_PR_BRANCH: '' })).toThrow(/NEMUS_PR_BRANCH is required/);
+    expect(() => parseFixPrEnv({ ...base, NEMUS_PR_NUMBER: '' })).toThrow(/NEMUS_PR_NUMBER is required/);
+    expect(() => parseFixPrEnv({ ...base, NEMUS_PR_NUMBER: 'x' })).toThrow(/non-negative integer/);
+  });
+
+  it('reads CI tuning overrides', () => {
+    const c = parseFixPrEnv({ ...base, NEMUS_CI_MAX_ITERATIONS: '2', NEMUS_CI_POLL_INTERVAL_MS: '100', NEMUS_CI_MAX_POLLS: '5' });
+    expect(c.maxIterations).toBe(2);
+    expect(c.pollIntervalMs).toBe(100);
+    expect(c.maxPollsPerIteration).toBe(5);
+  });
+});
+
+describe('runFixPr', () => {
+  const cfg = parseFixPrEnv({ NEMUS_REPOS: 'acme/api', NEMUS_PR_NUMBER: '42', NEMUS_PR_BRANCH: 'nemus/fix', NEMUS_WORKDIR: '/w' });
+
+  it('clones + checks out the PR head, then greens immediately', async () => {
+    const git = fakeGit();
+    const agent: AgentInvoker = { run: vi.fn(async () => {}) };
+    const forge = scriptedForge([[{ name: 'build', status: 'completed', conclusion: 'success' }]]);
+    const deps: FixPrDeps = { git, agent, forge, tokenSource, sleep: noSleep };
+
+    const res = await runFixPr(cfg, deps);
+    expect(res.mode).toBe('fix-pr');
+    expect(res.ok).toBe(true);
+    expect(res.ci).toEqual({ ok: true, state: 'green', iterations: 0 });
+    expect(git.calls.slice(0, 2)).toEqual(['clone /w/api', 'checkout nemus/fix']);
+    expect(agent.run).not.toHaveBeenCalled(); // already green → no fix pass
+    expect(res.repos[0]).toMatchObject({ repo: 'acme/api', cloned: true, prNumber: 42, changed: false });
+  });
+
+  it('runs a fix pass on failure, then greens (records an iteration + notifies)', async () => {
+    const git = fakeGit();
+    const agent: AgentInvoker = { run: vi.fn(async () => {}) };
+    const forge = scriptedForge([
+      [{ name: 'build', status: 'completed', conclusion: 'failure' }],
+      [{ name: 'build', status: 'completed', conclusion: 'success' }],
+    ]);
+    const events: any[] = [];
+    const notifier: Notifier = { notify: async (e) => { events.push(e); } };
+    const res = await runFixPr(cfg, { git, agent, forge, tokenSource, sleep: noSleep, notifier });
+
+    expect(agent.run).toHaveBeenCalledOnce();
+    expect(git.calls).toContain('commit');
+    expect(git.calls).toContain('push');
+    expect(res.ok).toBe(true);
+    expect(res.ci).toEqual({ ok: true, state: 'green', iterations: 1 });
+    expect(res.repos[0]).toMatchObject({ changed: true, pushed: true });
+    expect(events.map((e) => e.event)).toContain('ci_green');
+  });
+
+  it('reports a clone failure as a top-level error (no CI-loop)', async () => {
+    const git = fakeGit({ clone: async () => { throw new Error('auth denied'); } });
+    const agent: AgentInvoker = { run: vi.fn(async () => {}) };
+    const forge = scriptedForge([[]]);
+    const res = await runFixPr(cfg, { git, agent, forge, tokenSource, sleep: noSleep });
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/could not prepare PR checkout: auth denied/);
+    expect(res.repos[0].cloned).toBe(false);
+    expect(res.ci).toBeUndefined();
+  });
+
+  it('surfaces a give-up state (exhausted) from the CI-loop', async () => {
+    const git = fakeGit();
+    const agent: AgentInvoker = { run: vi.fn(async () => {}) };
+    // Always failing; maxIterations=1 → one fix, still red → exhausted.
+    const forge = scriptedForge([[{ name: 'build', status: 'completed', conclusion: 'failure' }]]);
+    const res = await runFixPr({ ...cfg, maxIterations: 1 }, { git, agent, forge, tokenSource, sleep: noSleep });
+    expect(res.ok).toBe(false);
+    expect(res.ci?.state).toBe('exhausted');
+    expect(res.repos[0].error).toBe('ci-loop: exhausted');
+    expect(forge.comments.length).toBe(1); // best-effort give-up comment on the PR
+  });
+});

--- a/packages/cloud/src/agent/fix-pr.ts
+++ b/packages/cloud/src/agent/fix-pr.ts
@@ -1,0 +1,172 @@
+import * as path from 'node:path';
+import { ForgeTokenSource } from '../forge/types';
+import { GitForge } from '../gitforge/types';
+import { Notifier } from '../notify/types';
+import { runCiLoop } from '../ci/loop';
+import { parseRepo } from './env';
+import { AgentInvoker, GitOps, RunResult } from './types';
+
+/**
+ * `fix-pr` entry mode: instead of opening a NEW PR, take an EXISTING PR and
+ * drive it to green with the bounded CI-loop (P3) + optional notifications (P4).
+ * This is what makes P3/P4 usable end-to-end inside the runner image — the
+ * container clones the repo, checks out the PR head, and hands off to runCiLoop.
+ *
+ * Vendor-neutral throughout: talks only to GitForge / GitOps / AgentInvoker /
+ * Notifier, so it works against GitHub or GitLab with no code change.
+ */
+export interface FixPrConfig {
+  repo: { owner: string; name: string; full: string };
+  /** PR/MR number (for the give-up comment + logging). */
+  prNumber: number;
+  /** Head branch the PR is built from — checks read here, fixes pushed here. */
+  branch: string;
+  agent: string;
+  /** Original task text, threaded into the fix prompt for context (optional). */
+  task?: string;
+  gitHost: string;
+  workdir: string;
+  /** CI-loop tuning (all optional; runCiLoop supplies defaults). */
+  maxIterations?: number;
+  pollIntervalMs?: number;
+  maxPollsPerIteration?: number;
+}
+
+export interface FixPrDeps {
+  git: GitOps;
+  agent: AgentInvoker;
+  forge: GitForge;
+  tokenSource: ForgeTokenSource;
+  notifier?: Notifier;
+  sleep: (ms: number) => Promise<void>;
+  log?: (s: string) => void;
+}
+
+/**
+ * Parse the runner-image env contract for `fix-pr` mode. In addition to the
+ * shared vars (NEMUS_AGENT/NEMUS_WORKDIR/GIT_HOST/NEMUS_OWNER):
+ *   NEMUS_REPOS        (required) a single `owner/name` (or bare name + NEMUS_OWNER)
+ *   NEMUS_PR_NUMBER    (required) the PR/MR number
+ *   NEMUS_PR_BRANCH    (required) the PR head branch
+ *   NEMUS_TASK         (optional) original task text, for fix-prompt context
+ *   NEMUS_CI_MAX_ITERATIONS / NEMUS_CI_POLL_INTERVAL_MS / NEMUS_CI_MAX_POLLS
+ */
+export function parseFixPrEnv(env: NodeJS.ProcessEnv = process.env): FixPrConfig {
+  const reposRaw = (env.NEMUS_REPOS ?? '')
+    .split(',')
+    .map((r) => r.trim())
+    .filter(Boolean);
+  if (reposRaw.length === 0) throw new Error('NEMUS_REPOS is required (one owner/name for fix-pr)');
+  if (reposRaw.length > 1) throw new Error('fix-pr operates on a single repo; NEMUS_REPOS has more than one');
+
+  const owner = (env.NEMUS_OWNER || env.GITHUB_ORG || env.NEMUS_GIT_OWNER)?.trim() || undefined;
+  const repo = parseRepo(reposRaw[0], owner);
+
+  const branch = env.NEMUS_PR_BRANCH?.trim();
+  if (!branch) throw new Error('NEMUS_PR_BRANCH is required (the PR head branch)');
+
+  const prNumber = intFromEnv(env.NEMUS_PR_NUMBER, 'NEMUS_PR_NUMBER');
+  if (prNumber === undefined) throw new Error('NEMUS_PR_NUMBER is required');
+
+  return {
+    repo,
+    prNumber,
+    branch,
+    agent: env.NEMUS_AGENT?.trim() || 'pi',
+    task: env.NEMUS_TASK?.trim() || undefined,
+    gitHost: env.GIT_HOST?.trim() || 'github.com',
+    workdir: env.NEMUS_WORKDIR?.trim() || '/workspace',
+    maxIterations: intFromEnv(env.NEMUS_CI_MAX_ITERATIONS, 'NEMUS_CI_MAX_ITERATIONS'),
+    pollIntervalMs: intFromEnv(env.NEMUS_CI_POLL_INTERVAL_MS, 'NEMUS_CI_POLL_INTERVAL_MS'),
+    maxPollsPerIteration: intFromEnv(env.NEMUS_CI_MAX_POLLS, 'NEMUS_CI_MAX_POLLS'),
+  };
+}
+
+/**
+ * Run the fix-pr flow: clone the repo, check out the PR head, and drive the
+ * bounded CI-loop. Returns a `RunResult` (schema 1) so result.json stays a
+ * single, uniform contract across entry modes.
+ */
+export async function runFixPr(config: FixPrConfig, deps: FixPrDeps): Promise<RunResult> {
+  const startedAt = new Date().toISOString();
+  const result: RunResult = {
+    schema: 1,
+    ok: false,
+    mode: 'fix-pr',
+    agent: config.agent,
+    task: config.task ?? `fix-pr ${config.repo.full}#${config.prNumber}`,
+    startedAt,
+    finishedAt: startedAt,
+    repos: [{ repo: config.repo.full, cloned: false, branch: config.branch }],
+  };
+  const entry = result.repos[0];
+
+  const repoDir = path.join(config.workdir, config.repo.name);
+
+  // Least-privilege token for git + the give-up comment on exactly this repo.
+  let token: string;
+  try {
+    const t = await deps.tokenSource.getToken({
+      repos: [config.repo.full],
+      permissions: { contents: 'write', pull_requests: 'write' },
+    });
+    token = t.token;
+  } catch (e) {
+    result.error = `forge auth failed: ${(e as Error).message}`;
+    result.finishedAt = new Date().toISOString();
+    return result;
+  }
+
+  // Clone + check out the PR head branch.
+  try {
+    const url = `https://x-access-token:${token}@${config.gitHost}/${config.repo.full}.git`;
+    await deps.git.clone(url, repoDir);
+    await deps.git.checkout(repoDir, config.branch);
+    entry.cloned = true;
+  } catch (e) {
+    entry.error = (e as Error).message;
+    result.error = `could not prepare PR checkout: ${(e as Error).message}`;
+    result.finishedAt = new Date().toISOString();
+    return result;
+  }
+
+  // Hand off to the bounded CI-loop (P3) with optional notifications (P4).
+  const ci = await runCiLoop(
+    {
+      repo: { owner: config.repo.owner, repo: config.repo.name },
+      prNumber: config.prNumber,
+      branch: config.branch,
+      workdir: repoDir,
+      agent: config.agent,
+      task: config.task,
+      maxIterations: config.maxIterations,
+      pollIntervalMs: config.pollIntervalMs,
+      maxPollsPerIteration: config.maxPollsPerIteration,
+    },
+    {
+      forge: deps.forge,
+      git: deps.git,
+      agent: deps.agent,
+      notifier: deps.notifier,
+      sleep: deps.sleep,
+      log: deps.log,
+    },
+  );
+
+  result.ci = { ok: ci.ok, state: ci.state, iterations: ci.iterations };
+  result.ok = ci.ok;
+  entry.changed = ci.iterations > 0;
+  entry.pushed = ci.iterations > 0;
+  entry.prNumber = config.prNumber;
+  if (!ci.ok) entry.error = `ci-loop: ${ci.state}`;
+  result.finishedAt = new Date().toISOString();
+  return result;
+}
+
+function intFromEnv(raw: string | undefined, name: string): number | undefined {
+  const s = raw?.trim();
+  if (!s) return undefined;
+  const n = Number(s);
+  if (!Number.isInteger(n) || n < 0) throw new Error(`${name} must be a non-negative integer, got "${raw}"`);
+  return n;
+}

--- a/packages/cloud/src/agent/git-ops.ts
+++ b/packages/cloud/src/agent/git-ops.ts
@@ -29,6 +29,11 @@ export class ShellGitOps implements GitOps {
     await run(this.exec, 'git', ['-C', dir, 'checkout', '-b', branch]);
   }
 
+  async checkout(dir: string, branch: string): Promise<void> {
+    // A fresh clone has origin/<branch>; `git checkout <branch>` sets up tracking.
+    await run(this.exec, 'git', ['-C', dir, 'checkout', branch]);
+  }
+
   async hasChanges(dir: string): Promise<boolean> {
     const { stdout } = await run(this.exec, 'git', ['-C', dir, 'status', '--porcelain']);
     return stdout.trim().length > 0;

--- a/packages/cloud/src/agent/types.ts
+++ b/packages/cloud/src/agent/types.ts
@@ -61,6 +61,18 @@ export interface RunResult {
   repos: RepoResult[];
   /** Top-level failure (env/agent), distinct from per-repo errors. */
   error?: string;
+  /** Which entry mode produced this result (default 'agent'). Additive/optional. */
+  mode?: 'agent' | 'fix-pr';
+  /** Present for `fix-pr` runs: the bounded CI-loop outcome. */
+  ci?: CiSummary;
+}
+
+/** Compact CI-loop outcome recorded in result.json for a `fix-pr` run. */
+export interface CiSummary {
+  ok: boolean;
+  /** green | no_checks | exhausted | stuck | timeout */
+  state: string;
+  iterations: number;
 }
 
 /** Git operations, injected so the flow is testable. Implementations shell git. */
@@ -69,6 +81,8 @@ export interface GitOps {
   clone(url: string, dir: string): Promise<void>;
   /** Create + switch to `branch` in the repo at `dir`. */
   checkoutNewBranch(dir: string, branch: string): Promise<void>;
+  /** Switch to an existing `branch` (e.g. a PR head) in the repo at `dir`. */
+  checkout(dir: string, branch: string): Promise<void>;
   /** True if the working tree has changes to commit. */
   hasChanges(dir: string): Promise<boolean>;
   /** Stage everything and commit with `message`. */

--- a/packages/cloud/src/cli/cloud.test.ts
+++ b/packages/cloud/src/cli/cloud.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseArgs, parseVars, buildRunTaskSpec, main, CloudCliDeps } from './cloud';
+import { parseArgs, parseVars, buildRunTaskSpec, buildFixPrTaskSpec, main, CloudCliDeps } from './cloud';
 import { TargetDescriptor, LogLine, Status } from '../runner/types';
 
 describe('parseArgs', () => {
@@ -58,6 +58,50 @@ describe('buildRunTaskSpec', () => {
     expect(() => buildRunTaskSpec({ image: 'i', task: 't' }, { GITHUB_TOKEN: 't' })).toThrow(/--repos/);
     expect(() => buildRunTaskSpec({ image: 'i', repos: 'a' }, { GITHUB_TOKEN: 't' })).toThrow(/--task/);
     expect(() => buildRunTaskSpec(flags, {})).toThrow(/no forge auth/);
+  });
+});
+
+describe('buildFixPrTaskSpec', () => {
+  const flags = { image: 'img', repo: 'acme/api', pr: '42', branch: 'nemus/fix', owner: 'acme' };
+
+  it('wires the fix-pr env contract (NEMUS_MODE + PR coords) + tag-safe labels', () => {
+    const spec = buildFixPrTaskSpec(flags, { GITHUB_TOKEN: 't' });
+    expect(spec.command).toEqual(['nemus-cloud-agent']);
+    expect(spec.env).toMatchObject({
+      NEMUS_MODE: 'fix-pr',
+      NEMUS_REPOS: 'acme/api',
+      NEMUS_PR_NUMBER: '42',
+      NEMUS_PR_BRANCH: 'nemus/fix',
+      NEMUS_AGENT: 'pi',
+      GITHUB_TOKEN: 't',
+    });
+    expect(spec.labels).toEqual({ 'nemus.agent': 'pi', 'nemus.mode': 'fix-pr', 'nemus.pr': '42', 'nemus.owner': 'acme' });
+    expect(Object.values(spec.labels!).some((v) => v.includes(','))).toBe(false);
+  });
+
+  it('forwards the code-host selector + notifier sinks + CI tuning', () => {
+    const spec = buildFixPrTaskSpec(
+      { ...flags, 'max-iterations': '2', 'poll-interval-ms': '100', 'max-polls': '5' },
+      { GITHUB_TOKEN: 't', NEMUS_FORGE_HOST: 'gitlab', GITLAB_API_URL: 'https://gl/api/v4', SLACK_WEBHOOK_URL: 'https://hook' },
+    );
+    expect(spec.env).toMatchObject({
+      NEMUS_FORGE_HOST: 'gitlab',
+      GITLAB_API_URL: 'https://gl/api/v4',
+      SLACK_WEBHOOK_URL: 'https://hook',
+      NEMUS_CI_MAX_ITERATIONS: '2',
+      NEMUS_CI_POLL_INTERVAL_MS: '100',
+      NEMUS_CI_MAX_POLLS: '5',
+    });
+  });
+
+  it('validates its inputs', () => {
+    expect(() => buildFixPrTaskSpec({ repo: 'a/b', pr: '1', branch: 'x' }, { GITHUB_TOKEN: 't' })).toThrow(/--image/);
+    expect(() => buildFixPrTaskSpec({ image: 'i', pr: '1', branch: 'x' }, { GITHUB_TOKEN: 't' })).toThrow(/--repo/);
+    expect(() => buildFixPrTaskSpec({ image: 'i', repo: 'a/b,c/d', pr: '1', branch: 'x' }, { GITHUB_TOKEN: 't' })).toThrow(/exactly one --repo/);
+    expect(() => buildFixPrTaskSpec({ image: 'i', repo: 'a/b', branch: 'x' }, { GITHUB_TOKEN: 't' })).toThrow(/--pr/);
+    expect(() => buildFixPrTaskSpec({ image: 'i', repo: 'a/b', pr: 'x', branch: 'b' }, { GITHUB_TOKEN: 't' })).toThrow(/--pr must be a number/);
+    expect(() => buildFixPrTaskSpec({ image: 'i', repo: 'a/b', pr: '1' }, { GITHUB_TOKEN: 't' })).toThrow(/--branch/);
+    expect(() => buildFixPrTaskSpec(flags, {})).toThrow(/no forge auth/);
   });
 });
 
@@ -136,6 +180,18 @@ describe('main dispatch', () => {
     files.set('.nemus-target.json', JSON.stringify({ version: 1, runner: 'fake' }));
     const code = await main(['run', '--image', 'i', '--repos', 'a', '--task', 't', '--wait'], deps);
     expect(code).toBe(1);
+  });
+
+  it('fix-pr: loads target and launches the fix-pr task', async () => {
+    const { deps, files, calls, out } = harness();
+    files.set('.nemus-target.json', JSON.stringify({ version: 1, runner: 'fake' }));
+    const code = await main(
+      ['fix-pr', '--image', 'img', '--repo', 'acme/api', '--pr', '42', '--branch', 'nemus/fix', '--wait'],
+      deps,
+    );
+    expect(code).toBe(0);
+    expect(calls).toEqual(expect.arrayContaining(['runner:fake', 'launch']));
+    expect(out.some((l) => l.includes('succeeded'))).toBe(true);
   });
 
   it('down: reads target then destroys', async () => {

--- a/packages/cloud/src/cli/cloud.ts
+++ b/packages/cloud/src/cli/cloud.ts
@@ -128,11 +128,6 @@ export function buildRunTaskSpec(flags: Flags, env: NodeJS.ProcessEnv): TaskSpec
   const agent = str(flags, 'agent') ?? 'pi';
   const owner = str(flags, 'owner');
   const report = str(flags, 'report') ?? 'pr';
-  const token = env.GITHUB_TOKEN || env.GIT_TOKEN;
-  const hasApp = !!(env.GITHUB_APP_ID && env.GITHUB_APP_PRIVATE_KEY && env.GITHUB_APP_INSTALLATION_ID);
-  if (!token && !hasApp) {
-    throw new Error('run: no forge auth — set GITHUB_TOKEN (or GITHUB_APP_ID/_PRIVATE_KEY/_INSTALLATION_ID)');
-  }
 
   const taskEnv: Record<string, string> = {
     NEMUS_REPOS: repos,
@@ -142,11 +137,7 @@ export function buildRunTaskSpec(flags: Flags, env: NodeJS.ProcessEnv): TaskSpec
   };
   if (owner) taskEnv.NEMUS_OWNER = owner;
   if (str(flags, 'git-host')) taskEnv.GIT_HOST = str(flags, 'git-host')!;
-  if (token) taskEnv.GITHUB_TOKEN = token;
-  // Pass App creds straight through when present (least-privilege in-task auth).
-  for (const k of ['GITHUB_APP_ID', 'GITHUB_APP_PRIVATE_KEY', 'GITHUB_APP_INSTALLATION_ID']) {
-    if (env[k]) taskEnv[k] = env[k]!;
-  }
+  injectForgeEnv(taskEnv, env, 'run');
 
   const cpu = str(flags, 'cpu');
   const memory = str(flags, 'memory');
@@ -158,6 +149,75 @@ export function buildRunTaskSpec(flags: Flags, env: NodeJS.ProcessEnv): TaskSpec
   if (owner) labels['nemus.owner'] = owner;
 
   return { image, env: taskEnv, command: ['nemus-cloud-agent'], resources, labels };
+}
+
+/** Build the TaskSpec for `fix-pr` mode: drive an EXISTING PR to green (no new
+ *  PR). Pure + exported so the env contract is unit-tested. */
+export function buildFixPrTaskSpec(flags: Flags, env: NodeJS.ProcessEnv): TaskSpec {
+  const image = str(flags, 'image');
+  const repo = str(flags, 'repo') ?? str(flags, 'repos');
+  const pr = str(flags, 'pr');
+  const branch = str(flags, 'branch');
+  if (!image) throw new Error('fix-pr: --image is required');
+  if (!repo) throw new Error('fix-pr: --repo owner/name is required');
+  if (repo.includes(',')) throw new Error('fix-pr: exactly one --repo (no comma-separated list)');
+  if (!pr) throw new Error('fix-pr: --pr <number> is required');
+  if (!/^\d+$/.test(pr)) throw new Error(`fix-pr: --pr must be a number, got "${pr}"`);
+  if (!branch) throw new Error('fix-pr: --branch <pr-head> is required');
+
+  const agent = str(flags, 'agent') ?? 'pi';
+  const owner = str(flags, 'owner');
+  const taskEnv: Record<string, string> = {
+    NEMUS_MODE: 'fix-pr',
+    NEMUS_REPOS: repo,
+    NEMUS_PR_NUMBER: pr,
+    NEMUS_PR_BRANCH: branch,
+    NEMUS_AGENT: agent,
+  };
+  if (owner) taskEnv.NEMUS_OWNER = owner;
+  if (str(flags, 'task')) taskEnv.NEMUS_TASK = str(flags, 'task')!;
+  if (str(flags, 'git-host')) taskEnv.GIT_HOST = str(flags, 'git-host')!;
+  for (const [flag, envKey] of [
+    ['max-iterations', 'NEMUS_CI_MAX_ITERATIONS'],
+    ['poll-interval-ms', 'NEMUS_CI_POLL_INTERVAL_MS'],
+    ['max-polls', 'NEMUS_CI_MAX_POLLS'],
+  ] as const) {
+    if (str(flags, flag)) taskEnv[envKey] = str(flags, flag)!;
+  }
+  injectForgeEnv(taskEnv, env, 'fix-pr');
+
+  const cpu = str(flags, 'cpu');
+  const memory = str(flags, 'memory');
+  const resources =
+    cpu || memory ? { cpu: cpu ? Number(cpu) : undefined, memoryMB: memory ? Number(memory) : undefined } : undefined;
+
+  const labels: Record<string, string> = { 'nemus.agent': agent, 'nemus.mode': 'fix-pr', 'nemus.pr': pr };
+  if (owner) labels['nemus.owner'] = owner;
+
+  return { image, env: taskEnv, command: ['nemus-cloud-agent'], resources, labels };
+}
+
+/**
+ * Inject forge auth + code-host selector + notifier sinks into a task env,
+ * shared by `run` and `fix-pr`. Requires forge auth (a token or App creds) and
+ * passes through the code-host / API-base / notifier vars when set, so the
+ * container can target GitHub or GitLab and report back out-of-band.
+ */
+function injectForgeEnv(taskEnv: Record<string, string>, env: NodeJS.ProcessEnv, cmd: string): void {
+  const token = env.GITHUB_TOKEN || env.GIT_TOKEN;
+  const hasApp = !!(env.GITHUB_APP_ID && env.GITHUB_APP_PRIVATE_KEY && env.GITHUB_APP_INSTALLATION_ID);
+  if (!token && !hasApp) {
+    throw new Error(`${cmd}: no forge auth — set GITHUB_TOKEN (or GITHUB_APP_ID/_PRIVATE_KEY/_INSTALLATION_ID)`);
+  }
+  if (token) taskEnv.GITHUB_TOKEN = token;
+  // Least-privilege in-task auth (App) + code-host selector + notifier sinks.
+  for (const k of [
+    'GITHUB_APP_ID', 'GITHUB_APP_PRIVATE_KEY', 'GITHUB_APP_INSTALLATION_ID',
+    'NEMUS_FORGE', 'NEMUS_FORGE_HOST', 'GITHUB_API_URL', 'GITLAB_API_URL',
+    'SLACK_WEBHOOK_URL', 'NEMUS_WEBHOOK_URL',
+  ]) {
+    if (env[k]) taskEnv[k] = env[k]!;
+  }
 }
 
 function loadTarget(deps: CloudCliDeps, file: string): TargetDescriptor {
@@ -207,7 +267,15 @@ async function cmdDown(flags: Flags, deps: CloudCliDeps): Promise<number> {
 }
 
 async function cmdRun(flags: Flags, deps: CloudCliDeps): Promise<number> {
-  const spec = buildRunTaskSpec(flags, deps.env);
+  return launchSpec(buildRunTaskSpec(flags, deps.env), flags, deps);
+}
+
+async function cmdFixPr(flags: Flags, deps: CloudCliDeps): Promise<number> {
+  return launchSpec(buildFixPrTaskSpec(flags, deps.env), flags, deps);
+}
+
+/** Launch a TaskSpec on the resolved target, with optional --follow / --wait. */
+async function launchSpec(spec: TaskSpec, flags: Flags, deps: CloudCliDeps): Promise<number> {
   const target = loadTarget(deps, str(flags, 'target') ?? DEFAULT_TARGET_FILE);
   const runner = deps.createRunner(target.runner);
   const handle = await runner.launch(spec, target);
@@ -237,9 +305,15 @@ Usage:
   nemus-cloud run   --image REF --repos a,b --task "..." [--target FILE]
                     [--agent pi] [--owner ORG] [--report pr|none] [--cpu N] [--memory MB]
                     [--git-host HOST] [--follow] [--wait]
+  nemus-cloud fix-pr --image REF --repo owner/name --pr N --branch HEAD [--target FILE]
+                    [--agent pi] [--owner ORG] [--task "..."] [--git-host HOST]
+                    [--max-iterations N] [--poll-interval-ms N] [--max-polls N]
+                    [--cpu N] [--memory MB] [--follow] [--wait]
 
-Forge auth for \`run\` comes from the environment: GITHUB_TOKEN, or
-GITHUB_APP_ID/_PRIVATE_KEY/_INSTALLATION_ID.`;
+Forge auth for \`run\`/\`fix-pr\` comes from the environment: GITHUB_TOKEN, or
+GITHUB_APP_ID/_PRIVATE_KEY/_INSTALLATION_ID. Target a different host with
+NEMUS_FORGE_HOST=gitlab (+ GITLAB_API_URL); report out-of-band with
+SLACK_WEBHOOK_URL / NEMUS_WEBHOOK_URL.`;
 
 export async function main(argv: string[], deps: CloudCliDeps = defaultDeps): Promise<number> {
   const { cmd, flags } = parseArgs(argv);
@@ -251,6 +325,8 @@ export async function main(argv: string[], deps: CloudCliDeps = defaultDeps): Pr
         return await cmdDown(flags, deps);
       case 'run':
         return await cmdRun(flags, deps);
+      case 'fix-pr':
+        return await cmdFixPr(flags, deps);
       case undefined:
       case 'help':
       case '--help':

--- a/packages/cloud/src/index.ts
+++ b/packages/cloud/src/index.ts
@@ -45,6 +45,9 @@ export * from './agent/types';
 export { parseAgentEnv, parseRepo } from './agent/env';
 export { runAgentTask, slug } from './agent/run';
 export type { RunAgentDeps } from './agent/run';
+// fix-pr entry mode: drive an existing PR to green (CI-loop + notifications).
+export { runFixPr, parseFixPrEnv } from './agent/fix-pr';
+export type { FixPrConfig, FixPrDeps } from './agent/fix-pr';
 export { ShellGitOps } from './agent/git-ops';
 export type { ShellGitOpsOptions } from './agent/git-ops';
 export { ShellAgentInvoker, buildAgentCommand } from './agent/agent-invoker';


### PR DESCRIPTION
Makes **P3 (bounded CI-loop)** and **P4 (notifications)** usable **end-to-end in a container**. Until now `runCiLoop` + `Notifier` existed and were unit-tested, but nothing in the image invoked them — this adds the second container entry mode that does.

## What's new
- **`fix-pr` container mode** (`NEMUS_MODE=fix-pr`). `runFixPr` / `parseFixPrEnv` (`agent/fix-pr.ts`): clone the repo, check out the **PR head branch**, and hand off to `runCiLoop` with `notifierFromEnv`. Instead of opening a *new* PR, it drives an *existing* one to green — poll checks → fix pass on failure → commit → push → re-check, bounded; a give-up posts the best-effort "needs a human" comment and (if configured) a Slack/webhook alert.
- **Uniform result contract.** Writes the same versioned `result.json` as `run`, with an added `mode: 'fix-pr'` and a compact `ci` summary `{ ok, state, iterations }` (additive/optional — schema stays `1`).
- **`GitOps.checkout(dir, branch)`** — check out an existing branch after clone.
- **Entrypoint** (`nemus-cloud-agent`) branches on `NEMUS_MODE` (`agent` | `fix-pr`); default unchanged.
- **CLI** — `nemus-cloud fix-pr --repo owner/name --pr N --branch HEAD` (+ `--task`, `--max-iterations`/`--poll-interval-ms`/`--max-polls`, `--follow`/`--wait`). A shared `injectForgeEnv` now forwards the **code-host selector** (`NEMUS_FORGE_HOST` + `GITHUB_API_URL`/`GITLAB_API_URL`) and **notifier sinks** (`SLACK_WEBHOOK_URL`/`NEMUS_WEBHOOK_URL`) for **both** `run` and `fix-pr`, so a container can target GitHub or GitLab and report out-of-band.

## Why this shape
- The env contract requires the caller to pass the **PR head branch + number explicitly** (the `nemus-cloud` CLI resolves them laptop-side before launch). This keeps the container dumb and the `GitForge` seam minimal — no new `getPullRequest` method needed just to resolve a branch.
- `fix-pr` operates on a **single repo** by construction (a PR belongs to one repo), enforced in both the env parser and the CLI.
- Everything routes through `GitForge`/`GitOps`/`AgentInvoker`/`Notifier`, so it's **vendor-neutral** — works against GitHub or GitLab, Slack or generic webhook, all opt-in.

## Verification
- **+12 tests → 151 cloud tests** pass (env parsing incl. validation; clone→checkout→green; fail→fix→green with `ci_green` notification; clone-failure as top-level error; `exhausted` give-up posts a PR comment; CLI `fix-pr` spec + dispatch). Cloud typecheck + build clean.
- **Core untouched** — no root `package.json` change, so no release triggers (private cloud package).
- No vendor references (grep-clean).

Closes the loop on the cloud package: provision (`up`) → run an agent (`run`) → drive the resulting PR to green (`fix-pr`), on your own infra, on your own forge.
