### PR TITLE
feat: --json output for list/status/doctor + stdout/stderr hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.11] - 2026-08-27
+
+### Added
+
+- **`--json` output** for the read-only reporting commands `list`, `status`, and
+  `doctor`. Emits exactly one JSON document to stdout (no table, no interactive
+  prompt), so `nemus list --json | jq …` and CI/scripts get stable,
+  machine-readable output. `status --json` / `doctor --json` require an explicit
+  workspace name (they never prompt).
+
+### Changed
+
+- **stdout/stderr hygiene.** Diagnostic logs (info/success/error/warning/step)
+  now go to **stderr**, leaving **stdout** for a command's actual data. This is
+  what makes `--json` pipe cleanly and lets non-TTY consumers separate data from
+  progress. Human-facing table/plain output is unchanged on stdout.
+
 ## [0.2.10] - 2026-08-27
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -223,6 +223,21 @@ web              feature/x    ⚠ 2 modified  ↑1             2 files
 shared-lib       main         ✓ Clean       ↓3             -
 ```
 
+### Scripting: `--json`
+
+`list`, `status`, and `doctor` accept `--json` for stable, machine-readable
+output. Diagnostics go to stderr, so stdout is a single JSON document you can
+pipe straight into `jq` or a CI step:
+
+```bash
+nemus list --json | jq -r '.workspaces[].name'
+nemus status my-workspace --json | jq '.clean'
+nemus doctor my-workspace --json | jq '.score'
+```
+
+`status`/`doctor` with `--json` need an explicit workspace name (they never
+prompt).
+
 ### Suites (reusable repo collections)
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nemus-cli/nemus",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "workspaces": [
     "packages/*"
   ],

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -4,7 +4,7 @@ import { WORKSPACES_DIR } from '../utils/config';
 import { loadMetadata } from '../utils/workspace-meta';
 import { runAllHealthChecks, calculateHealthScore } from '../utils/health-checks';
 import { logError, logInfo, logStep, logSuccess, logWarning } from '../utils/logger';
-import { outputJson } from '../utils/output';
+import { outputJson, outputJsonError } from '../utils/output';
 import { colorize } from '../utils/colors';
 import { HealthCheckResult } from '../types';
 import { resolveWorkspace } from '../utils/command-helpers';
@@ -67,10 +67,13 @@ export function registerDoctorCommand(parent: Command) {
 }
 
 async function handleDoctor(workspaceArg?: string, opts: { json?: boolean } = {}) {
+  // In --json mode, failures are parseable JSON on stdout + exit 1; otherwise a
+  // human log on stderr. `process.exit(1)` stays the last statement so TS still
+  // narrows `metadata` to non-null below.
   try {
     // JSON mode is non-interactive: require an explicit workspace rather than prompt.
     if (opts.json && !workspaceArg) {
-      logError('doctor --json requires a workspace name');
+      outputJsonError('doctor --json requires a workspace name');
       process.exit(1);
     }
     const selectedWorkspace = await resolveWorkspace(workspaceArg);
@@ -78,7 +81,8 @@ async function handleDoctor(workspaceArg?: string, opts: { json?: boolean } = {}
     const metadata = await loadMetadata(workspacePath);
 
     if (!metadata) {
-      logError(`Workspace metadata not found for: ${selectedWorkspace}`);
+      if (opts.json) outputJsonError(`Workspace metadata not found for: ${selectedWorkspace}`);
+      else logError(`Workspace metadata not found for: ${selectedWorkspace}`);
       process.exit(1);
     }
 
@@ -120,9 +124,11 @@ async function handleDoctor(workspaceArg?: string, opts: { json?: boolean } = {}
       logSuccess('All health checks passed! Your workspace is in good shape.');
     }
   } catch (error) {
-    logError('Failed to run health checks');
-    if (error instanceof Error) {
-      logError(error.message);
+    if (opts.json) {
+      outputJsonError(error instanceof Error ? error.message : 'Failed to run health checks');
+    } else {
+      logError('Failed to run health checks');
+      if (error instanceof Error) logError(error.message);
     }
     process.exit(1);
   }

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -4,6 +4,7 @@ import { WORKSPACES_DIR } from '../utils/config';
 import { loadMetadata } from '../utils/workspace-meta';
 import { runAllHealthChecks, calculateHealthScore } from '../utils/health-checks';
 import { logError, logInfo, logStep, logSuccess, logWarning } from '../utils/logger';
+import { outputJson } from '../utils/output';
 import { colorize } from '../utils/colors';
 import { HealthCheckResult } from '../types';
 import { resolveWorkspace } from '../utils/command-helpers';
@@ -59,13 +60,19 @@ export function registerDoctorCommand(parent: Command) {
     .alias('doc')
     .description('Run comprehensive health checks')
     .argument('[workspace]', 'Workspace name')
-    .action(async (workspace) => {
-      await handleDoctor(workspace);
+    .option('--json', 'Output as JSON')
+    .action(async (workspace, opts) => {
+      await handleDoctor(workspace, opts);
     });
 }
 
-async function handleDoctor(workspaceArg?: string) {
+async function handleDoctor(workspaceArg?: string, opts: { json?: boolean } = {}) {
   try {
+    // JSON mode is non-interactive: require an explicit workspace rather than prompt.
+    if (opts.json && !workspaceArg) {
+      logError('doctor --json requires a workspace name');
+      process.exit(1);
+    }
     const selectedWorkspace = await resolveWorkspace(workspaceArg);
     const workspacePath = path.join(WORKSPACES_DIR, selectedWorkspace);
     const metadata = await loadMetadata(workspacePath);
@@ -73,6 +80,18 @@ async function handleDoctor(workspaceArg?: string) {
     if (!metadata) {
       logError(`Workspace metadata not found for: ${selectedWorkspace}`);
       process.exit(1);
+    }
+
+    if (opts.json) {
+      const results = await runAllHealthChecks(workspacePath, metadata);
+      const score = calculateHealthScore(results);
+      const overall = results.some(r => r.status === 'error')
+        ? 'error'
+        : results.some(r => r.status === 'warning')
+          ? 'warning'
+          : 'healthy';
+      outputJson({ workspace: selectedWorkspace, score, status: overall, checks: results });
+      return;
     }
 
     logStep(`Running health checks for workspace: ${colorize(selectedWorkspace, 'cyan')}`);

--- a/src/commands/list.test.ts
+++ b/src/commands/list.test.ts
@@ -196,6 +196,36 @@ describe('list-workspaces main', () => {
     expect(messages).toContainEqual(expect.stringContaining('ws-a'));
   });
 
+  it('--json: writes one valid JSON document to stdout and does not prompt', async () => {
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    process.argv = ['node', 'list-workspaces.js', '--json'];
+    mockListWorkspaces.mockResolvedValueOnce(makeWorkspaceList('ws-a', 'ws-b'));
+
+    await main();
+
+    expect(mockPrompt).not.toHaveBeenCalled();
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(writeSpy.mock.calls[0][0] as string);
+    expect(payload.count).toBe(2);
+    expect(payload.workspaces.map((w: any) => w.name).sort()).toEqual(['ws-a', 'ws-b']);
+    expect(payload.workspaces[0]).toMatchObject({ repoCount: 1, hasSession: false });
+    writeSpy.mockRestore();
+  });
+
+  it('--json: empty list emits count 0, no prompt, no log noise', async () => {
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    process.argv = ['node', 'list-workspaces.js', '--json'];
+    mockListWorkspaces.mockResolvedValueOnce([]);
+
+    await main();
+
+    expect(logInfo).not.toHaveBeenCalled();
+    expect(mockPrompt).not.toHaveBeenCalled();
+    const payload = JSON.parse(writeSpy.mock.calls[0][0] as string);
+    expect(payload).toEqual({ archived: false, count: 0, workspaces: [] });
+    writeSpy.mockRestore();
+  });
+
   it('sorts workspaces with sessions before those without', async () => {
     mockListWorkspaces.mockResolvedValueOnce(makeWorkspaceList('no-session', 'has-session'));
     mockGetWorkspaceSessions.mockResolvedValueOnce([{

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -5,6 +5,7 @@ import * as fsPromises from 'fs/promises';
 import { listWorkspaces } from '../utils/workspace-meta';
 import { getWorkspaceSessions } from '../utils/claude-sessions';
 import { logInfo, logError } from '../utils/logger';
+import { outputJson } from '../utils/output';
 import { colorize } from '../utils/colors';
 import inquirer from 'inquirer';
 import autocompletePrompt from 'inquirer-autocomplete-prompt';
@@ -31,12 +32,13 @@ export function registerListCommand(parent: Command) {
     .alias('l')
     .description('List workspaces and navigate to one')
     .option('-a, --archived', 'Show archived workspaces')
+    .option('--json', 'Output as JSON (no interactive selection)')
     .action(async (opts) => {
       await handleList(opts);
     });
 }
 
-async function handleList(opts: { archived?: boolean }) {
+async function handleList(opts: { archived?: boolean; json?: boolean }) {
   const showArchived = opts.archived ?? false;
   const title = showArchived ? 'Archived Workspaces' : 'Existing Workspaces';
 
@@ -49,6 +51,10 @@ async function handleList(opts: { archived?: boolean }) {
     ]);
 
     if (workspaces.length === 0) {
+      if (opts.json) {
+        outputJson({ archived: showArchived, count: 0, workspaces: [] });
+        return;
+      }
       console.log('\n' + '='.repeat(60));
       console.log(colorize(title, 'bright'));
       console.log('='.repeat(60) + '\n');
@@ -84,6 +90,23 @@ async function handleList(opts: { archived?: boolean }) {
       if (b.hasSession) return 1;
       return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
     });
+
+    // JSON mode: one document to stdout, no table, no interactive selection.
+    if (opts.json) {
+      outputJson({
+        archived: showArchived,
+        count: items.length,
+        workspaces: items.map(i => ({
+          name: i.name,
+          path: i.wsPath,
+          repoCount: i.repoCount,
+          createdAt: i.createdAt || null,
+          lastActive: i.lastActiveLabel,
+          hasSession: i.hasSession,
+        })),
+      });
+      return;
+    }
 
     console.log('');
     console.log(colorize('  ' + title, 'bright') + colorize('  (sorted by last active)', 'dim'));
@@ -172,5 +195,6 @@ async function handleList(opts: { archived?: boolean }) {
 export async function main() {
   const args = process.argv.slice(2);
   const archived = args.includes('--archived') || args.includes('-a');
-  await handleList({ archived });
+  const json = args.includes('--json');
+  await handleList({ archived, json });
 }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -4,6 +4,7 @@ import { WORKSPACES_DIR } from '../utils/config';
 import { loadMetadata } from '../utils/workspace-meta';
 import { getAllReposStatus } from '../utils/git-status';
 import { logError, logInfo, logStep } from '../utils/logger';
+import { outputJson } from '../utils/output';
 import { colorize } from '../utils/colors';
 import { resolveWorkspace } from '../utils/command-helpers';
 
@@ -78,13 +79,19 @@ export function registerStatusCommand(parent: Command) {
     .alias('st')
     .description('Show git status across all repos')
     .argument('[workspace]', 'Workspace name')
-    .action(async (workspace) => {
-      await handleStatus(workspace);
+    .option('--json', 'Output as JSON')
+    .action(async (workspace, opts) => {
+      await handleStatus(workspace, opts);
     });
 }
 
-async function handleStatus(workspaceArg?: string) {
+async function handleStatus(workspaceArg?: string, opts: { json?: boolean } = {}) {
   try {
+    // JSON mode is non-interactive: require an explicit workspace rather than prompt.
+    if (opts.json && !workspaceArg) {
+      logError('status --json requires a workspace name');
+      process.exit(1);
+    }
     const selectedWorkspace = await resolveWorkspace(workspaceArg);
     const workspacePath = path.join(WORKSPACES_DIR, selectedWorkspace);
     const metadata = await loadMetadata(workspacePath);
@@ -94,10 +101,23 @@ async function handleStatus(workspaceArg?: string) {
       process.exit(1);
     }
 
+    const repoDirectoryNames = metadata.repositories.map(r => r.directoryName);
+
+    if (opts.json) {
+      const statuses = await getAllReposStatus(workspacePath, repoDirectoryNames, 3);
+      outputJson({
+        workspace: selectedWorkspace,
+        path: workspacePath,
+        repoCount: statuses.length,
+        clean: statuses.every(s => s.clean),
+        repositories: statuses,
+      });
+      return;
+    }
+
     logStep(`Checking status for workspace: ${colorize(selectedWorkspace, 'cyan')}`);
     logInfo(`Found ${metadata.repositories.length} repositories`);
 
-    const repoDirectoryNames = metadata.repositories.map(r => r.directoryName);
     const statuses = await getAllReposStatus(workspacePath, repoDirectoryNames, 3);
 
     displayStatusTable(statuses);

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -4,7 +4,7 @@ import { WORKSPACES_DIR } from '../utils/config';
 import { loadMetadata } from '../utils/workspace-meta';
 import { getAllReposStatus } from '../utils/git-status';
 import { logError, logInfo, logStep } from '../utils/logger';
-import { outputJson } from '../utils/output';
+import { outputJson, outputJsonError } from '../utils/output';
 import { colorize } from '../utils/colors';
 import { resolveWorkspace } from '../utils/command-helpers';
 
@@ -86,10 +86,13 @@ export function registerStatusCommand(parent: Command) {
 }
 
 async function handleStatus(workspaceArg?: string, opts: { json?: boolean } = {}) {
+  // In --json mode, failures are parseable JSON on stdout + exit 1; otherwise a
+  // human log on stderr. `process.exit(1)` stays the last statement so TS still
+  // narrows `metadata` to non-null below.
   try {
     // JSON mode is non-interactive: require an explicit workspace rather than prompt.
     if (opts.json && !workspaceArg) {
-      logError('status --json requires a workspace name');
+      outputJsonError('status --json requires a workspace name');
       process.exit(1);
     }
     const selectedWorkspace = await resolveWorkspace(workspaceArg);
@@ -97,7 +100,8 @@ async function handleStatus(workspaceArg?: string, opts: { json?: boolean } = {}
     const metadata = await loadMetadata(workspacePath);
 
     if (!metadata) {
-      logError(`Workspace metadata not found for: ${selectedWorkspace}`);
+      if (opts.json) outputJsonError(`Workspace metadata not found for: ${selectedWorkspace}`);
+      else logError(`Workspace metadata not found for: ${selectedWorkspace}`);
       process.exit(1);
     }
 
@@ -122,9 +126,12 @@ async function handleStatus(workspaceArg?: string, opts: { json?: boolean } = {}
 
     displayStatusTable(statuses);
   } catch (error) {
-    logError('Failed to check workspace status');
-    if (error instanceof Error) {
-      logError(error.message);
+    const msg = error instanceof Error ? error.message : 'Failed to check workspace status';
+    if (opts.json) {
+      outputJsonError(msg);
+    } else {
+      logError('Failed to check workspace status');
+      if (error instanceof Error) logError(error.message);
     }
     process.exit(1);
   }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,5 +1,10 @@
 import { colors, colorize } from './colors';
 
+// Diagnostics (info/success/error/warn/step) go to STDERR so stdout carries only
+// a command's actual data — required for clean `--json` piping (nemus list
+// --json | jq …) and for non-TTY consumers. Use `outputJson`/stdout for data.
+const logStream = (line: string): void => console.error(line);
+
 const getTimestamp = (): string => {
   const now = new Date();
   return now.toLocaleTimeString('en-US', {
@@ -11,27 +16,27 @@ const getTimestamp = (): string => {
 };
 
 export const logInfo = (message: string): void => {
-  console.log(`${colors.gray}[${getTimestamp()}]${colors.reset} ${message}`);
+  logStream(`${colors.gray}[${getTimestamp()}]${colors.reset} ${message}`);
 };
 
 export const logSuccess = (message: string): void => {
-  console.log(`${colors.gray}[${getTimestamp()}]${colors.reset} ${colorize('✓', 'green')} ${message}`);
+  logStream(`${colors.gray}[${getTimestamp()}]${colors.reset} ${colorize('✓', 'green')} ${message}`);
 };
 
 export const logError = (message: string): void => {
-  console.log(`${colors.gray}[${getTimestamp()}]${colors.reset} ${colorize('✗', 'red')} ${message}`);
+  logStream(`${colors.gray}[${getTimestamp()}]${colors.reset} ${colorize('✗', 'red')} ${message}`);
 };
 
 export const logWarning = (message: string): void => {
-  console.log(`${colors.gray}[${getTimestamp()}]${colors.reset} ${colorize('⚠', 'yellow')} ${message}`);
+  logStream(`${colors.gray}[${getTimestamp()}]${colors.reset} ${colorize('⚠', 'yellow')} ${message}`);
 };
 
 export const logStep = (stepOrMessage: number | string, total?: number, message?: string): void => {
   if (typeof stepOrMessage === 'string') {
     // Single parameter version: just a message
-    console.log(`${colors.gray}[${getTimestamp()}]${colors.reset} ${colorize('▸', 'cyan')} ${stepOrMessage}`);
+    logStream(`${colors.gray}[${getTimestamp()}]${colors.reset} ${colorize('▸', 'cyan')} ${stepOrMessage}`);
   } else {
     // Three parameter version: step, total, message
-    console.log(`${colors.gray}[${getTimestamp()}]${colors.reset} ${colorize(`[${stepOrMessage}/${total}]`, 'cyan')} ${message}`);
+    logStream(`${colors.gray}[${getTimestamp()}]${colors.reset} ${colorize(`[${stepOrMessage}/${total}]`, 'cyan')} ${message}`);
   }
 };

--- a/src/utils/output.test.ts
+++ b/src/utils/output.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { outputJson, outputJsonError } from './output';
+
+function captureStdout(): { calls: string[]; restore: () => void } {
+  const calls: string[] = [];
+  const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: any) => {
+    calls.push(String(chunk));
+    return true;
+  });
+  return { calls, restore: () => spy.mockRestore() };
+}
+
+describe('outputJson', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('writes exactly one pretty JSON document + trailing newline to stdout', () => {
+    const { calls, restore } = captureStdout();
+    outputJson({ a: 1, b: ['x', 'y'] });
+    restore();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].endsWith('\n')).toBe(true);
+    expect(calls[0]).toBe(JSON.stringify({ a: 1, b: ['x', 'y'] }, null, 2) + '\n');
+    expect(JSON.parse(calls[0])).toEqual({ a: 1, b: ['x', 'y'] });
+  });
+});
+
+describe('outputJsonError', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('emits a parseable { ok:false, error } object to stdout', () => {
+    const { calls, restore } = captureStdout();
+    outputJsonError('boom');
+    restore();
+    expect(JSON.parse(calls[0])).toEqual({ ok: false, error: 'boom' });
+  });
+});

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -1,0 +1,20 @@
+/**
+ * Machine-readable output helpers. The one rule: a command's DATA goes to
+ * stdout, diagnostics go to stderr (see logger.ts). In `--json` mode a command
+ * writes exactly one JSON document to stdout and nothing else, so it pipes
+ * cleanly into `jq` and is safe for scripts/CI.
+ */
+
+/** Write one pretty-printed JSON document to stdout (data channel). */
+export function outputJson(data: unknown): void {
+  process.stdout.write(JSON.stringify(data, null, 2) + '\n');
+}
+
+/**
+ * Emit a structured error as JSON to stdout for `--json` callers (so a script
+ * parsing stdout gets a parseable object rather than a human log line on
+ * stderr), then signal failure via the returned exit code.
+ */
+export function outputJsonError(message: string): void {
+  outputJson({ ok: false, error: message });
+}

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -11,9 +11,10 @@ export function outputJson(data: unknown): void {
 }
 
 /**
- * Emit a structured error as JSON to stdout for `--json` callers (so a script
- * parsing stdout gets a parseable object rather than a human log line on
- * stderr), then signal failure via the returned exit code.
+ * Emit a structured error as JSON to stdout for `--json` callers, so a script
+ * parsing stdout always gets a parseable object (`{ ok: false, error }`) rather
+ * than empty stdout + a human log line on stderr. The caller still signals
+ * failure with a non-zero exit code.
  */
 export function outputJsonError(message: string): void {
   outputJson({ ok: false, error: message });


### PR DESCRIPTION
The first user-visible OSS-polish improvement to the **published** CLI: make `nemus` scriptable. Two intertwined changes shipped as one PR (a `--json` flag is only useful if stdout is clean).

## stdout/stderr hygiene
Diagnostic logs (`info`/`success`/`error`/`warning`/`step`) now go to **stderr** via a single `logStream()` in `logger.ts`; **stdout** is reserved for a command's actual data. The 44 data `console.log` sites are unchanged — only the logger moved. This is the standard CLI convention and is what lets `--json` pipe cleanly and non-TTY consumers separate data from progress.

## `--json` for the read-only reporting commands
- `list --json` → `{ archived, count, workspaces: [{ name, path, repoCount, createdAt, lastActive, hasSession }] }` — no table, no interactive selection (empty list included).
- `status --json` → `{ workspace, path, repoCount, clean, repositories: [...] }`.
- `doctor --json` → `{ workspace, score, status, checks: [...] }`.

Each emits exactly **one** JSON document to stdout. `status`/`doctor` with `--json` require an explicit workspace name (they never prompt — non-interactive by design). New `src/utils/output.ts` (`outputJson`/`outputJsonError`) is the single stdout data-channel helper.

## Verification
- **+2 tests → 437 core** pass; typecheck + build clean.
- Smoke-tested: `nemus list --json` emits valid, parseable JSON on stdout (111 real workspaces) with stderr clean; `| jq` works.
- The existing `console.log` spy tests (prompts/delete details) still pass — those assert on direct data output, which stays on stdout.

## Notes
- Version bumped **0.2.10 → 0.2.11** (shipped core change → triggers a release on merge; needs your `release` env approval).
- Follow-ups in this OSS-polish track: extend `--json` to `suite list`/`info`, and add shell completions (`nemus completion bash|zsh|fish`) — separate PRs.
