### PR TITLE
feat: --json for suite list, sessions, analyze-deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.12] - 2026-08-27
+
+### Added
+
+- **`--json` for more read-only reporting commands**, extending 0.2.11's set
+  (`list`/`status`/`doctor`) to `suite list`, `sessions`, and `analyze-deps`.
+  Each emits exactly one JSON document to stdout (no tables, no interactive
+  prompt): `suite list --json` (saved suites + entries), `sessions --json`
+  (workspace sessions, list-only — no resume), `analyze-deps --json` (per-repo
+  dependencies/dependents/missing + circular deps + suggested missing repos;
+  requires an explicit workspace). `--json` errors are parseable
+  `{ ok:false, error }` on stdout + exit 1, consistent with 0.2.11.
+
 ## [0.2.11] - 2026-08-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -225,18 +225,23 @@ shared-lib       main         ✓ Clean       ↓3             -
 
 ### Scripting: `--json`
 
-`list`, `status`, and `doctor` accept `--json` for stable, machine-readable
-output. Diagnostics go to stderr, so stdout is a single JSON document you can
-pipe straight into `jq` or a CI step:
+The read-only reporting commands accept `--json` for stable, machine-readable
+output: `list`, `status`, `doctor`, `suite list`, `sessions`, and
+`analyze-deps`. Diagnostics go to stderr, so stdout is a single JSON document
+you can pipe straight into `jq` or a CI step:
 
 ```bash
 nemus list --json | jq -r '.workspaces[].name'
 nemus status my-workspace --json | jq '.clean'
 nemus doctor my-workspace --json | jq '.score'
+nemus suite list --json | jq -r '.suites[].name'
+nemus sessions --json | jq -r '.sessions[].workspaceName'
+nemus analyze-deps my-workspace --json | jq '.circularDependencies'
 ```
 
-`status`/`doctor` with `--json` need an explicit workspace name (they never
-prompt).
+The workspace-scoped ones (`status`/`doctor`/`analyze-deps`) need an explicit
+workspace name with `--json` (they never prompt). On failure, `--json` prints a
+parseable `{ "ok": false, "error": … }` to stdout and exits non-zero.
 
 ### Suites (reusable repo collections)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nemus-cli/nemus",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "workspaces": [
     "packages/*"
   ],

--- a/src/commands/analyze-deps.ts
+++ b/src/commands/analyze-deps.ts
@@ -9,6 +9,7 @@ import {
   updateWorkspaceMetadata,
 } from '../utils/dependency-analyzer';
 import { logError, logInfo, logStep, logSuccess } from '../utils/logger';
+import { outputJson, outputJsonError } from '../utils/output';
 import { colorize } from '../utils/colors';
 import inquirer from 'inquirer';
 import { resolveWorkspace } from '../utils/command-helpers';
@@ -42,26 +43,53 @@ export function registerAnalyzeDepsCommand(parent: Command) {
     .alias('ad')
     .description('Analyze inter-repo dependencies')
     .argument('[workspace]', 'Workspace name')
-    .action(async (workspace) => {
-      await handleAnalyzeDeps(workspace);
+    .option('--json', 'Output as JSON (no interactive save)')
+    .action(async (workspace, opts) => {
+      await handleAnalyzeDeps(workspace, opts);
     });
 }
 
-async function handleAnalyzeDeps(workspaceArg?: string) {
+async function handleAnalyzeDeps(workspaceArg?: string, opts: { json?: boolean } = {}) {
   try {
+    // JSON mode is non-interactive: require an explicit workspace rather than prompt.
+    if (opts.json && !workspaceArg) {
+      outputJsonError('analyze-deps --json requires a workspace name');
+      process.exit(1);
+    }
     const selectedWorkspace = await resolveWorkspace(workspaceArg);
     const workspacePath = path.join(WORKSPACES_DIR, selectedWorkspace);
     const metadata = await loadMetadata(workspacePath);
 
     if (!metadata) {
-      logError(`Workspace metadata not found for: ${selectedWorkspace}`);
+      if (opts.json) outputJsonError(`Workspace metadata not found for: ${selectedWorkspace}`);
+      else logError(`Workspace metadata not found for: ${selectedWorkspace}`);
       process.exit(1);
+    }
+
+    const repoNames = metadata.repositories.map(r => r.name);
+
+    if (opts.json) {
+      const analyses = await analyzeDependencies(workspacePath, repoNames);
+      const cycles = detectCircularDependencies(analyses);
+      const missing = new Set<string>();
+      for (const [, a] of analyses) for (const dep of a.missingDependencies) missing.add(dep);
+      outputJson({
+        workspace: selectedWorkspace,
+        repositories: Array.from(analyses.entries()).map(([name, a]) => ({
+          name,
+          dependencies: a.dependencies,
+          dependents: a.dependents,
+          missingDependencies: a.missingDependencies,
+        })),
+        circularDependencies: cycles,
+        missingRepositories: Array.from(missing),
+      });
+      return;
     }
 
     logStep(`Analyzing dependencies for workspace: ${colorize(selectedWorkspace, 'cyan')}`);
     logInfo('Scanning package.json, Dockerfile, and docker-compose.yml files...');
 
-    const repoNames = metadata.repositories.map(r => r.name);
     const analyses = await analyzeDependencies(workspacePath, repoNames);
 
     displayDependencyAnalysis(analyses);
@@ -110,9 +138,11 @@ async function handleAnalyzeDeps(workspaceArg?: string) {
       }
     }
   } catch (error) {
-    logError('Failed to analyze dependencies');
-    if (error instanceof Error) {
-      logError(error.message);
+    if (opts.json) {
+      outputJsonError(error instanceof Error ? error.message : 'Failed to analyze dependencies');
+    } else {
+      logError('Failed to analyze dependencies');
+      if (error instanceof Error) logError(error.message);
     }
     process.exit(1);
   }

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs/promises';
 import { getWorkspaceSessions, WorkspaceSession } from '../utils/claude-sessions';
 import { listWorkspaces } from '../utils/workspace-meta';
 import { logError, logInfo } from '../utils/logger';
+import { outputJson, outputJsonError } from '../utils/output';
 import { colorize } from '../utils/colors';
 import inquirer from 'inquirer';
 import autocompletePrompt from 'inquirer-autocomplete-prompt';
@@ -20,16 +21,21 @@ export function registerSessionsCommand(parent: Command) {
     .command('sessions')
     .alias('ses')
     .description('Resume a Claude session in a workspace')
-    .action(async () => {
-      await handleSessions();
+    .option('--json', 'List sessions as JSON (no interactive resume)')
+    .action(async (opts) => {
+      await handleSessions(opts);
     });
 }
 
-async function handleSessions() {
+async function handleSessions(opts: { json?: boolean } = {}) {
   try {
     const sessions = await getWorkspaceSessions();
 
     if (sessions.length === 0) {
+      if (opts.json) {
+        outputJson({ count: 0, sessions: [] });
+        return;
+      }
       logInfo('No workspace sessions found.');
       console.log('\nYou can create a workspace with: nemus create');
       console.log('Or navigate to one with: w go');
@@ -45,6 +51,23 @@ async function handleSessions() {
       const repoLabel = repoCount > 0 ? `${repoCount} repos` : 'no repos';
       return { session, repoLabel };
     });
+
+    // JSON mode: list sessions to stdout, no resume prompt / temp-file writes.
+    if (opts.json) {
+      outputJson({
+        count: items.length,
+        sessions: items.map(i => ({
+          workspaceName: i.session.workspaceName,
+          workspacePath: i.session.workspacePath,
+          sessionId: i.session.sessionId,
+          agentType: i.session.agentType ?? null,
+          lastActive: i.session.lastActiveLabel,
+          lastActiveAt: i.session.lastActiveAt.toISOString(),
+          repoCount: workspaceMap.get(i.session.workspaceName)?.metadata?.repositories?.length ?? 0,
+        })),
+      });
+      return;
+    }
 
     const maxNameLen = Math.max(...items.map(i => i.session.workspaceName.length));
 
@@ -92,8 +115,12 @@ async function handleSessions() {
     console.log(`\n${colorize('Resuming:', 'green')} ${session.workspaceName} (last active ${session.lastActiveLabel})`);
   } catch (error) {
     if ((error as any)?.name === 'ExitPromptError') return;
-    logError('Failed to list sessions');
-    if (error instanceof Error) { logError(error.message); }
+    if (opts.json) {
+      outputJsonError(error instanceof Error ? error.message : 'Failed to list sessions');
+    } else {
+      logError('Failed to list sessions');
+      if (error instanceof Error) { logError(error.message); }
+    }
     process.exit(1);
   }
 }

--- a/src/commands/suite/index.ts
+++ b/src/commands/suite/index.ts
@@ -17,9 +17,10 @@ export function registerSuiteCommands(parent: Command) {
   suite
     .command('list')
     .description('List all saved suites')
-    .action(async () => {
+    .option('--json', 'Output as JSON')
+    .action(async (opts) => {
       const { main } = await import('./list');
-      await main();
+      await main(opts);
     });
 
   suite

--- a/src/commands/suite/list.test.ts
+++ b/src/commands/suite/list.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { mockListSuites } = vi.hoisted(() => ({ mockListSuites: vi.fn() }));
+
+vi.mock('../../utils/suite', () => ({ listSuites: mockListSuites }));
+vi.mock('../../utils/logger', () => ({ logInfo: vi.fn(), logError: vi.fn() }));
+vi.mock('../../utils/colors', () => ({ colorize: (t: string) => t }));
+
+import { main } from './list';
+
+function makeSuite(name: string, entries = 1) {
+  return {
+    name,
+    description: `${name} desc`,
+    entries: Array.from({ length: entries }, (_, i) => ({ directoryName: `repo-${i}`, repoName: `repo-${i}` })),
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-02T00:00:00.000Z',
+  };
+}
+
+describe('suite list --json', () => {
+  let writeSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('emits one valid JSON document with normalized suites', async () => {
+    mockListSuites.mockResolvedValueOnce([makeSuite('fees', 2), makeSuite('platform', 1)]);
+    await main({ json: true });
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(writeSpy.mock.calls[0][0] as string);
+    expect(payload.count).toBe(2);
+    expect(payload.suites[0]).toEqual({
+      name: 'fees',
+      description: 'fees desc',
+      repoCount: 2,
+      entries: [
+        { directoryName: 'repo-0', repoName: 'repo-0' },
+        { directoryName: 'repo-1', repoName: 'repo-1' },
+      ],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-02T00:00:00.000Z',
+    });
+  });
+
+  it('empty list emits count 0 (no header/log noise)', async () => {
+    mockListSuites.mockResolvedValueOnce([]);
+    await main({ json: true });
+    const payload = JSON.parse(writeSpy.mock.calls[0][0] as string);
+    expect(payload).toEqual({ count: 0, suites: [] });
+  });
+
+  it('non-json mode does not write to the stdout data channel', async () => {
+    mockListSuites.mockResolvedValueOnce([makeSuite('fees')]);
+    await main();
+    // human output goes through console.log (mocked), not process.stdout.write
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/suite/list.ts
+++ b/src/commands/suite/list.ts
@@ -2,15 +2,31 @@
 
 import { listSuites } from '../../utils/suite';
 import { logInfo, logError } from '../../utils/logger';
+import { outputJson, outputJsonError } from '../../utils/output';
 import { colorize } from '../../utils/colors';
 
-export async function main() {
-  console.log('\n' + '='.repeat(60));
-  console.log(colorize('Saved Suites', 'bright'));
-  console.log('='.repeat(60) + '\n');
-
+export async function main(opts: { json?: boolean } = {}) {
   try {
     const suites = await listSuites();
+
+    if (opts.json) {
+      outputJson({
+        count: suites.length,
+        suites: suites.map(s => ({
+          name: s.name,
+          description: s.description ?? null,
+          repoCount: s.entries.length,
+          entries: s.entries.map(e => ({ directoryName: e.directoryName, repoName: e.repoName })),
+          createdAt: s.createdAt,
+          updatedAt: s.updatedAt,
+        })),
+      });
+      return;
+    }
+
+    console.log('\n' + '='.repeat(60));
+    console.log(colorize('Saved Suites', 'bright'));
+    console.log('='.repeat(60) + '\n');
 
     if (suites.length === 0) {
       logInfo('No suites found');
@@ -43,9 +59,11 @@ export async function main() {
 
     console.log('='.repeat(60) + '\n');
   } catch (error) {
-    logError('Failed to list suites');
-    if (error instanceof Error) {
-      logError(error.message);
+    if (opts.json) {
+      outputJsonError(error instanceof Error ? error.message : 'Failed to list suites');
+    } else {
+      logError('Failed to list suites');
+      if (error instanceof Error) logError(error.message);
     }
     process.exit(1);
   }


### PR DESCRIPTION
Second step of the OSS-polish scripting track: extends the `--json` set shipped in 0.2.11 (`list`/`status`/`doctor`) to the remaining read-only reporting commands, with the exact same contract — one JSON document to stdout, diagnostics on stderr, no interactive prompt, and a parseable `{ ok: false, error }` on stdout + exit 1 on failure.

## New `--json` commands
- **`suite list --json`** → `{ count, suites: [{ name, description, repoCount, entries, createdAt, updatedAt }] }` (empty list handled).
- **`sessions --json`** → `{ count, sessions: [{ workspaceName, workspacePath, sessionId, agentType, lastActive, lastActiveAt, repoCount }] }` — **list-only**: no interactive resume, no temp-file writes (the command's normal side effect).
- **`analyze-deps --json`** → `{ workspace, repositories: [{ name, dependencies, dependents, missingDependencies }], circularDependencies, missingRepositories }` — requires an explicit workspace (never prompts) and skips the save-to-metadata prompt.

## Verification
- **+3 tests → 442 core** pass; typecheck + build clean.
- Smoke-tested all three against real data: `suite list --json` (2 suites), `sessions --json` (89 sessions, ISO `lastActiveAt`), `analyze-deps --json` (valid graph), and the no-workspace error path (`{ ok:false, error }` + exit 1).

## Notes
- Version **0.2.11 → 0.2.12** (shipped core change → triggers a release on merge; needs your `release` env approval).
- Remaining OSS-polish item after this: shell completions (`nemus completion bash|zsh|fish`).
