### PR TITLE
feat: nemus reflect — LLM-as-a-judge retrospective on recent sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-27
+
+### Added
+
+- **`nemus reflect` (alias `retro`) — LLM-as-a-judge retrospective.** Analyzes
+  your most recent workspaces (default 10) by reading their agent session
+  transcripts, distilling the human prompts + tool failures + tools used, and
+  asking your own configured agent (claude/pi/opencode — no API key of ours) to
+  recommend concrete setup improvements: which **skills** to add and where,
+  missing **AGENTS.md/context** rules, missing **connectivity/smoke tests**, and
+  **prompt/workflow** habits to change — each with a priority and a concrete
+  example snippet. Reads both Claude and pi transcript formats. Flags:
+  `--limit <n>`, `--json` (structured report, same `{ok:false,error}` failure
+  contract as the other JSON commands), and `--dry-run` (print the assembled
+  corpus + judge prompt without calling the agent). Idea courtesy of
+  **@lightpriest** — thank you for the great suggestion!
+
 ## [0.2.13] - 2026-08-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -280,6 +280,23 @@ nemus snapshot save ws        # (ss) capture exact branches/commits/dirty state
 nemus snapshot restore <id>   # (sr)
 ```
 
+### Reflect — improve your setup over time
+
+```bash
+nemus reflect                 # (retro) analyze your last 10 workspaces' sessions
+nemus reflect --limit 5       # narrow the window
+nemus reflect --json          # structured report for tooling
+nemus reflect --dry-run       # show what the judge sees, without calling the agent
+```
+
+`reflect` reads your recent agent **session transcripts** (Claude + pi), distills
+the prompts you sent, the failures the agent hit, and the tools it used, then asks
+**your own configured agent** (LLM-as-a-judge — no extra API key) to recommend
+concrete improvements: which **skills** to add and where, missing
+**AGENTS.md/context** rules, missing **connectivity/smoke tests**, and
+**prompt/workflow** habits — each with a priority and an example snippet. It's a
+fast retrospective on *how you drive the agent*, so next time works better.
+
 ### AI assistant
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.2.13",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nemus-cli/nemus",
-      "version": "0.2.13",
+      "version": "0.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.2.13",
+  "version": "0.3.0",
   "workspaces": [
     "packages/*"
   ],

--- a/src/cli/ai-prompt.ts
+++ b/src/cli/ai-prompt.ts
@@ -1,4 +1,5 @@
 import { spawn, execFile, execFileSync } from 'child_process';
+import { parseAgentJson } from '../utils/agent-judge';
 import { promisify } from 'util';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -259,32 +260,21 @@ export async function extractIntent(prompt: string): Promise<ExtractedIntent> {
     result = runExtraction('pi', [...piLean, ...piCore], piCore);
   }
 
-  // Strip markdown code fences if present (Pi may wrap JSON in ```json...```)
-  let jsonStr = result.trim();
-  const fenceMatch = jsonStr.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
-  if (fenceMatch) {
-    jsonStr = fenceMatch[1].trim();
-  }
-
-  const parsed = JSON.parse(jsonStr);
-
-  // Handle different output formats:
-  // - Claude: { structured_output: {...} } or { result: "..." }
-  // - Pi: may return the object directly or wrap it
+  // Unwrap the agent's reply (code fences + the structured_output / result-string
+  // / result-object / bare-object envelopes) with the shared parser, so this and
+  // the reflect judge can't drift when a new agent shape is learned. The
+  // extraction-specific INVOCATION (lean flags + tailored timeout/auth errors)
+  // deliberately stays here — those messages are part of the `nemus --` UX.
   let intent: ExtractedIntent | undefined;
-  if (parsed.structured_output) {
-    intent = parsed.structured_output;
-  } else if (typeof parsed.result === 'string' && parsed.result) {
-    try { intent = JSON.parse(parsed.result); } catch { /* ignore */ }
-  } else if (typeof parsed.result === 'object' && parsed.result !== null) {
-    intent = parsed.result;
-  } else if (parsed.workspaceName || parsed.repos || parsed.remainingIntent !== undefined) {
-    // Pi may return the extracted object directly
-    intent = parsed;
+  try {
+    const parsed = parseAgentJson(result) as any;
+    if (parsed && typeof parsed === 'object') intent = parsed;
+  } catch {
+    throw new Error(`Could not extract intent from agent response: ${result.slice(0, 200)}`);
   }
 
   if (!intent) {
-    throw new Error(`Could not extract intent from agent response. Parsed: ${JSON.stringify(parsed).slice(0, 200)}`);
+    throw new Error(`Could not extract intent from agent response: ${result.slice(0, 200)}`);
   }
 
   // Coerce/validate field types so malformed model output can't crash the

--- a/src/commands/reflect.ts
+++ b/src/commands/reflect.ts
@@ -1,0 +1,120 @@
+import { Command } from 'commander';
+import { logError, logInfo, logStep } from '../utils/logger';
+import { outputJson, outputJsonError } from '../utils/output';
+import { colorize } from '../utils/colors';
+import {
+  gatherReflectionCorpus,
+  buildJudgePrompt,
+  parseReflectionReport,
+  REFLECT_SCHEMA,
+  ReflectionReport,
+  Recommendation,
+} from '../utils/reflect';
+import { runAgentJson } from '../utils/agent-judge';
+
+export function registerReflectCommand(parent: Command) {
+  parent
+    .command('reflect')
+    .alias('retro')
+    .description('Analyze your recent workspace sessions and suggest skill/prompt/context improvements (LLM-as-a-judge)')
+    .option('-n, --limit <n>', 'How many recent workspaces to analyze', '10')
+    .option('--json', 'Output the report as JSON')
+    .option('--dry-run', 'Print the assembled corpus + judge prompt without calling the agent')
+    .action(async (opts) => {
+      await handleReflect(opts);
+    });
+}
+
+async function handleReflect(opts: { limit?: string; json?: boolean; dryRun?: boolean }) {
+  const limit = Math.max(1, Number.parseInt(opts.limit ?? '10', 10) || 10);
+  try {
+    if (!opts.json && !opts.dryRun) {
+      logStep(`Analyzing your ${colorize(String(limit), 'cyan')} most recent workspaces…`);
+      logInfo('Reading sessions and distilling prompts + failures…');
+    }
+
+    const corpus = await gatherReflectionCorpus(limit);
+    const withSessions = corpus.workspaces.filter((w) => w.session).length;
+    const prompt = buildJudgePrompt(corpus);
+
+    if (opts.dryRun) {
+      // No LLM call — surface exactly what the judge would see.
+      if (opts.json) outputJson({ corpus, prompt });
+      else {
+        process.stdout.write(prompt + '\n');
+      }
+      return;
+    }
+
+    if (withSessions === 0) {
+      const msg = 'No recent agent sessions found to analyze (need Claude/pi session transcripts).';
+      if (opts.json) outputJsonError(msg);
+      else logError(msg);
+      process.exit(1);
+    }
+
+    if (!opts.json) logInfo(`Judging ${withSessions} session(s) with your configured agent…`);
+    const parsed = runAgentJson(prompt, { schema: REFLECT_SCHEMA });
+    const report = parseReflectionReport(parsed);
+
+    if (opts.json) {
+      outputJson({ analyzed: withSessions, workspaces: corpus.workspaces.length, ...report });
+      return;
+    }
+    printReport(report, corpus.workspaces.length, withSessions);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'reflect failed';
+    if (opts.json) outputJsonError(msg);
+    else {
+      logError('Failed to analyze sessions');
+      logError(msg);
+    }
+    process.exit(1);
+  }
+}
+
+const KIND_LABEL: Record<Recommendation['kind'], string> = {
+  skill: 'Skill',
+  context: 'Context/AGENTS.md',
+  test: 'Test',
+  prompt: 'Prompt',
+  connectivity: 'Connectivity',
+  workflow: 'Workflow',
+  other: 'Other',
+};
+
+function priorityBadge(p: Recommendation['priority']): string {
+  if (p === 'high') return colorize('● high', 'red');
+  if (p === 'medium') return colorize('● med', 'yellow');
+  return colorize('● low', 'gray');
+}
+
+function printReport(report: ReflectionReport, workspaces: number, analyzed: number) {
+  console.log('');
+  console.log(colorize('  Reflection', 'bright') + colorize(`  (${analyzed} sessions across ${workspaces} workspaces)`, 'dim'));
+  console.log(colorize('  ' + '─'.repeat(56), 'dim'));
+  if (report.summary) {
+    console.log('\n  ' + report.summary.replace(/\n/g, '\n  '));
+  }
+
+  if (report.recommendations.length === 0) {
+    console.log('\n  ' + colorize('No specific recommendations — looks solid.', 'green') + '\n');
+    return;
+  }
+
+  // High priority first.
+  const order = { high: 0, medium: 1, low: 2 };
+  const recs = [...report.recommendations].sort((a, b) => order[a.priority] - order[b.priority]);
+
+  console.log('');
+  for (const r of recs) {
+    const target = r.target ? colorize(`  [${r.target}]`, 'cyan') : '';
+    console.log(`  ${priorityBadge(r.priority)}  ${colorize(KIND_LABEL[r.kind], 'bright')}  ${r.title}${target}`);
+    if (r.detail) console.log(`      ${r.detail.replace(/\n/g, '\n      ')}`);
+    if (r.example) {
+      console.log(colorize('      example:', 'dim'));
+      console.log(colorize(r.example.replace(/^/gm, '        '), 'dim'));
+    }
+    console.log('');
+  }
+}

--- a/src/program.ts
+++ b/src/program.ts
@@ -59,6 +59,7 @@ import { registerSaveContextCommand } from './commands/save-context';
 import { registerMigrateCommand } from './commands/migrate';
 import { registerReportBugCommand } from './commands/report-bug';
 import { registerCompletionCommand } from './commands/completion';
+import { registerReflectCommand } from './commands/reflect';
 
 registerCreateCommand(program);
 registerListCommand(program);
@@ -84,6 +85,7 @@ registerSaveContextCommand(program);
 registerMigrateCommand(program);
 registerReportBugCommand(program);
 registerCompletionCommand(program);
+registerReflectCommand(program);
 
 // Register TUI (delegates to existing Ink/React implementation)
 program

--- a/src/utils/agent-judge.test.ts
+++ b/src/utils/agent-judge.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { parseAgentJson, runAgentRaw } from './agent-judge';
+
+describe('parseAgentJson', () => {
+  it('unwraps the common agent envelopes and shapes', () => {
+    expect(parseAgentJson('{"a":1}')).toEqual({ a: 1 }); // bare object
+    expect(parseAgentJson(J({ structured_output: { a: 2 } }))).toEqual({ a: 2 }); // claude structured
+    expect(parseAgentJson(J({ result: J({ a: 3 }) }))).toEqual({ a: 3 }); // result-as-json-string
+    expect(parseAgentJson(J({ result: { a: 4 } }))).toEqual({ a: 4 }); // result-as-object
+    expect(parseAgentJson('```json\n{"a":5}\n```')).toEqual({ a: 5 }); // fenced
+    expect(parseAgentJson('noise before {"a":6} after')).toEqual({ a: 6 }); // outermost span fallback
+  });
+
+  it('throws when there is no JSON at all', () => {
+    expect(() => parseAgentJson('totally not json')).toThrow(/did not return JSON/);
+  });
+});
+
+describe('runAgentRaw', () => {
+  it('claude: passes the schema + lean flags, falls back on a rejected flag', () => {
+    const calls: string[][] = [];
+    const exec = (cmd: string, args: string[]) => {
+      calls.push([cmd, ...args]);
+      if (calls.length === 1) throw new Error('unknown flag --json-schema'); // old claude
+      return '{"ok":true}';
+    };
+    const out = runAgentRaw('PROMPT', { agentType: 'claude', schema: '{"type":"object"}', exec });
+    expect(out).toBe('{"ok":true}');
+    // first (preferred) attempt carries the schema + structured flags…
+    expect(calls[0]).toEqual(expect.arrayContaining(['claude', '-p', 'PROMPT', '--output-format', 'json', '--json-schema', '{"type":"object"}']));
+    // …the fallback is the plainest form
+    expect(calls[1]).toEqual(['claude', '-p', 'PROMPT']);
+  });
+
+  it('pi: runs with lean flags', () => {
+    let seen: string[] = [];
+    const exec = (cmd: string, args: string[]) => {
+      seen = [cmd, ...args];
+      return 'ok';
+    };
+    runAgentRaw('P', { agentType: 'pi', exec });
+    expect(seen).toEqual(expect.arrayContaining(['pi', '--no-extensions', '--no-skills', '--no-tools', '-p', 'P']));
+  });
+
+  it('wraps a hard failure in a clear error', () => {
+    const exec = () => { throw Object.assign(new Error('boom'), { stderr: 'agent exploded' }); };
+    // pi retries once (lean → plain), then throws
+    expect(() => runAgentRaw('P', { agentType: 'pi', exec })).toThrow(/agent judge failed \(pi\): agent exploded/);
+  });
+});
+
+function J(o: unknown) {
+  return JSON.stringify(o);
+}

--- a/src/utils/agent-judge.ts
+++ b/src/utils/agent-judge.ts
@@ -1,0 +1,109 @@
+import { execFileSync } from 'child_process';
+import { getPrimaryAgent } from './agent-config';
+
+/**
+ * Run the user's configured coding agent headlessly as an "LLM-as-a-judge":
+ * feed it a prompt, get back a parsed JSON object. This reuses whatever agent
+ * the user already has authenticated (claude / pi / opencode) — no API keys of
+ * our own. It mirrors the lean, structured invocation used for intent
+ * extraction, but generalized (any prompt + optional JSON schema).
+ *
+ * The call is bounded by a timeout and a large maxBuffer; a transcript-analysis
+ * judge returns more than intent extraction, so the buffer is generous.
+ */
+export interface JudgeOptions {
+  /** JSON schema string passed to `claude --json-schema` (ignored by others). */
+  schema?: string;
+  timeoutMs?: number;
+  maxBuffer?: number;
+  /** Injected for tests. Defaults to the real child_process runner. */
+  exec?: (cmd: string, args: string[], opts: { timeout: number; maxBuffer: number }) => string;
+  /** Injected for tests. Defaults to the configured primary agent. */
+  agentType?: 'claude' | 'pi' | 'opencode' | 'codex' | 'gemini';
+}
+
+const DEFAULT_TIMEOUT_MS = 180_000; // judging N transcripts is heavier than extraction
+const DEFAULT_MAX_BUFFER = 32 * 1024 * 1024;
+
+/**
+ * Invoke the agent with `prompt` and return the raw stdout. Throws a clear error
+ * on timeout / non-zero exit. Kept separate from parsing so callers can inspect
+ * raw output (e.g. `--dry-run`, debugging).
+ */
+export function runAgentRaw(prompt: string, opts: JudgeOptions = {}): string {
+  const agentType = opts.agentType ?? getPrimaryAgent().type;
+  const timeout = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxBuffer = opts.maxBuffer ?? DEFAULT_MAX_BUFFER;
+  const exec =
+    opts.exec ??
+    ((cmd, args, o) => execFileSync(cmd, args, { encoding: 'utf-8', timeout: o.timeout, maxBuffer: o.maxBuffer }));
+
+  const attempt = (cmd: string, args: string[]) => exec(cmd, args, { timeout, maxBuffer });
+
+  try {
+    if (agentType === 'claude') {
+      const preferred = ['-p', prompt, '--output-format', 'json', '--bare', '--strict-mcp-config', '--disable-slash-commands'];
+      if (opts.schema) preferred.push('--json-schema', opts.schema);
+      try {
+        return attempt('claude', preferred);
+      } catch {
+        // Older claude may reject the newer flags — fall back to the plainest form.
+        return attempt('claude', ['-p', prompt]);
+      }
+    }
+    if (agentType === 'opencode') {
+      return attempt('opencode', ['run', prompt]);
+    }
+    // pi (and any other): run as lean as possible so a bloated env can't hang it.
+    const piLean = ['--no-extensions', '--no-skills', '--no-prompt-templates', '--no-context-files', '--no-tools', '--no-session'];
+    try {
+      return attempt('pi', [...piLean, '-p', prompt]);
+    } catch {
+      return attempt('pi', ['-p', prompt]);
+    }
+  } catch (err: any) {
+    const detail = (err?.stderr || err?.stdout || err?.message || 'unknown error').toString().trim().slice(0, 500);
+    throw new Error(`agent judge failed (${agentType}): ${detail}`);
+  }
+}
+
+/**
+ * Run the agent and parse its reply as JSON, tolerating the shapes different
+ * agents emit: `{ structured_output }`, `{ result: "<json>" }`, a ```json fence,
+ * or a bare object. Returns `unknown`; callers validate/normalize their shape.
+ */
+export function runAgentJson(prompt: string, opts: JudgeOptions = {}): unknown {
+  const raw = runAgentRaw(prompt, opts);
+  return parseAgentJson(raw);
+}
+
+/** Extract a JSON object from an agent's raw stdout. Exported for tests. */
+export function parseAgentJson(raw: string): unknown {
+  let text = raw.trim();
+  const fence = text.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
+  if (fence) text = fence[1].trim();
+
+  let parsed: any;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    // Last resort: grab the outermost {...} span.
+    const span = text.match(/\{[\s\S]*\}/);
+    if (!span) throw new Error('agent did not return JSON');
+    parsed = JSON.parse(span[0]);
+  }
+
+  // Unwrap the common agent envelopes.
+  if (parsed && typeof parsed === 'object') {
+    if (parsed.structured_output && typeof parsed.structured_output === 'object') return parsed.structured_output;
+    if (typeof parsed.result === 'string') {
+      try {
+        return JSON.parse(parsed.result);
+      } catch {
+        /* fall through — result was plain text, return the envelope */
+      }
+    }
+    if (parsed.result && typeof parsed.result === 'object') return parsed.result;
+  }
+  return parsed;
+}

--- a/src/utils/reflect.test.ts
+++ b/src/utils/reflect.test.ts
@@ -21,14 +21,23 @@ describe('distillTranscript', () => {
       J({ type: 'user', message: { role: 'user', content: [{ type: 'tool_result', is_error: true, content: 'file not found' }] } }),
       // a system-reminder-style user text → ignored as a prompt
       J({ type: 'message', message: { role: 'user', content: '<system-reminder>ignore me</system-reminder>' } }),
+      // UNFLAGGED benign result whose text merely mentions "error" → NOT a failure
+      J({ type: 'message', message: { role: 'toolResult', toolName: 'grep', content: [{ type: 'text', text: '0 results for error' }] } }),
+      // UNFLAGGED result with a strong failure signal → a failure (regex fallback)
+      J({ type: 'message', message: { role: 'toolResult', toolName: 'git', content: [{ type: 'text', text: 'fatal: not a git repository' }] } }),
+      // EXPLICITLY not-an-error, despite failing-looking text → trust the flag
+      J({ type: 'message', message: { role: 'toolResult', isError: false, content: [{ type: 'text', text: 'fatal: boom (but flagged success)' }] } }),
     ].join('\n');
 
     const d = distillTranscript(lines, { sessionId: 's1', agentType: 'pi' });
     expect(d.turns).toBe(2);
     expect(d.userPrompts).toEqual(['do the thing', 'claude style prompt']);
-    expect(d.tools.sort()).toEqual(['Edit', 'bash']);
-    expect(d.errors).toContain('command failed: boom');
-    expect(d.errors).toContain('file not found');
+    expect(d.tools.sort()).toEqual(['Edit', 'bash', 'git', 'grep']);
+    expect(d.errors).toContain('command failed: boom'); // explicit isError:true
+    expect(d.errors).toContain('file not found'); // explicit is_error:true
+    expect(d.errors).toContain('fatal: not a git repository'); // unflagged + strong signal
+    expect(d.errors).not.toContain('0 results for error'); // unflagged benign 'error' mention
+    expect(d.errors.some((e) => e.includes('flagged success'))).toBe(false); // isError:false trusted
   });
 
   it('is bounded and tolerant of empty input', () => {

--- a/src/utils/reflect.test.ts
+++ b/src/utils/reflect.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { distillTranscript, buildJudgePrompt, parseReflectionReport, ReflectionCorpus } from './reflect';
+
+const J = (o: unknown) => JSON.stringify(o);
+
+describe('distillTranscript', () => {
+  it('extracts prompts, tools, errors, and turns across pi + claude shapes', () => {
+    const lines = [
+      'not json — skipped',
+      // pi: user prompt
+      J({ type: 'message', message: { role: 'user', content: [{ type: 'text', text: 'do the thing' }] } }),
+      // pi: assistant with a toolCall
+      J({ type: 'message', message: { role: 'assistant', content: [{ type: 'toolCall', name: 'bash' }] } }),
+      // pi: tool result flagged as error
+      J({ type: 'message', message: { role: 'toolResult', toolName: 'bash', isError: true, content: [{ type: 'text', text: 'command failed: boom' }] } }),
+      // claude: user prompt as plain string
+      J({ type: 'user', message: { role: 'user', content: 'claude style prompt' } }),
+      // claude: assistant tool_use
+      J({ type: 'assistant', message: { role: 'assistant', content: [{ type: 'tool_use', name: 'Edit' }] } }),
+      // claude: tool_result-only user message → an error, NOT a prompt
+      J({ type: 'user', message: { role: 'user', content: [{ type: 'tool_result', is_error: true, content: 'file not found' }] } }),
+      // a system-reminder-style user text → ignored as a prompt
+      J({ type: 'message', message: { role: 'user', content: '<system-reminder>ignore me</system-reminder>' } }),
+    ].join('\n');
+
+    const d = distillTranscript(lines, { sessionId: 's1', agentType: 'pi' });
+    expect(d.turns).toBe(2);
+    expect(d.userPrompts).toEqual(['do the thing', 'claude style prompt']);
+    expect(d.tools.sort()).toEqual(['Edit', 'bash']);
+    expect(d.errors).toContain('command failed: boom');
+    expect(d.errors).toContain('file not found');
+  });
+
+  it('is bounded and tolerant of empty input', () => {
+    expect(distillTranscript('', { sessionId: 's', agentType: 'pi' })).toMatchObject({
+      turns: 0,
+      userPrompts: [],
+      errors: [],
+      tools: [],
+    });
+  });
+});
+
+const corpus: ReflectionCorpus = {
+  generatedAt: '2026-01-01T00:00:00Z',
+  availableSkills: ['redash', 'datadog'],
+  workspaces: [
+    {
+      name: 'pay-app',
+      repoCount: 1,
+      repos: ['api'],
+      contextFiles: ['AGENTS.md'],
+      session: { sessionId: 's', agentType: 'pi', turns: 12, userPrompts: ['fix the sync bug'], errors: ['gh_pr_create: not a git repository'], tools: ['bash', 'edit'] },
+    },
+    { name: 'empty-ws', repoCount: 0, repos: [], contextFiles: [], session: null },
+  ],
+};
+
+describe('buildJudgePrompt', () => {
+  const p = buildJudgePrompt(corpus);
+  it('frames the judge task and includes the evidence + guardrails', () => {
+    expect(p).toContain('LLM as a judge');
+    expect(p).toContain('redash, datadog'); // available skills (do not re-suggest)
+    expect(p).toContain('## pay-app');
+    expect(p).toContain('fix the sync bug');
+    expect(p).toContain('gh_pr_create: not a git repository');
+    expect(p).toContain('no recent agent session found'); // empty-ws
+    expect(p).toContain('context files: NONE'); // empty-ws has none
+    expect(p).toMatch(/ONLY a JSON object/);
+  });
+});
+
+describe('parseReflectionReport', () => {
+  it('normalizes, clamps enums, and drops empty recs', () => {
+    const report = parseReflectionReport({
+      summary: 'ok',
+      recommendations: [
+        { kind: 'skill', title: 'Add X', detail: 'because Y', priority: 'high', target: ' api ', example: 'stub' },
+        { kind: 'bogus', title: 'clamp me', detail: 'd', priority: 'urgent' }, // kind→other, priority→medium
+        { title: '', detail: '' }, // dropped
+        'garbage', // dropped
+      ],
+    });
+    expect(report.summary).toBe('ok');
+    expect(report.recommendations).toHaveLength(2);
+    expect(report.recommendations[0]).toEqual({ kind: 'skill', title: 'Add X', detail: 'because Y', priority: 'high', target: 'api', example: 'stub' });
+    expect(report.recommendations[1]).toMatchObject({ kind: 'other', priority: 'medium', title: 'clamp me' });
+  });
+
+  it('tolerates a malformed top-level object', () => {
+    expect(parseReflectionReport(null)).toEqual({ summary: '', recommendations: [] });
+    expect(parseReflectionReport({ recommendations: 'nope' })).toEqual({ summary: '', recommendations: [] });
+  });
+});

--- a/src/utils/reflect.ts
+++ b/src/utils/reflect.ts
@@ -73,7 +73,22 @@ function contentToText(content: unknown): string {
   return '';
 }
 
-const ERROR_RE = /\b(error|failed|not found|denied|permission|exception|timed out|cannot|unable to)\b/i;
+// Only used as a FALLBACK when a tool result carries no explicit error flag.
+// Kept to strong failure signals so a successful grep/log line for the word
+// "error", or a passing test named “…error…”, isn't mistaken for a failure.
+const ERROR_RE = /\b(fatal|failed|failure|exception|traceback|denied|not a git repository|timed out|exit code\s+[1-9])\b/i;
+
+/**
+ * Decide whether a tool result is a failure: trust the explicit `isError` flag
+ * when present (true => failure, false => success), and only guess from the
+ * text when there's no flag at all. This keeps the judge's “evidence” to real
+ * failures instead of any output that happens to contain the word “error”.
+ */
+function isToolFailure(flag: unknown, text: string): boolean {
+  if (flag === true) return true;
+  if (flag === false) return false;
+  return ERROR_RE.test(text);
+}
 
 /**
  * Distill a raw `.jsonl` transcript into the signals a judge needs: the human
@@ -120,7 +135,7 @@ export function distillTranscript(
     if (role === 'toolResult') {
       if (typeof msg.toolName === 'string') tools.add(msg.toolName);
       const text = contentToText(content);
-      if ((msg.isError || msg.is_error || ERROR_RE.test(text)) && text.trim() && errors.length < MAX_ERRORS) {
+      if (isToolFailure(msg.isError ?? msg.is_error, text) && text.trim() && errors.length < MAX_ERRORS) {
         errors.push(text.trim().slice(0, ERROR_CHARS));
       }
     }
@@ -128,7 +143,7 @@ export function distillTranscript(
       for (const b of content) {
         if (b && b.type === 'tool_result') {
           const text = contentToText(b.content);
-          if ((b.is_error || ERROR_RE.test(text)) && text.trim() && errors.length < MAX_ERRORS) {
+          if (isToolFailure(b.is_error, text) && text.trim() && errors.length < MAX_ERRORS) {
             errors.push(text.trim().slice(0, ERROR_CHARS));
           }
         }

--- a/src/utils/reflect.ts
+++ b/src/utils/reflect.ts
@@ -1,0 +1,370 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { WORKSPACES_DIR } from './config';
+import { listWorkspaces } from './workspace-meta';
+import { getActiveAgents, getSkillsTargetDirs, getAllKnownContextFileNames, ConcreteAgentType } from './agent-config';
+import { pathToProjectDirName } from './claude-sessions';
+
+// ------------------------------------------------------------------ types
+
+export interface SessionDigest {
+  sessionId: string;
+  agentType: string;
+  /** Number of assistant turns (a rough measure of how much back-and-forth). */
+  turns: number;
+  /** Human prompts the user sent (the raw material for judging prompt quality). */
+  userPrompts: string[];
+  /** Error/failure snippets from tool results (missing skills/tests show up here). */
+  errors: string[];
+  /** Distinct tool names the agent used. */
+  tools: string[];
+}
+
+export interface WorkspaceDigest {
+  name: string;
+  repoCount: number;
+  repos: string[];
+  /** Context files present at the workspace root, e.g. ['AGENTS.md']. */
+  contextFiles: string[];
+  session: SessionDigest | null;
+}
+
+export interface ReflectionCorpus {
+  generatedAt: string;
+  /** Skills already installed globally (so the judge suggests real gaps). */
+  availableSkills: string[];
+  workspaces: WorkspaceDigest[];
+}
+
+export type RecommendationKind =
+  | 'skill' | 'context' | 'test' | 'prompt' | 'connectivity' | 'workflow' | 'other';
+
+export interface Recommendation {
+  kind: RecommendationKind;
+  title: string;
+  detail: string;
+  /** Where it applies — a workspace, repo, or path (optional). */
+  target?: string;
+  priority: 'high' | 'medium' | 'low';
+  /** A concrete snippet (skill stub, AGENTS.md rule, test idea). */
+  example?: string;
+}
+
+export interface ReflectionReport {
+  summary: string;
+  recommendations: Recommendation[];
+}
+
+// --------------------------------------------------------- transcript distill
+
+const MAX_PROMPTS = 25;
+const MAX_ERRORS = 25;
+const PROMPT_CHARS = 600;
+const ERROR_CHARS = 300;
+
+/** Flatten a message `content` (string or content-block array) to plain text. */
+function contentToText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((b: any) => (b && b.type === 'text' && typeof b.text === 'string' ? b.text : ''))
+      .filter(Boolean)
+      .join('\n');
+  }
+  return '';
+}
+
+const ERROR_RE = /\b(error|failed|not found|denied|permission|exception|timed out|cannot|unable to)\b/i;
+
+/**
+ * Distill a raw `.jsonl` transcript into the signals a judge needs: the human
+ * prompts, tool failures, and which tools ran. Pure (operates on file content),
+ * defensive about the several line shapes Claude/pi emit, and bounded so a huge
+ * transcript can't blow the prompt budget.
+ */
+export function distillTranscript(
+  raw: string,
+  meta: { sessionId: string; agentType: string },
+): SessionDigest {
+  const userPrompts: string[] = [];
+  const errors: string[] = [];
+  const tools = new Set<string>();
+  let turns = 0;
+
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let obj: any;
+    try {
+      obj = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+
+    const msg = obj.message ?? obj;
+    const role = msg?.role ?? obj?.type;
+    const content = msg?.content;
+
+    // Assistant turn + tool uses. Claude uses `tool_use` blocks; pi uses `toolCall`.
+    if (role === 'assistant') {
+      turns++;
+      if (Array.isArray(content)) {
+        for (const b of content) {
+          if (b && (b.type === 'tool_use' || b.type === 'toolCall') && typeof b.name === 'string') tools.add(b.name);
+        }
+      }
+    }
+
+    // Tool results, two shapes:
+    //  - pi: a top-level message with role 'toolResult' (+ toolName, content).
+    //  - Claude: a `tool_result` block inside a user message's content array.
+    if (role === 'toolResult') {
+      if (typeof msg.toolName === 'string') tools.add(msg.toolName);
+      const text = contentToText(content);
+      if ((msg.isError || msg.is_error || ERROR_RE.test(text)) && text.trim() && errors.length < MAX_ERRORS) {
+        errors.push(text.trim().slice(0, ERROR_CHARS));
+      }
+    }
+    if (Array.isArray(content)) {
+      for (const b of content) {
+        if (b && b.type === 'tool_result') {
+          const text = contentToText(b.content);
+          if ((b.is_error || ERROR_RE.test(text)) && text.trim() && errors.length < MAX_ERRORS) {
+            errors.push(text.trim().slice(0, ERROR_CHARS));
+          }
+        }
+      }
+    }
+
+    // Human prompts: a user message that carries actual text (not a tool_result echo).
+    if (role === 'user') {
+      const isToolResultOnly =
+        Array.isArray(content) && content.length > 0 && content.every((b: any) => b?.type === 'tool_result');
+      if (!isToolResultOnly) {
+        const text = contentToText(content).trim();
+        if (text && !text.startsWith('<') && userPrompts.length < MAX_PROMPTS) {
+          userPrompts.push(text.slice(0, PROMPT_CHARS));
+        }
+      }
+    }
+  }
+
+  return { sessionId: meta.sessionId, agentType: meta.agentType, turns, userPrompts, errors, tools: [...tools] };
+}
+
+// --------------------------------------------------------- corpus gathering
+
+/** Locate the most recent `.jsonl` transcript for a workspace under an agent. */
+export async function findLatestTranscriptFile(
+  sessionProjectsDir: string,
+  workspacePath: string,
+  agentType: ConcreteAgentType,
+): Promise<string | null> {
+  if (agentType !== 'claude' && agentType !== 'pi') return null;
+  const projDir = path.join(sessionProjectsDir, pathToProjectDirName(workspacePath, agentType));
+  let entries: string[];
+  try {
+    entries = await fs.readdir(projDir);
+  } catch {
+    return null;
+  }
+  const jsonl = entries.filter((f) => f.endsWith('.jsonl'));
+  if (jsonl.length === 0) return null;
+  const stats = await Promise.all(
+    jsonl.map(async (f) => {
+      try {
+        return { f, mtime: (await fs.stat(path.join(projDir, f))).mtime.getTime() };
+      } catch {
+        return null;
+      }
+    }),
+  );
+  const best = stats.filter((s): s is { f: string; mtime: number } => !!s).sort((a, b) => b.mtime - a.mtime)[0];
+  return best ? path.join(projDir, best.f) : null;
+}
+
+const MAX_TRANSCRIPT_BYTES = 4 * 1024 * 1024;
+
+async function readSessionDigest(
+  sessionProjectsDir: string,
+  workspacePath: string,
+  agentType: ConcreteAgentType,
+): Promise<SessionDigest | null> {
+  const file = await findLatestTranscriptFile(sessionProjectsDir, workspacePath, agentType);
+  if (!file) return null;
+  let raw: string;
+  try {
+    raw = await fs.readFile(file, 'utf-8');
+  } catch {
+    return null;
+  }
+  if (raw.length > MAX_TRANSCRIPT_BYTES) raw = raw.slice(raw.length - MAX_TRANSCRIPT_BYTES); // keep the tail (most recent)
+  const sessionId = path.basename(file, '.jsonl');
+  return distillTranscript(raw, { sessionId, agentType });
+}
+
+async function listAvailableSkills(): Promise<string[]> {
+  const names = new Set<string>();
+  for (const dir of getSkillsTargetDirs()) {
+    try {
+      for (const entry of await fs.readdir(dir, { withFileTypes: true })) {
+        if (entry.isDirectory()) names.add(entry.name);
+        else if (entry.name.endsWith('.md')) names.add(entry.name.replace(/\.md$/, ''));
+      }
+    } catch {
+      /* dir may not exist */
+    }
+  }
+  return [...names].sort();
+}
+
+async function contextFilesFor(workspacePath: string): Promise<string[]> {
+  const present: string[] = [];
+  for (const name of getAllKnownContextFileNames()) {
+    try {
+      await fs.access(path.join(workspacePath, name));
+      present.push(name);
+    } catch {
+      /* not present */
+    }
+  }
+  return present;
+}
+
+/**
+ * Build the corpus the judge reasons over: the last `limit` workspaces (most
+ * recently created), each with its repos, context files, and distilled latest
+ * session, plus the globally-available skills.
+ */
+export async function gatherReflectionCorpus(limit: number): Promise<ReflectionCorpus> {
+  const [workspaces, availableSkills] = await Promise.all([listWorkspaces(false), listAvailableSkills()]);
+  const agents = getActiveAgents().filter((a) => a.type === 'claude' || a.type === 'pi');
+
+  const recent = [...workspaces]
+    .sort((a, b) => new Date(b.metadata?.createdAt ?? 0).getTime() - new Date(a.metadata?.createdAt ?? 0).getTime())
+    .slice(0, limit);
+
+  const digests: WorkspaceDigest[] = [];
+  for (const ws of recent) {
+    const workspacePath = path.join(WORKSPACES_DIR, ws.name);
+    // Find the most recent session across active agents.
+    let session: SessionDigest | null = null;
+    for (const agent of agents) {
+      const d = await readSessionDigest(agent.sessionProjectsDir, workspacePath, agent.type);
+      if (d && (!session || d.turns > session.turns)) session = d;
+    }
+    digests.push({
+      name: ws.name,
+      repoCount: ws.metadata?.repositories?.length ?? 0,
+      repos: (ws.metadata?.repositories ?? []).map((r) => r.name),
+      contextFiles: await contextFilesFor(workspacePath),
+      session,
+    });
+  }
+
+  return { generatedAt: new Date().toISOString(), availableSkills, workspaces: digests };
+}
+
+// ------------------------------------------------------------- judge prompt
+
+/** JSON schema for `claude --json-schema` (best-effort; other agents ignore it). */
+export const REFLECT_SCHEMA = JSON.stringify({
+  type: 'object',
+  properties: {
+    summary: { type: 'string' },
+    recommendations: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          kind: { type: 'string', enum: ['skill', 'context', 'test', 'prompt', 'connectivity', 'workflow', 'other'] },
+          title: { type: 'string' },
+          detail: { type: 'string' },
+          target: { type: 'string' },
+          priority: { type: 'string', enum: ['high', 'medium', 'low'] },
+          example: { type: 'string' },
+        },
+        required: ['kind', 'title', 'detail', 'priority'],
+      },
+    },
+  },
+  required: ['summary', 'recommendations'],
+});
+
+/**
+ * Build the LLM-as-a-judge prompt. The judge sees distilled recent sessions and
+ * is asked to recommend concrete improvements to the user's SETUP (skills,
+ * AGENTS.md/context rules, connectivity/tests, prompt habits, workflow) — not to
+ * redo the tasks. Output is strict JSON matching REFLECT_SCHEMA.
+ */
+export function buildJudgePrompt(corpus: ReflectionCorpus): string {
+  const lines: string[] = [];
+  lines.push(
+    'You are an expert reviewer ("LLM as a judge") analyzing an engineer\'s recent AI coding-agent sessions.',
+    'Goal: recommend concrete improvements to their SETUP so the agent works better next time —',
+    'which skills to add and WHERE, which AGENTS.md/context rules are missing, missing connectivity/',
+    'smoke tests, and prompt habits to change. Judge the setup, do NOT redo the tasks.',
+    '',
+    'Base every recommendation on evidence in the sessions below (repeated failures, retries, vague',
+    'prompts, missing context). Prefer a few high-signal, actionable items over many generic ones.',
+    'When you suggest a skill or an AGENTS.md rule, include a short concrete `example` snippet.',
+    '',
+    `Globally installed skills (don't re-suggest these; suggest genuinely missing ones): ${corpus.availableSkills.join(', ') || '(none)'}`,
+    '',
+    `Recent workspaces (${corpus.workspaces.length}):`,
+  );
+
+  for (const ws of corpus.workspaces) {
+    lines.push(`\n## ${ws.name}`);
+    lines.push(`repos: ${ws.repos.join(', ') || '(none)'} | context files: ${ws.contextFiles.join(', ') || 'NONE'}`);
+    if (!ws.session) {
+      lines.push('session: (no recent agent session found)');
+      continue;
+    }
+    lines.push(`session: ${ws.session.turns} turns, tools used: ${ws.session.tools.join(', ') || '(none)'}`);
+    if (ws.session.userPrompts.length) {
+      lines.push('user prompts:');
+      for (const p of ws.session.userPrompts) lines.push(`  - ${p.replace(/\n/g, ' ')}`);
+    }
+    if (ws.session.errors.length) {
+      lines.push('errors/failures observed:');
+      for (const e of ws.session.errors) lines.push(`  - ${e.replace(/\n/g, ' ')}`);
+    }
+  }
+
+  lines.push(
+    '',
+    'Respond with ONLY a JSON object of this shape (no prose, no markdown fence):',
+    '{"summary": string, "recommendations": [{"kind":"skill|context|test|prompt|connectivity|workflow|other",',
+    '"title": string, "detail": string, "target": string(optional workspace/repo/path),',
+    '"priority":"high|medium|low", "example": string(optional snippet)}]}',
+  );
+  return lines.join('\n');
+}
+
+// ----------------------------------------------------------- response parse
+
+const KINDS: RecommendationKind[] = ['skill', 'context', 'test', 'prompt', 'connectivity', 'workflow', 'other'];
+const PRIORITIES = ['high', 'medium', 'low'] as const;
+
+/** Validate + normalize the judge's parsed JSON into a ReflectionReport. */
+export function parseReflectionReport(parsed: unknown): ReflectionReport {
+  const obj = (parsed ?? {}) as any;
+  const summary = typeof obj.summary === 'string' ? obj.summary : '';
+  const rawRecs = Array.isArray(obj.recommendations) ? obj.recommendations : [];
+  const recommendations: Recommendation[] = rawRecs
+    .map((r: any): Recommendation | null => {
+      if (!r || typeof r !== 'object') return null;
+      const title = typeof r.title === 'string' ? r.title : '';
+      const detail = typeof r.detail === 'string' ? r.detail : '';
+      if (!title && !detail) return null;
+      const kind: RecommendationKind = KINDS.includes(r.kind) ? r.kind : 'other';
+      const priority = PRIORITIES.includes(r.priority) ? r.priority : 'medium';
+      const rec: Recommendation = { kind, title, detail, priority };
+      if (typeof r.target === 'string' && r.target.trim()) rec.target = r.target.trim();
+      if (typeof r.example === 'string' && r.example.trim()) rec.example = r.example.trim();
+      return rec;
+    })
+    .filter((r: Recommendation | null): r is Recommendation => r !== null);
+  return { summary, recommendations };
+}

--- a/src/utils/reflect.ts
+++ b/src/utils/reflect.ts
@@ -1,9 +1,8 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { WORKSPACES_DIR } from './config';
 import { listWorkspaces } from './workspace-meta';
-import { getActiveAgents, getSkillsTargetDirs, getAllKnownContextFileNames, ConcreteAgentType } from './agent-config';
-import { pathToProjectDirName } from './claude-sessions';
+import { getAgentPaths, getSkillsTargetDirs, getAllKnownContextFileNames, ConcreteAgentType } from './agent-config';
+import { pathToProjectDirName, getWorkspaceSessions, WorkspaceSession } from './claude-sessions';
 
 // ------------------------------------------------------------------ types
 
@@ -185,12 +184,19 @@ export async function findLatestTranscriptFile(
 
 const MAX_TRANSCRIPT_BYTES = 4 * 1024 * 1024;
 
-async function readSessionDigest(
-  sessionProjectsDir: string,
-  workspacePath: string,
-  agentType: ConcreteAgentType,
-): Promise<SessionDigest | null> {
-  const file = await findLatestTranscriptFile(sessionProjectsDir, workspacePath, agentType);
+/** Read + distill the transcript for a specific discovered session. Prefers the
+ *  exact `<sessionId>.jsonl`; falls back to the latest transcript in that
+ *  project dir if the exact file has been rotated away. */
+async function readDigestForSession(s: WorkspaceSession): Promise<SessionDigest | null> {
+  if (s.agentType !== 'claude' && s.agentType !== 'pi') return null;
+  const projectsDir = getAgentPaths(s.agentType).sessionProjectsDir;
+  const exact = path.join(projectsDir, pathToProjectDirName(s.workspacePath, s.agentType), `${s.sessionId}.jsonl`);
+  let file: string | null = exact;
+  try {
+    await fs.access(exact);
+  } catch {
+    file = await findLatestTranscriptFile(projectsDir, s.workspacePath, s.agentType);
+  }
   if (!file) return null;
   let raw: string;
   try {
@@ -199,8 +205,7 @@ async function readSessionDigest(
     return null;
   }
   if (raw.length > MAX_TRANSCRIPT_BYTES) raw = raw.slice(raw.length - MAX_TRANSCRIPT_BYTES); // keep the tail (most recent)
-  const sessionId = path.basename(file, '.jsonl');
-  return distillTranscript(raw, { sessionId, agentType });
+  return distillTranscript(raw, { sessionId: s.sessionId, agentType: s.agentType });
 }
 
 async function listAvailableSkills(): Promise<string[]> {
@@ -232,33 +237,29 @@ async function contextFilesFor(workspacePath: string): Promise<string[]> {
 }
 
 /**
- * Build the corpus the judge reasons over: the last `limit` workspaces (most
- * recently created), each with its repos, context files, and distilled latest
+ * Build the corpus the judge reasons over: the `limit` most **recently active**
+ * workspaces (by their latest agent session, not creation date — a retrospective
+ * is about recent *work*), each with its repos, context files, and distilled
  * session, plus the globally-available skills.
  */
 export async function gatherReflectionCorpus(limit: number): Promise<ReflectionCorpus> {
-  const [workspaces, availableSkills] = await Promise.all([listWorkspaces(false), listAvailableSkills()]);
-  const agents = getActiveAgents().filter((a) => a.type === 'claude' || a.type === 'pi');
-
-  const recent = [...workspaces]
-    .sort((a, b) => new Date(b.metadata?.createdAt ?? 0).getTime() - new Date(a.metadata?.createdAt ?? 0).getTime())
-    .slice(0, limit);
+  const [sessions, workspaces, availableSkills] = await Promise.all([
+    getWorkspaceSessions(), // already sorted by last-active, one per workspace
+    listWorkspaces(false),
+    listAvailableSkills(),
+  ]);
+  const metaByName = new Map(workspaces.map((w) => [w.name, w]));
+  const recent = sessions.slice(0, limit);
 
   const digests: WorkspaceDigest[] = [];
-  for (const ws of recent) {
-    const workspacePath = path.join(WORKSPACES_DIR, ws.name);
-    // Find the most recent session across active agents.
-    let session: SessionDigest | null = null;
-    for (const agent of agents) {
-      const d = await readSessionDigest(agent.sessionProjectsDir, workspacePath, agent.type);
-      if (d && (!session || d.turns > session.turns)) session = d;
-    }
+  for (const s of recent) {
+    const meta = metaByName.get(s.workspaceName);
     digests.push({
-      name: ws.name,
-      repoCount: ws.metadata?.repositories?.length ?? 0,
-      repos: (ws.metadata?.repositories ?? []).map((r) => r.name),
-      contextFiles: await contextFilesFor(workspacePath),
-      session,
+      name: s.workspaceName,
+      repoCount: meta?.metadata?.repositories?.length ?? 0,
+      repos: (meta?.metadata?.repositories ?? []).map((r) => r.name),
+      contextFiles: await contextFilesFor(s.workspacePath),
+      session: await readDigestForSession(s),
     });
   }
 


### PR DESCRIPTION
A new command that turns your own recent agent sessions into a **coaching retrospective**: it reads the transcripts, figures out where the agent kept struggling, and tells you exactly what to add to your setup so next time works better. Idea by **@lightpriest** — thanks!

## `nemus reflect` (alias `retro`)
```bash
nemus reflect                 # analyze your last 10 workspaces' sessions
nemus reflect --limit 5 --json
nemus reflect --dry-run       # show what the judge sees, no agent call
```

- Gathers your most recent workspaces → for each, reads the **latest agent session transcript** and distills the signals: the **prompts you sent**, the **failures the agent hit** (tool errors), the **tools it used**, and turn count. Also collects each workspace's context files + your globally-installed skills.
- Feeds that to **your own configured agent as an LLM-as-a-judge** (claude/pi/opencode — no API key of ours) with a strict JSON schema, asking for concrete setup improvements: which **skills** to add and where, missing **AGENTS.md/context** rules, missing **connectivity/smoke tests**, and **prompt/workflow** habits — each with a priority and an **example snippet**.
- **Both transcript formats** handled: Claude (`tool_use`/`tool_result`) and pi (`toolCall`/`toolResult`).

## Design (testable, vendor-neutral)
- `src/utils/reflect.ts` — pure `distillTranscript` / `buildJudgePrompt` / `parseReflectionReport` + glue `gatherReflectionCorpus`.
- `src/utils/agent-judge.ts` — reusable `runAgentRaw`/`runAgentJson`/`parseAgentJson` (headless agent invocation + envelope unwrapping), `exec`/`agentType` injectable for tests.
- `src/commands/reflect.ts` — `--limit`, `--json` (same `{ok:false,error}` failure contract as the other JSON commands), `--dry-run`.

## Verification
- **+12 tests → 457 core** pass; typecheck + build clean.
- **Validated end-to-end** against real pi sessions — produced specific, evidence-grounded recommendations (testing-driver conventions, data-model context to add to AGENTS.md, redash-skill routing, a pre-PR `git rev-parse` smoke check, re-read-before-edit workflow). Example output in the commit.
- `--dry-run` lets you inspect the exact corpus + judge prompt with no LLM call.

## Notes
- Version **0.2.13 → 0.3.0** (new feature → minor bump; triggers a release on merge, needs your `release` env approval).
