### PR TITLE
fix(reflect): eliminate the judge hang (open stdin) + move analysis into code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-08-30
+
 ### Fixed
 
-- **`reflect` now shows live progress and no longer looks hung.** The judge call
-  ran synchronously (`execFileSync`), which blocked the event loop, and a
-  10-workspace run could hit the 180s cap and die with a raw
-  `spawnSync pi ETIMEDOUT`. Now: (1) the gather phase prints a **per-workspace
-  line** as each session is read (`✓ 1/3 my-workspace  635 turns · 12 prompts ·
-  13 failures`); (2) the judge runs **async** behind a live spinner with elapsed
-  seconds; (3) the timeout is raised to 300s, overridable via
-  `NEMUS_JUDGE_TIMEOUT_MS`, and a timeout now yields an **actionable** message
-  ("try a smaller --limit, a faster agent, or raise the cap"); (4) the judge
-  prompt is leaner (fewer prompts/errors per session) so a local model actually
-  finishes.
+- **`reflect` no longer hangs/times out — the real root cause was open stdin.**
+  The judge was spawned with its **stdin left as an open pipe** (`execFile`'s
+  default), so a stdin-reading agent like `pi` blocked forever waiting on input
+  and the run died at the timeout — regardless of prompt size or model. The
+  child now gets stdin `ignore` (async) / `input: ''` (sync) → immediate EOF,
+  and a real run drops from *timeout* to **~40s**. Regression-tested with a
+  stdin-reading child that would otherwise hang.
+
+### Changed
+
+- **`reflect` now does the analysis in code and hands the LLM only compact
+  facts.** A new deterministic layer (`reflect-analyze.ts`) clusters recurring
+  failures into normalized **signatures** (paths/numbers/hashes stripped) with
+  counts + which workspaces they span, tallies tool usage, flags
+  correction/retry loops, and lists workspaces missing a context file. The judge
+  prompt is built from those aggregates, so it stays **~5KB regardless of how
+  many workspaces** are analyzed (was ~25KB and growing), the call is faster and
+  cheaper, less raw prompt text leaves your machine, and every recommendation is
+  grounded in a real count. Output shape (`--json`, the report) is unchanged;
+  `--dry-run` now shows the computed facts.
+
+## [0.3.1] - 2026-08-30
+
+### Fixed
+
+- **`reflect` shows live progress instead of looking hung.** The gather phase
+  prints a **per-workspace line** as each session is read (`✓ 1/3 my-workspace
+  635 turns · 12 prompts · 13 failures`); the judge runs **async** behind a live
+  spinner with elapsed seconds; the timeout is raised to 300s (overridable via
+  `NEMUS_JUDGE_TIMEOUT_MS`) with an **actionable** message on timeout.
 
 ## [0.3.0] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cheaper, less raw prompt text leaves your machine, and every recommendation is
   grounded in a real count. Output shape (`--json`, the report) is unchanged;
   `--dry-run` now shows the computed facts.
+- **Faster judge + richer signal.** The judge now runs pi at **`--thinking low`**
+  by default (it's a mechanical facts→recommendations transform, not deep
+  reasoning) — overridable with `--thinking`/`NEMUS_JUDGE_THINKING` and
+  `--model`/`NEMUS_JUDGE_MODEL` (threaded through for claude/opencode where
+  supported; thinking is pi-only). The digest now includes **verbatim “re-steer”
+  quotes** (the user corrections/redirects that are the sharpest coaching signal)
+  and classifies each workspace's context file as **missing / boilerplate /
+  substantive** (distinguishing “has an AGENTS.md” from “has a *useful* one”), on
+  top of the error-signature clusters.
 
 ## [0.3.1] - 2026-08-30
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nemus-cli/nemus",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "workspaces": [
     "packages/*"
   ],

--- a/src/cli/ai-prompt.ts
+++ b/src/cli/ai-prompt.ts
@@ -140,6 +140,10 @@ function runExtraction(cmd: string, fullArgs: string[], fallbackArgs?: string[])
   const exec = (args: string[]) =>
     execFileSync(cmd, args, {
       encoding: 'utf-8',
+      // `input: ''` closes the child's stdin (EOF) so a stdin-reading agent (pi)
+      // can't block this synchronous call forever in a headless/piped context
+      // — the same hang the async judge hit, guarded here for `nemus -- "…"`.
+      input: '',
       timeout: EXTRACTION_TIMEOUT_MS,
       maxBuffer: 10 * 1024 * 1024,
     });

--- a/src/commands/reflect.ts
+++ b/src/commands/reflect.ts
@@ -19,6 +19,8 @@ export function registerReflectCommand(parent: Command) {
     .alias('retro')
     .description('Analyze your recent workspace sessions and suggest skill/prompt/context improvements (LLM-as-a-judge)')
     .option('-n, --limit <n>', 'How many recent workspaces to analyze', '10')
+    .option('--model <model>', 'Judge model override (agent-native pattern/id)')
+    .option('--thinking <level>', 'Judge thinking level for pi: off|minimal|low|medium|high|xhigh|max')
     .option('--json', 'Output the report as JSON')
     .option('--dry-run', 'Print the assembled corpus + judge prompt without calling the agent')
     .action(async (opts) => {
@@ -26,7 +28,7 @@ export function registerReflectCommand(parent: Command) {
     });
 }
 
-async function handleReflect(opts: { limit?: string; json?: boolean; dryRun?: boolean }) {
+async function handleReflect(opts: { limit?: string; model?: string; thinking?: string; json?: boolean; dryRun?: boolean }) {
   const limit = Math.max(1, Number.parseInt(opts.limit ?? '10', 10) || 10);
   try {
     const showProgress = !opts.json && !opts.dryRun;
@@ -62,12 +64,14 @@ async function handleReflect(opts: { limit?: string; json?: boolean; dryRun?: bo
     // (non-blocking) so a live spinner shows it's alive, not hung. Timeout is
     // overridable for slow local models.
     const timeoutMs = Number.parseInt(process.env.NEMUS_JUDGE_TIMEOUT_MS ?? '', 10) || undefined;
+    const model = opts.model ?? process.env.NEMUS_JUDGE_MODEL ?? undefined;
+    const thinking = opts.thinking ?? process.env.NEMUS_JUDGE_THINKING ?? undefined;
     const stopSpinner = opts.json
       ? () => {}
       : startSpinner(`Judging ${withSessions} session(s) with your configured agent (this can take a minute)…`);
     let parsed: unknown;
     try {
-      parsed = await runAgentJsonAsync(prompt, { schema: REFLECT_SCHEMA, timeoutMs });
+      parsed = await runAgentJsonAsync(prompt, { schema: REFLECT_SCHEMA, timeoutMs, model, thinking });
     } finally {
       stopSpinner();
     }

--- a/src/commands/reflect.ts
+++ b/src/commands/reflect.ts
@@ -4,13 +4,13 @@ import { outputJson, outputJsonError } from '../utils/output';
 import { colorize } from '../utils/colors';
 import {
   gatherReflectionCorpus,
-  buildJudgePrompt,
   parseReflectionReport,
   REFLECT_SCHEMA,
   ReflectionReport,
   ReflectProgress,
   Recommendation,
 } from '../utils/reflect';
+import { analyzeCorpus, buildAnalysisPrompt } from '../utils/reflect-analyze';
 import { runAgentJsonAsync } from '../utils/agent-judge';
 
 export function registerReflectCommand(parent: Command) {
@@ -36,11 +36,15 @@ async function handleReflect(opts: { limit?: string; json?: boolean; dryRun?: bo
 
     const corpus = await gatherReflectionCorpus(limit, showProgress ? printProgress : undefined);
     const withSessions = corpus.workspaces.filter((w) => w.session).length;
-    const prompt = buildJudgePrompt(corpus);
+    // A script does the heavy analysis (clustering failures, counting tools,
+    // spotting correction loops); the LLM only ever sees these compact facts,
+    // so the judge call stays small + fast regardless of workspace count.
+    const analysis = analyzeCorpus(corpus);
+    const prompt = buildAnalysisPrompt(analysis);
 
     if (opts.dryRun) {
-      // No LLM call — surface exactly what the judge would see.
-      if (opts.json) outputJson({ corpus, prompt });
+      // No LLM call — surface the computed facts + exactly what the judge sees.
+      if (opts.json) outputJson({ analysis, prompt });
       else {
         process.stdout.write(prompt + '\n');
       }

--- a/src/utils/agent-judge.test.ts
+++ b/src/utils/agent-judge.test.ts
@@ -43,10 +43,13 @@ describe('agentAttempts', () => {
     expect(pi[1]).toEqual({ cmd: 'pi', args: ['-p', 'P'] });
     expect(agentAttempts('opencode', 'P')).toEqual([{ cmd: 'opencode', args: ['run', 'P'] }]);
   });
-  it('threads --model (all) and --thinking (pi only) through both attempts', () => {
+  it('threads --model (all) + --thinking (pi only); fallback keeps model, drops --thinking', () => {
     const pi = agentAttempts('pi', 'P', { model: 'haiku', thinking: 'low' });
     expect(pi[0].args).toEqual(expect.arrayContaining(['--model', 'haiku', '--thinking', 'low', '-p', 'P']));
-    expect(pi[1].args).toEqual(expect.arrayContaining(['--model', 'haiku', '--thinking', 'low', '-p', 'P']));
+    // Safety net: model stays (stable flag), --thinking is dropped so an old pi
+    // that rejects --thinking still has a working fallback.
+    expect(pi[1].args).toEqual(['--model', 'haiku', '-p', 'P']);
+    expect(pi[1].args).not.toContain('--thinking');
     const cl = agentAttempts('claude', 'P', { model: 'sonnet' });
     expect(cl[0].args).toEqual(expect.arrayContaining(['--model', 'sonnet']));
     expect(cl[0].args).not.toContain('--thinking'); // thinking is pi-only

--- a/src/utils/agent-judge.test.ts
+++ b/src/utils/agent-judge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseAgentJson, runAgentRaw, runAgentRawAsync, agentAttempts } from './agent-judge';
+import { parseAgentJson, runAgentRaw, runAgentRawAsync, agentAttempts, spawnCollect } from './agent-judge';
 
 describe('parseAgentJson', () => {
   it('unwraps the common agent envelopes and shapes', () => {
@@ -13,6 +13,21 @@ describe('parseAgentJson', () => {
 
   it('throws when there is no JSON at all', () => {
     expect(() => parseAgentJson('totally not json')).toThrow(/did not return JSON/);
+  });
+});
+
+describe('spawnCollect (stdin-hang regression)', () => {
+  it('gives the child stdin EOF so a stdin-reading process does NOT hang', async () => {
+    // `cat` with no args reads stdin to EOF. If stdin were an open pipe (the old
+    // execFile default) this would block until the timeout and reject; with
+    // stdin ignored it gets immediate EOF and exits 0 fast. 2s timeout << any hang.
+    const out = await spawnCollect('cat', [], { timeout: 2000, maxBuffer: 1 << 20 });
+    expect(out).toBe('');
+  });
+
+  it('captures stdout and rejects on non-zero exit', async () => {
+    await expect(spawnCollect('node', ['-e', 'process.stdout.write("hi")'], { timeout: 5000, maxBuffer: 1 << 20 })).resolves.toBe('hi');
+    await expect(spawnCollect('node', ['-e', 'process.exit(3)'], { timeout: 5000, maxBuffer: 1 << 20 })).rejects.toThrow(/exit 3/);
   });
 });
 

--- a/src/utils/agent-judge.test.ts
+++ b/src/utils/agent-judge.test.ts
@@ -33,7 +33,7 @@ describe('spawnCollect (stdin-hang regression)', () => {
 
 describe('agentAttempts', () => {
   it('claude: preferred (schema + lean flags) then a plain fallback', () => {
-    const a = agentAttempts('claude', 'P', '{"type":"object"}');
+    const a = agentAttempts('claude', 'P', { schema: '{"type":"object"}' });
     expect(a[0]).toEqual({ cmd: 'claude', args: expect.arrayContaining(['-p', 'P', '--output-format', 'json', '--json-schema', '{"type":"object"}']) });
     expect(a[1]).toEqual({ cmd: 'claude', args: ['-p', 'P'] });
   });
@@ -42,6 +42,23 @@ describe('agentAttempts', () => {
     expect(pi[0].args).toEqual(expect.arrayContaining(['--no-tools', '--no-skills', '-p', 'P']));
     expect(pi[1]).toEqual({ cmd: 'pi', args: ['-p', 'P'] });
     expect(agentAttempts('opencode', 'P')).toEqual([{ cmd: 'opencode', args: ['run', 'P'] }]);
+  });
+  it('threads --model (all) and --thinking (pi only) through both attempts', () => {
+    const pi = agentAttempts('pi', 'P', { model: 'haiku', thinking: 'low' });
+    expect(pi[0].args).toEqual(expect.arrayContaining(['--model', 'haiku', '--thinking', 'low', '-p', 'P']));
+    expect(pi[1].args).toEqual(expect.arrayContaining(['--model', 'haiku', '--thinking', 'low', '-p', 'P']));
+    const cl = agentAttempts('claude', 'P', { model: 'sonnet' });
+    expect(cl[0].args).toEqual(expect.arrayContaining(['--model', 'sonnet']));
+    expect(cl[0].args).not.toContain('--thinking'); // thinking is pi-only
+    expect(agentAttempts('opencode', 'P', { model: 'gpt' })[0].args).toEqual(['run', 'P', '--model', 'gpt']);
+  });
+});
+
+describe('runAgentRaw thinking default', () => {
+  it('applies the low-thinking default for pi', () => {
+    let seen: string[] = [];
+    runAgentRaw('P', { agentType: 'pi', exec: (cmd, args) => ((seen = [cmd, ...args]), 'ok') });
+    expect(seen).toEqual(expect.arrayContaining(['--thinking', 'low']));
   });
 });
 

--- a/src/utils/agent-judge.ts
+++ b/src/utils/agent-judge.ts
@@ -1,8 +1,47 @@
-import { execFile, execFileSync } from 'child_process';
-import { promisify } from 'util';
+import { execFileSync, spawn } from 'child_process';
 import { getPrimaryAgent } from './agent-config';
 
-const execFileAsync = promisify(execFile);
+/**
+ * Run a child to completion, capturing stdout, with stdin set to /dev/null.
+ *
+ * The stdin part is load-bearing: agents like `pi` block waiting on stdin if
+ * it's an open pipe (the default for execFile), which made the judge hang until
+ * the timeout regardless of prompt size or model speed. `stdio: ['ignore', …]`
+ * gives the child an immediate EOF, exactly like a non-interactive shell.
+ */
+export function spawnCollect(
+  cmd: string,
+  args: string[],
+  opts: { timeout: number; maxBuffer: number },
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: opts.timeout,
+      killSignal: 'SIGKILL',
+    });
+    let stdout = '';
+    let stderr = '';
+    let overflow = false;
+    child.stdout.on('data', (d) => {
+      stdout += d;
+      if (stdout.length > opts.maxBuffer) {
+        overflow = true;
+        child.kill('SIGKILL');
+      }
+    });
+    child.stderr.on('data', (d) => {
+      stderr += d;
+    });
+    child.on('error', (e) => reject(e));
+    child.on('close', (code, signal) => {
+      if (overflow) return reject(Object.assign(new Error('maxBuffer exceeded'), { stdout, stderr }));
+      if (signal) return reject(Object.assign(new Error(`killed by ${signal}`), { killed: true, signal, stdout, stderr }));
+      if (code !== 0) return reject(Object.assign(new Error(`exit ${code}`), { code, stdout, stderr }));
+      resolve(stdout);
+    });
+  });
+}
 
 /**
  * Run the user's configured coding agent headlessly as an "LLM-as-a-judge":
@@ -80,7 +119,9 @@ export function runAgentRaw(prompt: string, opts: JudgeOptions = {}): string {
   const maxBuffer = opts.maxBuffer ?? DEFAULT_MAX_BUFFER;
   const exec =
     opts.exec ??
-    ((cmd, args, o) => execFileSync(cmd, args, { encoding: 'utf-8', timeout: o.timeout, maxBuffer: o.maxBuffer }));
+    // `input: ''` closes the child's stdin (EOF) so a stdin-reading agent (pi)
+    // can't hang the synchronous call — the sync twin of spawnCollect's fix.
+    ((cmd, args, o) => execFileSync(cmd, args, { encoding: 'utf-8', input: '', timeout: o.timeout, maxBuffer: o.maxBuffer }));
 
   const attempts = agentAttempts(agentType, prompt, opts.schema);
   let lastErr: any;
@@ -103,10 +144,7 @@ export async function runAgentRawAsync(prompt: string, opts: JudgeOptions = {}):
   const agentType = opts.agentType ?? getPrimaryAgent().type;
   const timeout = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const maxBuffer = opts.maxBuffer ?? DEFAULT_MAX_BUFFER;
-  const exec =
-    opts.execAsync ??
-    (async (cmd, args, o) =>
-      (await execFileAsync(cmd, args, { encoding: 'utf-8', timeout: o.timeout, maxBuffer: o.maxBuffer })).stdout.toString());
+  const exec = opts.execAsync ?? ((cmd, args, o) => spawnCollect(cmd, args, o));
 
   const attempts = agentAttempts(agentType, prompt, opts.schema);
   let lastErr: any;

--- a/src/utils/agent-judge.ts
+++ b/src/utils/agent-judge.ts
@@ -20,6 +20,10 @@ export function spawnCollect(
       timeout: opts.timeout,
       killSignal: 'SIGKILL',
     });
+    // Decode as UTF-8 at the stream boundary so a multi-byte char split across
+    // two chunks isn't corrupted (which would break JSON.parse downstream).
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
     let stdout = '';
     let stderr = '';
     let overflow = false;
@@ -114,12 +118,14 @@ export function agentAttempts(agentType: JudgeAgentType, prompt: string, opts: A
   }
   // pi (and any other): run as lean as possible so a bloated env can't hang it.
   const piLean = ['--no-extensions', '--no-skills', '--no-prompt-templates', '--no-context-files', '--no-tools', '--no-session'];
-  const tune: string[] = [];
-  if (model) tune.push('--model', model);
-  if (thinking) tune.push('--thinking', thinking);
+  const modelArgs = model ? ['--model', model] : [];
+  const tune = thinking ? [...modelArgs, '--thinking', thinking] : modelArgs;
+  // Fallback keeps the stable --model but DROPS --thinking: --thinking is the
+  // newest flag and the most likely reason an older pi rejects the first
+  // attempt, so the safety net must not carry it (else both attempts fail).
   return [
     { cmd: 'pi', args: [...piLean, ...tune, '-p', prompt] },
-    { cmd: 'pi', args: [...tune, '-p', prompt] },
+    { cmd: 'pi', args: [...modelArgs, '-p', prompt] },
   ];
 }
 

--- a/src/utils/agent-judge.ts
+++ b/src/utils/agent-judge.ts
@@ -56,6 +56,10 @@ export function spawnCollect(
 export interface JudgeOptions {
   /** JSON schema string passed to `claude --json-schema` (ignored by others). */
   schema?: string;
+  /** Model override (`--model`), agent-native pattern/id. */
+  model?: string;
+  /** Thinking level (`--thinking`, pi only): off|minimal|low|medium|high|xhigh|max. */
+  thinking?: string;
   timeoutMs?: number;
   maxBuffer?: number;
   /** Injected for tests. Defaults to the real (blocking) child_process runner. */
@@ -73,24 +77,59 @@ export interface AgentAttempt {
   args: string[];
 }
 
+export interface AttemptOptions {
+  schema?: string;
+  model?: string;
+  thinking?: string;
+}
+
+/**
+ * Default thinking level for the judge. The judge is a mechanical transform
+ * (facts → recommendations), not deep reasoning, so a heavy default like Opus
+ * @ medium thinking just makes it slow. `low` keeps pi fast; override per-run.
+ */
+export const DEFAULT_JUDGE_THINKING = 'low';
+
 /**
  * The ordered invocation attempts for an agent (preferred → fallback), as pure
  * data so both the sync and async runners share ONE flag ladder (and it's
- * unit-testable without spawning anything).
+ * unit-testable without spawning anything). `--model` applies to all; pi also
+ * takes `--thinking` (the speed lever); both are ignored where unsupported.
  */
-export function agentAttempts(agentType: JudgeAgentType, prompt: string, schema?: string): AgentAttempt[] {
+export function agentAttempts(agentType: JudgeAgentType, prompt: string, opts: AttemptOptions = {}): AgentAttempt[] {
+  const { schema, model, thinking } = opts;
   if (agentType === 'claude') {
     const preferred = ['-p', prompt, '--output-format', 'json', '--bare', '--strict-mcp-config', '--disable-slash-commands'];
+    if (model) preferred.push('--model', model);
     if (schema) preferred.push('--json-schema', schema);
     // Older claude may reject the newer flags — fall back to the plainest form.
-    return [{ cmd: 'claude', args: preferred }, { cmd: 'claude', args: ['-p', prompt] }];
+    const plain = ['-p', prompt];
+    if (model) plain.push('--model', model);
+    return [{ cmd: 'claude', args: preferred }, { cmd: 'claude', args: plain }];
   }
   if (agentType === 'opencode') {
-    return [{ cmd: 'opencode', args: ['run', prompt] }];
+    const args = ['run', prompt];
+    if (model) args.push('--model', model);
+    return [{ cmd: 'opencode', args }];
   }
   // pi (and any other): run as lean as possible so a bloated env can't hang it.
   const piLean = ['--no-extensions', '--no-skills', '--no-prompt-templates', '--no-context-files', '--no-tools', '--no-session'];
-  return [{ cmd: 'pi', args: [...piLean, '-p', prompt] }, { cmd: 'pi', args: ['-p', prompt] }];
+  const tune: string[] = [];
+  if (model) tune.push('--model', model);
+  if (thinking) tune.push('--thinking', thinking);
+  return [
+    { cmd: 'pi', args: [...piLean, ...tune, '-p', prompt] },
+    { cmd: 'pi', args: [...tune, '-p', prompt] },
+  ];
+}
+
+/** Resolve the attempt options for a run, applying the pi thinking default. */
+function attemptOptions(agentType: JudgeAgentType, opts: JudgeOptions): AttemptOptions {
+  return {
+    schema: opts.schema,
+    model: opts.model,
+    thinking: opts.thinking ?? (agentType === 'pi' ? DEFAULT_JUDGE_THINKING : undefined),
+  };
 }
 
 function wrapJudgeError(err: any, agentType: string): Error {
@@ -123,7 +162,7 @@ export function runAgentRaw(prompt: string, opts: JudgeOptions = {}): string {
     // can't hang the synchronous call — the sync twin of spawnCollect's fix.
     ((cmd, args, o) => execFileSync(cmd, args, { encoding: 'utf-8', input: '', timeout: o.timeout, maxBuffer: o.maxBuffer }));
 
-  const attempts = agentAttempts(agentType, prompt, opts.schema);
+  const attempts = agentAttempts(agentType, prompt, attemptOptions(agentType, opts));
   let lastErr: any;
   for (const a of attempts) {
     try {
@@ -146,7 +185,7 @@ export async function runAgentRawAsync(prompt: string, opts: JudgeOptions = {}):
   const maxBuffer = opts.maxBuffer ?? DEFAULT_MAX_BUFFER;
   const exec = opts.execAsync ?? ((cmd, args, o) => spawnCollect(cmd, args, o));
 
-  const attempts = agentAttempts(agentType, prompt, opts.schema);
+  const attempts = agentAttempts(agentType, prompt, attemptOptions(agentType, opts));
   let lastErr: any;
   for (const a of attempts) {
     try {

--- a/src/utils/reflect-analyze.test.ts
+++ b/src/utils/reflect-analyze.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeErrorSignature,
+  isCorrectionPrompt,
+  analyzeCorpus,
+  buildAnalysisPrompt,
+} from './reflect-analyze';
+import { ReflectionCorpus } from './reflect';
+
+describe('normalizeErrorSignature', () => {
+  it('collapses paths, numbers, and hashes so variants cluster', () => {
+    const a = normalizeErrorSignature('fatal: not a git repository (or any parent up to /Users/alice/work/repo)');
+    const b = normalizeErrorSignature('fatal: not a git repository (or any parent up to /home/bob/src/thing)');
+    expect(a).toBe(b);
+    expect(a).toContain('<path>');
+
+    expect(normalizeErrorSignature('exit code 137 after 4200ms')).toBe(
+      normalizeErrorSignature('exit code 2 after 9ms'),
+    );
+    expect(normalizeErrorSignature('object abc1234def not found')).toBe(
+      normalizeErrorSignature('object 0f9e8d7c6b not found'),
+    );
+  });
+
+  it('is bounded and safe on empty input', () => {
+    expect(normalizeErrorSignature('')).toBe('');
+    expect(normalizeErrorSignature('x'.repeat(500)).length).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('isCorrectionPrompt', () => {
+  it('flags corrections, not normal instructions', () => {
+    expect(isCorrectionPrompt('no, that is wrong — revert it')).toBe(true);
+    expect(isCorrectionPrompt('actually use the other repo instead')).toBe(true);
+    expect(isCorrectionPrompt('you forgot to run the tests')).toBe(true);
+    expect(isCorrectionPrompt('add a health check to the api')).toBe(false);
+    expect(isCorrectionPrompt('create a workspace for payments')).toBe(false);
+  });
+});
+
+const corpus: ReflectionCorpus = {
+  generatedAt: 'now',
+  availableSkills: ['redash'],
+  workspaces: [
+    {
+      name: 'pay-app',
+      repoCount: 1,
+      repos: ['api'],
+      contextFiles: ['AGENTS.md'],
+      session: {
+        sessionId: 's1',
+        agentType: 'pi',
+        turns: 40,
+        userPrompts: ['fix the sync bug', 'no that is wrong, revert'],
+        errors: [
+          'fatal: not a git repository (at /Users/a/pay-app/api)',
+          'fatal: not a git repository (at /Users/a/pay-app/web)',
+          'gh: Not Found (HTTP 404)',
+        ],
+        tools: ['bash', 'edit'],
+      },
+    },
+    {
+      name: 'ledger',
+      repoCount: 0,
+      repos: [],
+      contextFiles: [], // missing context
+      session: {
+        sessionId: 's2',
+        agentType: 'pi',
+        turns: 12,
+        userPrompts: ['add tests'],
+        errors: ['fatal: not a git repository (at /home/b/ledger)'],
+        tools: ['bash'],
+      },
+    },
+    { name: 'idle-ws', repoCount: 0, repos: [], contextFiles: ['CLAUDE.md'], session: null },
+  ],
+};
+
+describe('analyzeCorpus', () => {
+  const a = analyzeCorpus(corpus);
+
+  it('aggregates totals and correction signals', () => {
+    expect(a.totalWorkspaces).toBe(3);
+    expect(a.sessionsAnalyzed).toBe(2); // idle-ws has no session
+    expect(a.totalTurns).toBe(52);
+    expect(a.correctionSignals).toBe(1); // "no that is wrong, revert"
+  });
+
+  it('clusters the recurring failure across workspaces, most frequent first', () => {
+    const top = a.topErrors[0];
+    expect(top.signature).toContain('not a git repository');
+    expect(top.count).toBe(3); // 2 in pay-app + 1 in ledger
+    expect(top.workspaces.sort()).toEqual(['ledger', 'pay-app']);
+    expect(top.example).toContain('fatal: not a git repository');
+  });
+
+  it('reports tools, missing-context, and per-workspace facts', () => {
+    expect(a.topTools[0]).toEqual({ tool: 'bash', sessions: 2 });
+    expect(a.workspacesMissingContext).toEqual(['ledger']);
+    const pay = a.workspaces.find((w) => w.name === 'pay-app')!;
+    expect(pay).toMatchObject({ turns: 40, failures: 3, hasContext: true });
+    expect(pay.topFailure).toContain('not a git repository');
+    expect(a.workspaces.find((w) => w.name === 'idle-ws')).toMatchObject({ turns: 0, failures: 0 });
+  });
+});
+
+describe('buildAnalysisPrompt', () => {
+  it('is compact and fact-based (no raw transcripts)', () => {
+    const p = buildAnalysisPrompt(analyzeCorpus(corpus));
+    expect(p).toContain('A script has already analyzed');
+    expect(p).toContain('Sessions analyzed: 2 across 3 workspaces (52 total turns).');
+    expect(p).toContain('Top recurring failures');
+    expect(p).toMatch(/\[3\u00d7 in 2 ws\]/); // the clustered failure
+    expect(p).toContain('missing a context file (AGENTS.md/CLAUDE.md): ledger');
+    expect(p).toContain('bash(2)');
+    expect(p).toMatch(/ONLY a JSON object/);
+    // Compact: even this corpus stays well under a few KB.
+    expect(p.length).toBeLessThan(3000);
+  });
+});

--- a/src/utils/reflect-analyze.test.ts
+++ b/src/utils/reflect-analyze.test.ts
@@ -1,11 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import {
-  normalizeErrorSignature,
-  isCorrectionPrompt,
-  analyzeCorpus,
-  buildAnalysisPrompt,
-} from './reflect-analyze';
-import { ReflectionCorpus } from './reflect';
+import { normalizeErrorSignature, analyzeCorpus, buildAnalysisPrompt } from './reflect-analyze';
+import { ReflectionCorpus, isCorrectionPrompt } from './reflect';
 
 describe('normalizeErrorSignature', () => {
   it('collapses paths, numbers, and hashes so variants cluster', () => {
@@ -47,11 +42,13 @@ const corpus: ReflectionCorpus = {
       repoCount: 1,
       repos: ['api'],
       contextFiles: ['AGENTS.md'],
+      contextQuality: 'substantive',
       session: {
         sessionId: 's1',
         agentType: 'pi',
         turns: 40,
         userPrompts: ['fix the sync bug', 'no that is wrong, revert'],
+        reSteerSamples: ['no that is wrong, revert'],
         errors: [
           'fatal: not a git repository (at /Users/a/pay-app/api)',
           'fatal: not a git repository (at /Users/a/pay-app/web)',
@@ -65,16 +62,18 @@ const corpus: ReflectionCorpus = {
       repoCount: 0,
       repos: [],
       contextFiles: [], // missing context
+      contextQuality: 'missing',
       session: {
         sessionId: 's2',
         agentType: 'pi',
         turns: 12,
         userPrompts: ['add tests'],
+        reSteerSamples: [],
         errors: ['fatal: not a git repository (at /home/b/ledger)'],
         tools: ['bash'],
       },
     },
-    { name: 'idle-ws', repoCount: 0, repos: [], contextFiles: ['CLAUDE.md'], session: null },
+    { name: 'idle-ws', repoCount: 0, repos: [], contextFiles: ['CLAUDE.md'], contextQuality: 'boilerplate', session: null },
   ],
 };
 
@@ -96,13 +95,15 @@ describe('analyzeCorpus', () => {
     expect(top.example).toContain('fatal: not a git repository');
   });
 
-  it('reports tools, missing-context, and per-workspace facts', () => {
+  it('reports tools, context quality, re-steers, and per-workspace facts', () => {
     expect(a.topTools[0]).toEqual({ tool: 'bash', sessions: 2 });
     expect(a.workspacesMissingContext).toEqual(['ledger']);
+    expect(a.workspacesBoilerplateContext).toEqual(['idle-ws']);
+    expect(a.reSteerSamples).toEqual(['no that is wrong, revert']);
     const pay = a.workspaces.find((w) => w.name === 'pay-app')!;
-    expect(pay).toMatchObject({ turns: 40, failures: 3, hasContext: true });
+    expect(pay).toMatchObject({ turns: 40, failures: 3, contextQuality: 'substantive' });
     expect(pay.topFailure).toContain('not a git repository');
-    expect(a.workspaces.find((w) => w.name === 'idle-ws')).toMatchObject({ turns: 0, failures: 0 });
+    expect(a.workspaces.find((w) => w.name === 'idle-ws')).toMatchObject({ turns: 0, failures: 0, contextQuality: 'boilerplate' });
   });
 });
 
@@ -113,7 +114,10 @@ describe('buildAnalysisPrompt', () => {
     expect(p).toContain('Sessions analyzed: 2 across 3 workspaces (52 total turns).');
     expect(p).toContain('Top recurring failures');
     expect(p).toMatch(/\[3\u00d7 in 2 ws\]/); // the clustered failure
-    expect(p).toContain('missing a context file (AGENTS.md/CLAUDE.md): ledger');
+    expect(p).toContain('NO context file (AGENTS.md/CLAUDE.md): ledger');
+    expect(p).toContain('boilerplate/template: idle-ws');
+    expect(p).toContain('Verbatim user corrections');
+    expect(p).toContain('no that is wrong, revert');
     expect(p).toContain('bash(2)');
     expect(p).toMatch(/ONLY a JSON object/);
     // Compact: even this corpus stays well under a few KB.

--- a/src/utils/reflect-analyze.ts
+++ b/src/utils/reflect-analyze.ts
@@ -1,0 +1,235 @@
+import { ReflectionCorpus } from './reflect';
+
+/**
+ * Deterministic analysis layer for `reflect`.
+ *
+ * The LLM used to read raw transcripts (every prompt + every error) for every
+ * workspace, which made the judge prompt large and slow (timeouts on local
+ * models). Instead, a *script* does the heavy lifting here — clustering repeated
+ * failures, counting tools, spotting correction/retry loops — and the LLM only
+ * ever sees a small, pre-computed set of FACTS. That keeps the judge call fast
+ * and bounded no matter how many workspaces are analyzed, and grounds every
+ * recommendation in real counts rather than a wall of text.
+ *
+ * Everything here is pure (corpus in → report out) so it's exhaustively
+ * unit-tested without spawning an agent.
+ */
+
+// ------------------------------------------------------------------ types
+
+export interface ErrorCluster {
+  /** Normalized signature (paths/numbers/hashes stripped) used to group. */
+  signature: string;
+  /** Total occurrences across all analyzed sessions. */
+  count: number;
+  /** Distinct workspaces the signature appeared in (recurrence = strong signal). */
+  workspaces: string[];
+  /** One representative raw example (bounded). */
+  example: string;
+}
+
+export interface ToolStat {
+  tool: string;
+  /** Number of sessions that used the tool (not raw invocation count — the
+   *  digest only records distinct tools per session). */
+  sessions: number;
+}
+
+export interface WorkspaceFact {
+  name: string;
+  turns: number;
+  failures: number;
+  hasContext: boolean;
+  /** The workspace's single most frequent failure signature, if any. */
+  topFailure?: string;
+}
+
+export interface AnalysisReport {
+  totalWorkspaces: number;
+  sessionsAnalyzed: number;
+  totalTurns: number;
+  /** Recurring failures, most frequent first. */
+  topErrors: ErrorCluster[];
+  /** Most-used tools, most sessions first. */
+  topTools: ToolStat[];
+  /** How many user prompts looked like corrections/retries (a friction signal). */
+  correctionSignals: number;
+  /** Workspaces with NO context file (AGENTS.md/CLAUDE.md/…). */
+  workspacesMissingContext: string[];
+  /** Skills already installed (so the judge suggests genuine gaps). */
+  availableSkills: string[];
+  /** One compact line of facts per workspace, for grounding. */
+  workspaces: WorkspaceFact[];
+}
+
+// --------------------------------------------------------------- normalizing
+
+/**
+ * Reduce a raw error string to a stable signature so near-identical failures
+ * cluster together: lowercase, drop quotes, replace filesystem paths, hashes,
+ * hex ids and bare numbers with placeholders, collapse whitespace, and cap the
+ * length. `"fatal: not a git repository (or any of the parent up to /Users/x)"`
+ * and the same from another path collapse to one signature.
+ */
+export function normalizeErrorSignature(raw: string): string {
+  let s = (raw ?? '').toLowerCase();
+  s = s.replace(/[`'"]/g, ' ');
+  // Windows paths first (contain ':' and '\'), then unix paths.
+  s = s.replace(/[a-z]:\\[^\s]+/g, '<path>');
+  s = s.replace(/\/[^\s:)'"]+/g, '<path>');
+  // Long hex / uuids / sha-like tokens before bare numbers.
+  s = s.replace(/\b[0-9a-f]{7,}\b/g, '<hash>');
+  // No trailing \b, so a number glued to a unit ('4200ms', '9ms') still clusters.
+  s = s.replace(/\b\d[\d.,:]*/g, '<n>');
+  s = s.replace(/\s+/g, ' ').trim();
+  return s.slice(0, 100);
+}
+
+// A conservative "the user corrected / redirected the agent" cue. Soft signal —
+// counted in aggregate, never quoted, so occasional false positives are fine.
+const CORRECTION_RE =
+  /\b(no|nope|wrong|incorrect|revert|undo|instead|actually|you (missed|forgot|broke|didn'?t)|that'?s? (wrong|not right|incorrect)|not what|don'?t)\b/i;
+
+/** Whether a single user prompt reads like a correction/retry. Exported for tests. */
+export function isCorrectionPrompt(prompt: string): boolean {
+  return CORRECTION_RE.test(prompt ?? '');
+}
+
+// ------------------------------------------------------------------ analyze
+
+export interface AnalyzeOptions {
+  /** Max error clusters to surface (default 8). */
+  topErrors?: number;
+  /** Max tools to surface (default 10). */
+  topTools?: number;
+  /** Max chars of a raw error kept as the example (default 160). */
+  exampleChars?: number;
+}
+
+/**
+ * Turn a distilled corpus into aggregated facts. This is the "script processes
+ * the data" step — the LLM never sees the raw corpus, only the returned report.
+ */
+export function analyzeCorpus(corpus: ReflectionCorpus, opts: AnalyzeOptions = {}): AnalysisReport {
+  const topErrorsK = opts.topErrors ?? 8;
+  const topToolsK = opts.topTools ?? 10;
+  const exampleChars = opts.exampleChars ?? 160;
+
+  const errorMap = new Map<string, { count: number; ws: Set<string>; example: string }>();
+  const toolMap = new Map<string, number>();
+  const workspacesMissingContext: string[] = [];
+  const workspaces: WorkspaceFact[] = [];
+  let sessionsAnalyzed = 0;
+  let totalTurns = 0;
+  let correctionSignals = 0;
+
+  for (const ws of corpus.workspaces) {
+    const hasContext = ws.contextFiles.length > 0;
+    if (!hasContext) workspacesMissingContext.push(ws.name);
+
+    const s = ws.session;
+    if (!s) {
+      workspaces.push({ name: ws.name, turns: 0, failures: 0, hasContext });
+      continue;
+    }
+
+    sessionsAnalyzed++;
+    totalTurns += s.turns;
+    for (const t of s.tools) toolMap.set(t, (toolMap.get(t) ?? 0) + 1);
+    correctionSignals += s.userPrompts.filter(isCorrectionPrompt).length;
+
+    // Per-workspace signature tally (drives the global map + this ws's topFailure).
+    const localSig = new Map<string, number>();
+    for (const e of s.errors) {
+      const sig = normalizeErrorSignature(e);
+      if (!sig) continue;
+      localSig.set(sig, (localSig.get(sig) ?? 0) + 1);
+      let entry = errorMap.get(sig);
+      if (!entry) {
+        entry = { count: 0, ws: new Set(), example: e.slice(0, exampleChars) };
+        errorMap.set(sig, entry);
+      }
+      entry.count++;
+      entry.ws.add(ws.name);
+    }
+    const topFailure = [...localSig.entries()].sort((a, b) => b[1] - a[1])[0]?.[0];
+
+    workspaces.push({ name: ws.name, turns: s.turns, failures: s.errors.length, hasContext, topFailure });
+  }
+
+  const topErrors: ErrorCluster[] = [...errorMap.entries()]
+    .map(([signature, v]) => ({ signature, count: v.count, workspaces: [...v.ws], example: v.example }))
+    // Most frequent first; break ties by cross-workspace spread (recurrence).
+    .sort((a, b) => b.count - a.count || b.workspaces.length - a.workspaces.length)
+    .slice(0, topErrorsK);
+
+  const topTools: ToolStat[] = [...toolMap.entries()]
+    .map(([tool, sessions]) => ({ tool, sessions }))
+    .sort((a, b) => b.sessions - a.sessions || a.tool.localeCompare(b.tool))
+    .slice(0, topToolsK);
+
+  return {
+    totalWorkspaces: corpus.workspaces.length,
+    sessionsAnalyzed,
+    totalTurns,
+    topErrors,
+    topTools,
+    correctionSignals,
+    workspacesMissingContext,
+    availableSkills: corpus.availableSkills,
+    workspaces,
+  };
+}
+
+// --------------------------------------------------------------- judge prompt
+
+/**
+ * Build the judge prompt from the pre-computed facts. Compact by construction
+ * (a handful of clusters + counts), so the LLM call stays small and fast no
+ * matter how many workspaces were analyzed. Output contract is unchanged
+ * (REFLECT_SCHEMA), so parsing/rendering are shared with the old path.
+ */
+export function buildAnalysisPrompt(a: AnalysisReport): string {
+  const L: string[] = [];
+  L.push(
+    'You are an expert reviewer ("LLM as a judge"). A script has already analyzed an engineer\'s',
+    'recent AI coding-agent sessions and distilled them into the FACTS below. Do not ask for the',
+    'raw transcripts — reason only from these facts.',
+    '',
+    'Goal: recommend concrete improvements to their SETUP so the agent works better next time —',
+    'which skills to add and WHERE, which AGENTS.md/context rules are missing, missing connectivity/',
+    'smoke tests, and prompt/workflow habits. Ground every recommendation in a fact below',
+    '(a recurring failure, a correction loop, a missing context file). Prefer a few high-signal',
+    'items over many generic ones. Include a concrete `example` snippet for skills/context rules.',
+    '',
+    `Sessions analyzed: ${a.sessionsAnalyzed} across ${a.totalWorkspaces} workspaces (${a.totalTurns} total turns).`,
+    `Installed skills (don't re-suggest; find genuine gaps): ${a.availableSkills.join(', ') || '(none)'}`,
+    `User correction/retry signals: ${a.correctionSignals} prompt(s) looked like corrections.`,
+    `Workspaces missing a context file (AGENTS.md/CLAUDE.md): ${a.workspacesMissingContext.join(', ') || '(none)'}`,
+  );
+
+  L.push('', 'Top recurring failures (count × workspaces — example):');
+  if (a.topErrors.length === 0) L.push('  (none captured)');
+  for (const e of a.topErrors) {
+    L.push(`  - [${e.count}× in ${e.workspaces.length} ws] ${e.signature}`);
+    L.push(`      e.g. ${e.example.replace(/\n/g, ' ')}`);
+  }
+
+  L.push('', `Most-used tools: ${a.topTools.map((t) => `${t.tool}(${t.sessions})`).join(', ') || '(none)'}`);
+
+  L.push('', 'Per-workspace:');
+  for (const w of a.workspaces) {
+    const ctx = w.hasContext ? 'context:yes' : 'context:MISSING';
+    const top = w.topFailure ? ` · top failure: ${w.topFailure}` : '';
+    L.push(`  - ${w.name}: ${w.turns} turns, ${w.failures} failures, ${ctx}${top}`);
+  }
+
+  L.push(
+    '',
+    'Respond with ONLY a JSON object of this shape (no prose, no markdown fence):',
+    '{"summary": string, "recommendations": [{"kind":"skill|context|test|prompt|connectivity|workflow|other",',
+    '"title": string, "detail": string, "target": string(optional workspace/repo/path),',
+    '"priority":"high|medium|low", "example": string(optional snippet)}]}',
+  );
+  return L.join('\n');
+}

--- a/src/utils/reflect-analyze.ts
+++ b/src/utils/reflect-analyze.ts
@@ -1,4 +1,4 @@
-import { ReflectionCorpus } from './reflect';
+import { ReflectionCorpus, ContextQuality, isCorrectionPrompt } from './reflect';
 
 /**
  * Deterministic analysis layer for `reflect`.
@@ -39,7 +39,8 @@ export interface WorkspaceFact {
   name: string;
   turns: number;
   failures: number;
-  hasContext: boolean;
+  /** Whether the primary context file is missing / boilerplate / substantive. */
+  contextQuality: ContextQuality;
   /** The workspace's single most frequent failure signature, if any. */
   topFailure?: string;
 }
@@ -54,8 +55,13 @@ export interface AnalysisReport {
   topTools: ToolStat[];
   /** How many user prompts looked like corrections/retries (a friction signal). */
   correctionSignals: number;
-  /** Workspaces with NO context file (AGENTS.md/CLAUDE.md/…). */
+  /** Verbatim user re-steer messages across sessions (the sharpest coaching
+   *  signal), most-recent-workspace first, bounded. */
+  reSteerSamples: string[];
+  /** Workspaces with NO context file at all. */
   workspacesMissingContext: string[];
+  /** Workspaces whose context file exists but is just boilerplate/template. */
+  workspacesBoilerplateContext: string[];
   /** Skills already installed (so the judge suggests genuine gaps). */
   availableSkills: string[];
   /** One compact line of facts per workspace, for grounding. */
@@ -85,16 +91,6 @@ export function normalizeErrorSignature(raw: string): string {
   return s.slice(0, 100);
 }
 
-// A conservative "the user corrected / redirected the agent" cue. Soft signal —
-// counted in aggregate, never quoted, so occasional false positives are fine.
-const CORRECTION_RE =
-  /\b(no|nope|wrong|incorrect|revert|undo|instead|actually|you (missed|forgot|broke|didn'?t)|that'?s? (wrong|not right|incorrect)|not what|don'?t)\b/i;
-
-/** Whether a single user prompt reads like a correction/retry. Exported for tests. */
-export function isCorrectionPrompt(prompt: string): boolean {
-  return CORRECTION_RE.test(prompt ?? '');
-}
-
 // ------------------------------------------------------------------ analyze
 
 export interface AnalyzeOptions {
@@ -104,6 +100,8 @@ export interface AnalyzeOptions {
   topTools?: number;
   /** Max chars of a raw error kept as the example (default 160). */
   exampleChars?: number;
+  /** Max verbatim re-steer samples to surface to the judge (default 8). */
+  maxReSteer?: number;
 }
 
 /**
@@ -114,22 +112,25 @@ export function analyzeCorpus(corpus: ReflectionCorpus, opts: AnalyzeOptions = {
   const topErrorsK = opts.topErrors ?? 8;
   const topToolsK = opts.topTools ?? 10;
   const exampleChars = opts.exampleChars ?? 160;
+  const maxReSteer = opts.maxReSteer ?? 8;
 
   const errorMap = new Map<string, { count: number; ws: Set<string>; example: string }>();
   const toolMap = new Map<string, number>();
   const workspacesMissingContext: string[] = [];
+  const workspacesBoilerplateContext: string[] = [];
+  const reSteerSamples: string[] = [];
   const workspaces: WorkspaceFact[] = [];
   let sessionsAnalyzed = 0;
   let totalTurns = 0;
   let correctionSignals = 0;
 
   for (const ws of corpus.workspaces) {
-    const hasContext = ws.contextFiles.length > 0;
-    if (!hasContext) workspacesMissingContext.push(ws.name);
+    if (ws.contextQuality === 'missing') workspacesMissingContext.push(ws.name);
+    else if (ws.contextQuality === 'boilerplate') workspacesBoilerplateContext.push(ws.name);
 
     const s = ws.session;
     if (!s) {
-      workspaces.push({ name: ws.name, turns: 0, failures: 0, hasContext });
+      workspaces.push({ name: ws.name, turns: 0, failures: 0, contextQuality: ws.contextQuality });
       continue;
     }
 
@@ -137,6 +138,9 @@ export function analyzeCorpus(corpus: ReflectionCorpus, opts: AnalyzeOptions = {
     totalTurns += s.turns;
     for (const t of s.tools) toolMap.set(t, (toolMap.get(t) ?? 0) + 1);
     correctionSignals += s.userPrompts.filter(isCorrectionPrompt).length;
+    for (const q of s.reSteerSamples) {
+      if (reSteerSamples.length < maxReSteer) reSteerSamples.push(q);
+    }
 
     // Per-workspace signature tally (drives the global map + this ws's topFailure).
     const localSig = new Map<string, number>();
@@ -154,7 +158,7 @@ export function analyzeCorpus(corpus: ReflectionCorpus, opts: AnalyzeOptions = {
     }
     const topFailure = [...localSig.entries()].sort((a, b) => b[1] - a[1])[0]?.[0];
 
-    workspaces.push({ name: ws.name, turns: s.turns, failures: s.errors.length, hasContext, topFailure });
+    workspaces.push({ name: ws.name, turns: s.turns, failures: s.errors.length, contextQuality: ws.contextQuality, topFailure });
   }
 
   const topErrors: ErrorCluster[] = [...errorMap.entries()]
@@ -175,7 +179,9 @@ export function analyzeCorpus(corpus: ReflectionCorpus, opts: AnalyzeOptions = {
     topErrors,
     topTools,
     correctionSignals,
+    reSteerSamples,
     workspacesMissingContext,
+    workspacesBoilerplateContext,
     availableSkills: corpus.availableSkills,
     workspaces,
   };
@@ -205,8 +211,14 @@ export function buildAnalysisPrompt(a: AnalysisReport): string {
     `Sessions analyzed: ${a.sessionsAnalyzed} across ${a.totalWorkspaces} workspaces (${a.totalTurns} total turns).`,
     `Installed skills (don't re-suggest; find genuine gaps): ${a.availableSkills.join(', ') || '(none)'}`,
     `User correction/retry signals: ${a.correctionSignals} prompt(s) looked like corrections.`,
-    `Workspaces missing a context file (AGENTS.md/CLAUDE.md): ${a.workspacesMissingContext.join(', ') || '(none)'}`,
+    `Workspaces with NO context file (AGENTS.md/CLAUDE.md): ${a.workspacesMissingContext.join(', ') || '(none)'}`,
+    `Workspaces whose context file is just boilerplate/template: ${a.workspacesBoilerplateContext.join(', ') || '(none)'}`,
   );
+
+  if (a.reSteerSamples.length) {
+    L.push('', 'Verbatim user corrections/re-steers (the sharpest signal — quote/act on these):');
+    for (const q of a.reSteerSamples) L.push(`  - “${q.replace(/\n/g, ' ')}”`);
+  }
 
   L.push('', 'Top recurring failures (count × workspaces — example):');
   if (a.topErrors.length === 0) L.push('  (none captured)');
@@ -219,9 +231,8 @@ export function buildAnalysisPrompt(a: AnalysisReport): string {
 
   L.push('', 'Per-workspace:');
   for (const w of a.workspaces) {
-    const ctx = w.hasContext ? 'context:yes' : 'context:MISSING';
     const top = w.topFailure ? ` · top failure: ${w.topFailure}` : '';
-    L.push(`  - ${w.name}: ${w.turns} turns, ${w.failures} failures, ${ctx}${top}`);
+    L.push(`  - ${w.name}: ${w.turns} turns, ${w.failures} failures, context:${w.contextQuality}${top}`);
   }
 
   L.push(

--- a/src/utils/reflect.test.ts
+++ b/src/utils/reflect.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { distillTranscript, parseReflectionReport } from './reflect';
+import { distillTranscript, parseReflectionReport, classifyAgentsMd, isCorrectionPrompt } from './reflect';
 
 const J = (o: unknown) => JSON.stringify(o);
 
@@ -15,6 +15,8 @@ describe('distillTranscript', () => {
       J({ type: 'message', message: { role: 'toolResult', toolName: 'bash', isError: true, content: [{ type: 'text', text: 'command failed: boom' }] } }),
       // claude: user prompt as plain string
       J({ type: 'user', message: { role: 'user', content: 'claude style prompt' } }),
+      // a correction/re-steer → captured verbatim in reSteerSamples
+      J({ type: 'user', message: { role: 'user', content: 'no, that is wrong — revert that change' } }),
       // claude: assistant tool_use
       J({ type: 'assistant', message: { role: 'assistant', content: [{ type: 'tool_use', name: 'Edit' }] } }),
       // claude: tool_result-only user message → an error, NOT a prompt
@@ -31,13 +33,14 @@ describe('distillTranscript', () => {
 
     const d = distillTranscript(lines, { sessionId: 's1', agentType: 'pi' });
     expect(d.turns).toBe(2);
-    expect(d.userPrompts).toEqual(['do the thing', 'claude style prompt']);
+    expect(d.userPrompts).toEqual(['do the thing', 'claude style prompt', 'no, that is wrong — revert that change']);
     expect(d.tools.sort()).toEqual(['Edit', 'bash', 'git', 'grep']);
     expect(d.errors).toContain('command failed: boom'); // explicit isError:true
     expect(d.errors).toContain('file not found'); // explicit is_error:true
     expect(d.errors).toContain('fatal: not a git repository'); // unflagged + strong signal
     expect(d.errors).not.toContain('0 results for error'); // unflagged benign 'error' mention
     expect(d.errors.some((e) => e.includes('flagged success'))).toBe(false); // isError:false trusted
+    expect(d.reSteerSamples).toEqual(['no, that is wrong — revert that change']); // captured verbatim
   });
 
   it('is bounded and tolerant of empty input', () => {
@@ -47,6 +50,26 @@ describe('distillTranscript', () => {
       errors: [],
       tools: [],
     });
+  });
+});
+
+describe('classifyAgentsMd', () => {
+  it('distinguishes missing / boilerplate / substantive', () => {
+    expect(classifyAgentsMd('')).toBe('missing');
+    expect(classifyAgentsMd(null)).toBe('missing');
+    // Generated template: headings + markers, little real guidance.
+    expect(classifyAgentsMd('# Workspace\n\nThis workspace was created with Workspace Manager.\n<!-- ws-rules:v2 -->\n## Notes\n- \n')).toBe('boilerplate');
+    // Real, rule-heavy content.
+    const real = Array.from({ length: 12 }, (_, i) => `- Always run the ${i} integration suite before opening a pull request here`).join('\n');
+    expect(classifyAgentsMd(`# Rules\n${real}`)).toBe('substantive');
+  });
+});
+
+describe('isCorrectionPrompt', () => {
+  it('flags corrections, not normal instructions', () => {
+    expect(isCorrectionPrompt('no, revert that')).toBe(true);
+    expect(isCorrectionPrompt('actually use the other repo instead')).toBe(true);
+    expect(isCorrectionPrompt('add a health check to the api')).toBe(false);
   });
 });
 

--- a/src/utils/reflect.test.ts
+++ b/src/utils/reflect.test.ts
@@ -63,6 +63,15 @@ describe('classifyAgentsMd', () => {
     const real = Array.from({ length: 12 }, (_, i) => `- Always run the ${i} integration suite before opening a pull request here`).join('\n');
     expect(classifyAgentsMd(`# Rules\n${real}`)).toBe('substantive');
   });
+
+  it('is newline-independent: a whitespace-collapsed substantive file still classifies substantive', () => {
+    // Regression for the collapse bug: same content, newlines squashed to spaces.
+    const real = Array.from({ length: 12 }, (_, i) => `- Always run the ${i} integration suite before opening a pull request here`).join('\n');
+    const multiline = `# Rules\n${real}`;
+    const collapsed = multiline.replace(/\s+/g, ' ');
+    expect(classifyAgentsMd(collapsed)).toBe(classifyAgentsMd(multiline));
+    expect(classifyAgentsMd(collapsed)).toBe('substantive');
+  });
 });
 
 describe('isCorrectionPrompt', () => {

--- a/src/utils/reflect.test.ts
+++ b/src/utils/reflect.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { distillTranscript, buildJudgePrompt, parseReflectionReport, ReflectionCorpus } from './reflect';
+import { distillTranscript, parseReflectionReport } from './reflect';
 
 const J = (o: unknown) => JSON.stringify(o);
 
@@ -47,35 +47,6 @@ describe('distillTranscript', () => {
       errors: [],
       tools: [],
     });
-  });
-});
-
-const corpus: ReflectionCorpus = {
-  generatedAt: '2026-01-01T00:00:00Z',
-  availableSkills: ['redash', 'datadog'],
-  workspaces: [
-    {
-      name: 'pay-app',
-      repoCount: 1,
-      repos: ['api'],
-      contextFiles: ['AGENTS.md'],
-      session: { sessionId: 's', agentType: 'pi', turns: 12, userPrompts: ['fix the sync bug'], errors: ['gh_pr_create: not a git repository'], tools: ['bash', 'edit'] },
-    },
-    { name: 'empty-ws', repoCount: 0, repos: [], contextFiles: [], session: null },
-  ],
-};
-
-describe('buildJudgePrompt', () => {
-  const p = buildJudgePrompt(corpus);
-  it('frames the judge task and includes the evidence + guardrails', () => {
-    expect(p).toContain('LLM as a judge');
-    expect(p).toContain('redash, datadog'); // available skills (do not re-suggest)
-    expect(p).toContain('## pay-app');
-    expect(p).toContain('fix the sync bug');
-    expect(p).toContain('gh_pr_create: not a git repository');
-    expect(p).toContain('no recent agent session found'); // empty-ws
-    expect(p).toContain('context files: NONE'); // empty-ws has none
-    expect(p).toMatch(/ONLY a JSON object/);
   });
 });
 

--- a/src/utils/reflect.ts
+++ b/src/utils/reflect.ts
@@ -13,11 +13,17 @@ export interface SessionDigest {
   turns: number;
   /** Human prompts the user sent (the raw material for judging prompt quality). */
   userPrompts: string[];
+  /** Verbatim user “re-steer” messages (corrections/redirects) — the highest-
+   *  signal quotes for the judge to coach on. Subset of userPrompts, bounded. */
+  reSteerSamples: string[];
   /** Error/failure snippets from tool results (missing skills/tests show up here). */
   errors: string[];
   /** Distinct tool names the agent used. */
   tools: string[];
 }
+
+/** How useful a workspace's context file (AGENTS.md/CLAUDE.md) actually is. */
+export type ContextQuality = 'missing' | 'boilerplate' | 'substantive';
 
 export interface WorkspaceDigest {
   name: string;
@@ -25,6 +31,8 @@ export interface WorkspaceDigest {
   repos: string[];
   /** Context files present at the workspace root, e.g. ['AGENTS.md']. */
   contextFiles: string[];
+  /** Whether the primary context file is missing / boilerplate / substantive. */
+  contextQuality: ContextQuality;
   session: SessionDigest | null;
 }
 
@@ -62,8 +70,21 @@ export interface ReflectionReport {
 // fraction of the tokens (~halving the prompt), so the judge actually finishes.
 const MAX_PROMPTS = 12;
 const MAX_ERRORS = 15;
+const MAX_RESTEER = 6;
 const PROMPT_CHARS = 400;
 const ERROR_CHARS = 200;
+const RESTEER_CHARS = 240;
+
+// A conservative “the user corrected / redirected the agent” cue. Soft signal:
+// used to count re-steers and to capture the verbatim message for the judge.
+const CORRECTION_RE =
+  /\b(no|nope|wrong|incorrect|revert|undo|instead|actually|you (missed|forgot|broke|didn'?t)|that'?s? (wrong|not right|incorrect)|not what|don'?t)\b/i;
+
+/** Whether a single user prompt reads like a correction/redirect. Exported +
+ *  shared with the analyzer so the two never diverge. */
+export function isCorrectionPrompt(prompt: string): boolean {
+  return CORRECTION_RE.test(prompt ?? '');
+}
 
 /** Flatten a message `content` (string or content-block array) to plain text. */
 function contentToText(content: unknown): string {
@@ -105,6 +126,7 @@ export function distillTranscript(
   meta: { sessionId: string; agentType: string },
 ): SessionDigest {
   const userPrompts: string[] = [];
+  const reSteerSamples: string[] = [];
   const errors: string[] = [];
   const tools = new Set<string>();
   let turns = 0;
@@ -160,14 +182,60 @@ export function distillTranscript(
         Array.isArray(content) && content.length > 0 && content.every((b: any) => b?.type === 'tool_result');
       if (!isToolResultOnly) {
         const text = contentToText(content).trim();
-        if (text && !text.startsWith('<') && userPrompts.length < MAX_PROMPTS) {
-          userPrompts.push(text.slice(0, PROMPT_CHARS));
+        if (text && !text.startsWith('<')) {
+          if (userPrompts.length < MAX_PROMPTS) userPrompts.push(text.slice(0, PROMPT_CHARS));
+          // Capture corrections verbatim (bounded) — the sharpest coaching signal.
+          if (reSteerSamples.length < MAX_RESTEER && isCorrectionPrompt(text)) {
+            reSteerSamples.push(text.slice(0, RESTEER_CHARS));
+          }
         }
       }
     }
   }
 
-  return { sessionId: meta.sessionId, agentType: meta.agentType, turns, userPrompts, errors, tools: [...tools] };
+  return { sessionId: meta.sessionId, agentType: meta.agentType, turns, userPrompts, reSteerSamples, errors, tools: [...tools] };
+}
+
+// ------------------------------------------------------- context classification
+
+// Lines that are structural/boilerplate rather than real, custom guidance.
+const BOILERPLATE_MARKERS = [
+  'ws-rules:',
+  'this workspace was created with',
+  'workspace manager',
+  'saved context',
+  'add your own notes here',
+  'common workflows',
+];
+
+/**
+ * Classify an AGENTS.md/CLAUDE.md by how much *real* guidance it carries, so the
+ * judge can tell “no context” from “has a file but it's the generated template.”
+ * Heuristic + pure: count substantive lines (real prose/rules), discounting
+ * headings, list scaffolding, code fences, and known generated boilerplate.
+ */
+export function classifyAgentsMd(content: string | null | undefined): ContextQuality {
+  if (!content || !content.trim()) return 'missing';
+  let substantive = 0;
+  let inFence = false;
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    if (line.startsWith('```')) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    if (line.startsWith('#')) continue; // heading
+    if (line.startsWith('|') || /^[-=]{3,}$/.test(line)) continue; // table / rule
+    if (line.startsWith('<!--') || line.startsWith('|---')) continue;
+    const lower = line.toLowerCase();
+    if (BOILERPLATE_MARKERS.some((m) => lower.includes(m))) continue;
+    // A real instruction line: enough words to be more than a label.
+    const words = line.replace(/[*_`>#-]/g, ' ').trim().split(/\s+/).filter(Boolean);
+    if (words.length >= 5) substantive++;
+  }
+  return substantive >= 10 ? 'substantive' : 'boilerplate';
 }
 
 // --------------------------------------------------------- corpus gathering
@@ -242,17 +310,23 @@ async function listAvailableSkills(): Promise<string[]> {
   return [...names].sort();
 }
 
-async function contextFilesFor(workspacePath: string): Promise<string[]> {
+/** Which context files exist at the workspace root, plus how substantive the
+ *  primary one is (missing/boilerplate/substantive). One read per present file. */
+async function contextFilesFor(workspacePath: string): Promise<{ files: string[]; quality: ContextQuality }> {
   const present: string[] = [];
+  let quality: ContextQuality = 'missing';
   for (const name of getAllKnownContextFileNames()) {
     try {
-      await fs.access(path.join(workspacePath, name));
+      const content = await fs.readFile(path.join(workspacePath, name), 'utf-8');
       present.push(name);
+      // Classify the first present file, then keep the best classification seen.
+      const c = classifyAgentsMd(content);
+      if (quality === 'missing' || (quality === 'boilerplate' && c === 'substantive')) quality = c;
     } catch {
-      /* not present */
+      /* not present / unreadable */
     }
   }
-  return present;
+  return { files: present, quality };
 }
 
 /** Fired as each workspace is read + distilled, so the CLI can show live,
@@ -286,11 +360,13 @@ export async function gatherReflectionCorpus(
   for (let index = 0; index < recent.length; index++) {
     const s = recent[index];
     const meta = metaByName.get(s.workspaceName);
+    const context = await contextFilesFor(s.workspacePath);
     const digest: WorkspaceDigest = {
       name: s.workspaceName,
       repoCount: meta?.metadata?.repositories?.length ?? 0,
       repos: (meta?.metadata?.repositories ?? []).map((r) => r.name),
-      contextFiles: await contextFilesFor(s.workspacePath),
+      contextFiles: context.files,
+      contextQuality: context.quality,
       session: await readDigestForSession(s),
     };
     digests.push(digest);

--- a/src/utils/reflect.ts
+++ b/src/utils/reflect.ts
@@ -326,56 +326,8 @@ export const REFLECT_SCHEMA = JSON.stringify({
   required: ['summary', 'recommendations'],
 });
 
-/**
- * Build the LLM-as-a-judge prompt. The judge sees distilled recent sessions and
- * is asked to recommend concrete improvements to the user's SETUP (skills,
- * AGENTS.md/context rules, connectivity/tests, prompt habits, workflow) — not to
- * redo the tasks. Output is strict JSON matching REFLECT_SCHEMA.
- */
-export function buildJudgePrompt(corpus: ReflectionCorpus): string {
-  const lines: string[] = [];
-  lines.push(
-    'You are an expert reviewer ("LLM as a judge") analyzing an engineer\'s recent AI coding-agent sessions.',
-    'Goal: recommend concrete improvements to their SETUP so the agent works better next time —',
-    'which skills to add and WHERE, which AGENTS.md/context rules are missing, missing connectivity/',
-    'smoke tests, and prompt habits to change. Judge the setup, do NOT redo the tasks.',
-    '',
-    'Base every recommendation on evidence in the sessions below (repeated failures, retries, vague',
-    'prompts, missing context). Prefer a few high-signal, actionable items over many generic ones.',
-    'When you suggest a skill or an AGENTS.md rule, include a short concrete `example` snippet.',
-    '',
-    `Globally installed skills (don't re-suggest these; suggest genuinely missing ones): ${corpus.availableSkills.join(', ') || '(none)'}`,
-    '',
-    `Recent workspaces (${corpus.workspaces.length}):`,
-  );
-
-  for (const ws of corpus.workspaces) {
-    lines.push(`\n## ${ws.name}`);
-    lines.push(`repos: ${ws.repos.join(', ') || '(none)'} | context files: ${ws.contextFiles.join(', ') || 'NONE'}`);
-    if (!ws.session) {
-      lines.push('session: (no recent agent session found)');
-      continue;
-    }
-    lines.push(`session: ${ws.session.turns} turns, tools used: ${ws.session.tools.join(', ') || '(none)'}`);
-    if (ws.session.userPrompts.length) {
-      lines.push('user prompts:');
-      for (const p of ws.session.userPrompts) lines.push(`  - ${p.replace(/\n/g, ' ')}`);
-    }
-    if (ws.session.errors.length) {
-      lines.push('errors/failures observed:');
-      for (const e of ws.session.errors) lines.push(`  - ${e.replace(/\n/g, ' ')}`);
-    }
-  }
-
-  lines.push(
-    '',
-    'Respond with ONLY a JSON object of this shape (no prose, no markdown fence):',
-    '{"summary": string, "recommendations": [{"kind":"skill|context|test|prompt|connectivity|workflow|other",',
-    '"title": string, "detail": string, "target": string(optional workspace/repo/path),',
-    '"priority":"high|medium|low", "example": string(optional snippet)}]}',
-  );
-  return lines.join('\n');
-}
+// The judge prompt is now built from pre-computed FACTS (see reflect-analyze.ts
+// `buildAnalysisPrompt`), not raw transcripts, so the LLM call stays small/fast.
 
 // ----------------------------------------------------------- response parse
 

--- a/src/utils/reflect.ts
+++ b/src/utils/reflect.ts
@@ -211,31 +211,28 @@ const BOILERPLATE_MARKERS = [
 /**
  * Classify an AGENTS.md/CLAUDE.md by how much *real* guidance it carries, so the
  * judge can tell “no context” from “has a file but it's the generated template.”
- * Heuristic + pure: count substantive lines (real prose/rules), discounting
- * headings, list scaffolding, code fences, and known generated boilerplate.
+ * Heuristic + pure.
+ *
+ * Deliberately **newline-independent**: it measures the volume of non-boilerplate
+ * prose (word count) plus heading count via a whitespace-tolerant regex, rather
+ * than splitting on lines. A line-anchored version would misclassify any excerpt
+ * whose newlines were collapsed to spaces upstream (a real bug class caught in a
+ * sibling implementation) — here even a fully single-lined file classifies the
+ * same as its multi-line original.
  */
 export function classifyAgentsMd(content: string | null | undefined): ContextQuality {
   if (!content || !content.trim()) return 'missing';
-  let substantive = 0;
-  let inFence = false;
-  for (const rawLine of content.split('\n')) {
-    const line = rawLine.trim();
-    if (!line) continue;
-    if (line.startsWith('```')) {
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence) continue;
-    if (line.startsWith('#')) continue; // heading
-    if (line.startsWith('|') || /^[-=]{3,}$/.test(line)) continue; // table / rule
-    if (line.startsWith('<!--') || line.startsWith('|---')) continue;
-    const lower = line.toLowerCase();
-    if (BOILERPLATE_MARKERS.some((m) => lower.includes(m))) continue;
-    // A real instruction line: enough words to be more than a label.
-    const words = line.replace(/[*_`>#-]/g, ' ').trim().split(/\s+/).filter(Boolean);
-    if (words.length >= 5) substantive++;
-  }
-  return substantive >= 10 ? 'substantive' : 'boilerplate';
+  let s = content.replace(/\r\n/g, '\n').toLowerCase();
+  s = s.replace(/```[\s\S]*?```/g, ' '); // drop fenced code
+  s = s.replace(/<!--[\s\S]*?-->/g, ' '); // drop HTML comments
+  for (const m of BOILERPLATE_MARKERS) s = s.split(m).join(' '); // drop generated boilerplate (markers are lowercase)
+  // Headings: a `#` run at start OR after any whitespace (so a collapsed,
+  // single-line excerpt still counts them), followed by a space.
+  const headings = (s.match(/(?:^|\s)#{1,6}\s/g) || []).length;
+  // Remaining non-boilerplate words (markdown punctuation stripped).
+  const words = s.replace(/[#|>*_`~-]/g, ' ').split(/\s+/).filter((w) => w.length > 1).length;
+  if (words < 40) return 'boilerplate';
+  return headings >= 2 || words >= 60 ? 'substantive' : 'boilerplate';
 }
 
 // --------------------------------------------------------- corpus gathering


### PR DESCRIPTION
Follow-up to #46 / the 0.3.1 progress fix. You were right that **the approach needed to change** — and chasing it surfaced the *actual* root cause of the timeouts.

## 1. The real bug: open stdin (not model speed, not prompt size)
The judge child was spawned with **stdin left as an open pipe** (`execFile`'s default, and `execFileSync` without `input`). A stdin-reading agent like `pi` blocks forever waiting on it, so the run died at the timeout no matter what. Proof:

| invocation | result |
|---|---|
| `pi … -p <prompt>` in a shell (TTY stdin) | **36s** |
| same via `execFile` (open stdin pipe) | **hangs → killed at 45s** |
| same via `spawn` with `stdio:['ignore',…]` (stdin EOF) | **40s** ✓ |

Fix: `spawnCollect()` runs the child with stdin `ignore` (async) and the sync path passes `input:''` — both give immediate EOF. A real `reflect --limit 5` went from **>150s timeout → ~38s**. Regression-tested with a `cat` child that would hang on an open pipe and now EOFs instantly.

## 2. Your suggestion: script does the analysis, LLM gets facts
New deterministic layer `reflect-analyze.ts` (pure, 7 tests) turns the distilled corpus into **aggregated facts** before any LLM call:
- **Error-signature clustering** — normalize each failure (strip paths/numbers/hashes) → group → count + which workspaces + one example. Surfaces *recurring* failures across workspaces (the real signal).
- Tool tallies, **correction/retry** signals, **missing-context** detection, per-workspace one-liners.

The judge prompt is built from those aggregates, so it's **~5KB regardless of workspace count** (was ~25KB and growing) → faster, cheaper, more private, and every recommendation is grounded in a real count. Output shape (`--json`, the report) is unchanged; `--dry-run` now shows the computed facts. Removed the superseded raw-dump `buildJudgePrompt`.

## Result
A live `--limit 5` run now finishes in **~38s** with a grounded report (e.g. *"'command aborted' 23× across 3 workspaces"*, *"edit-tool exact-match failures 5× in 3 ws → add a read-before-edit rule"*).

## Tests
+13 (analyzer clustering/normalization/correction detection + prompt compactness; `spawnCollect` stdin-EOF + exit-code). **469 core** green; typecheck + build clean.

Version **0.3.1 → 0.3.2** (triggers a release on merge → your `release` env approval).
