### PR TITLE
feat(reflect): --workspace filter + save reports to ~/.nemus/reflect/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-08-30
+
+### Added
+
+- **`reflect --workspace <name>`** — analyze a single workspace by name (ignores
+  `--limit`); a clean error if that workspace has no recent Claude/pi session.
+- **`reflect` now saves each report** as timestamped JSON under
+  `~/.nemus/reflect/` (scope suffix for single-workspace runs), so runs can be
+  revisited or diffed over time. Best-effort (never fails the run); disable with
+  **`--no-save`**. The path is printed after a run (and included as `savedTo` in
+  `--json`).
+
 ## [0.3.2] - 2026-08-30
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nemus-cli/nemus",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "workspaces": [
     "packages/*"
   ],

--- a/src/commands/reflect.ts
+++ b/src/commands/reflect.ts
@@ -5,6 +5,7 @@ import { colorize } from '../utils/colors';
 import {
   gatherReflectionCorpus,
   parseReflectionReport,
+  saveReflectionReport,
   REFLECT_SCHEMA,
   ReflectionReport,
   ReflectProgress,
@@ -19,24 +20,40 @@ export function registerReflectCommand(parent: Command) {
     .alias('retro')
     .description('Analyze your recent workspace sessions and suggest skill/prompt/context improvements (LLM-as-a-judge)')
     .option('-n, --limit <n>', 'How many recent workspaces to analyze', '10')
+    .option('-w, --workspace <name>', 'Analyze a single workspace by name (ignores --limit)')
     .option('--model <model>', 'Judge model override (agent-native pattern/id)')
     .option('--thinking <level>', 'Judge thinking level for pi: off|minimal|low|medium|high|xhigh|max')
     .option('--json', 'Output the report as JSON')
+    .option('--no-save', 'Do not save the report to ~/.nemus/reflect/')
     .option('--dry-run', 'Print the assembled corpus + judge prompt without calling the agent')
     .action(async (opts) => {
       await handleReflect(opts);
     });
 }
 
-async function handleReflect(opts: { limit?: string; model?: string; thinking?: string; json?: boolean; dryRun?: boolean }) {
+async function handleReflect(opts: {
+  limit?: string;
+  workspace?: string;
+  model?: string;
+  thinking?: string;
+  json?: boolean;
+  save?: boolean; // commander sets `save: false` for --no-save
+  dryRun?: boolean;
+}) {
   const limit = Math.max(1, Number.parseInt(opts.limit ?? '10', 10) || 10);
   try {
     const showProgress = !opts.json && !opts.dryRun;
     if (showProgress) {
-      logStep(`Analyzing your ${colorize(String(limit), 'cyan')} most recent workspaces…`);
+      logStep(
+        opts.workspace
+          ? `Analyzing workspace ${colorize(opts.workspace, 'cyan')}…`
+          : `Analyzing your ${colorize(String(limit), 'cyan')} most recent workspaces…`,
+      );
     }
 
-    const corpus = await gatherReflectionCorpus(limit, showProgress ? printProgress : undefined);
+    const corpus = await gatherReflectionCorpus(limit, showProgress ? printProgress : undefined, {
+      workspace: opts.workspace,
+    });
     const withSessions = corpus.workspaces.filter((w) => w.session).length;
     // A script does the heavy analysis (clustering failures, counting tools,
     // spotting correction loops); the LLM only ever sees these compact facts,
@@ -54,7 +71,9 @@ async function handleReflect(opts: { limit?: string; model?: string; thinking?: 
     }
 
     if (withSessions === 0) {
-      const msg = 'No recent agent sessions found to analyze (need Claude/pi session transcripts).';
+      const msg = opts.workspace
+        ? `No recent agent session found for workspace "${opts.workspace}" (need a Claude/pi transcript).`
+        : 'No recent agent sessions found to analyze (need Claude/pi session transcripts).';
       if (opts.json) outputJsonError(msg);
       else logError(msg);
       process.exit(1);
@@ -77,11 +96,26 @@ async function handleReflect(opts: { limit?: string; model?: string; thinking?: 
     }
     const report = parseReflectionReport(parsed);
 
+    // Persist the report (best-effort; never fails the run) unless --no-save.
+    let savedTo: string | undefined;
+    if (opts.save !== false) {
+      try {
+        savedTo = await saveReflectionReport(report, {
+          analyzed: withSessions,
+          workspaces: corpus.workspaces.length,
+          workspace: opts.workspace,
+        });
+      } catch {
+        /* saving is a convenience, not the point */
+      }
+    }
+
     if (opts.json) {
-      outputJson({ analyzed: withSessions, workspaces: corpus.workspaces.length, ...report });
+      outputJson({ analyzed: withSessions, workspaces: corpus.workspaces.length, ...report, savedTo });
       return;
     }
     printReport(report, corpus.workspaces.length, withSessions);
+    if (savedTo) logInfo(`Saved report to ${colorize(savedTo, 'dim')}`);
   } catch (error) {
     const msg = error instanceof Error ? error.message : 'reflect failed';
     if (opts.json) outputJsonError(msg);

--- a/src/utils/reflect.test.ts
+++ b/src/utils/reflect.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { distillTranscript, parseReflectionReport, classifyAgentsMd, isCorrectionPrompt } from './reflect';
+import { distillTranscript, parseReflectionReport, classifyAgentsMd, isCorrectionPrompt, saveReflectionReport } from './reflect';
+import * as fs from 'fs/promises';
+import * as path from 'path';
 
 const J = (o: unknown) => JSON.stringify(o);
 
@@ -50,6 +52,24 @@ describe('distillTranscript', () => {
       errors: [],
       tools: [],
     });
+  });
+});
+
+describe('saveReflectionReport', () => {
+  it('writes a timestamped JSON report (sanitized scope) and returns its path', async () => {
+    const file = await saveReflectionReport(
+      { summary: 'ok', recommendations: [{ kind: 'skill', title: 't', detail: 'd', priority: 'high' }] },
+      { analyzed: 2, workspaces: 3, workspace: 'pay/app' },
+    );
+    try {
+      expect(file).toMatch(/\.json$/);
+      expect(path.basename(file)).toContain('pay_app'); // scope suffix, path-sanitized
+      const written = JSON.parse(await fs.readFile(file, 'utf-8'));
+      expect(written).toMatchObject({ analyzed: 2, workspaces: 3, workspace: 'pay/app', summary: 'ok' });
+      expect(written.generatedAt).toBeTruthy();
+    } finally {
+      await fs.rm(file, { force: true });
+    }
   });
 });
 

--- a/src/utils/reflect.ts
+++ b/src/utils/reflect.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { CACHE_DIR } from './config';
 import { listWorkspaces } from './workspace-meta';
 import { getAgentPaths, getSkillsTargetDirs, getAllKnownContextFileNames, ConcreteAgentType } from './agent-config';
 import { pathToProjectDirName, getWorkspaceSessions, WorkspaceSession } from './claude-sessions';
@@ -344,6 +345,7 @@ export interface ReflectProgress {
 export async function gatherReflectionCorpus(
   limit: number,
   onProgress?: (p: ReflectProgress) => void,
+  opts: { workspace?: string } = {},
 ): Promise<ReflectionCorpus> {
   const [sessions, workspaces, availableSkills] = await Promise.all([
     getWorkspaceSessions(), // already sorted by last-active, one per workspace
@@ -351,7 +353,10 @@ export async function gatherReflectionCorpus(
     listAvailableSkills(),
   ]);
   const metaByName = new Map(workspaces.map((w) => [w.name, w]));
-  const recent = sessions.slice(0, limit);
+  // A single named workspace (ignores limit), else the N most recently active.
+  const recent = opts.workspace
+    ? sessions.filter((s) => s.workspaceName === opts.workspace)
+    : sessions.slice(0, limit);
 
   const digests: WorkspaceDigest[] = [];
   for (let index = 0; index < recent.length; index++) {
@@ -427,4 +432,26 @@ export function parseReflectionReport(parsed: unknown): ReflectionReport {
     })
     .filter((r: Recommendation | null): r is Recommendation => r !== null);
   return { summary, recommendations };
+}
+
+// -------------------------------------------------------------- report saving
+
+/** Where saved reflection reports live: `~/.nemus/reflect/`. */
+export const REFLECT_REPORTS_DIR = path.join(CACHE_DIR, 'reflect');
+
+/**
+ * Persist a reflection report as timestamped JSON under `~/.nemus/reflect/`, so
+ * a run can be revisited or diffed over time. Returns the written path. Pure
+ * side-effect (mkdir -p + write); callers treat failure as non-fatal.
+ */
+export async function saveReflectionReport(
+  report: ReflectionReport,
+  meta: { analyzed: number; workspaces: number; workspace?: string },
+): Promise<string> {
+  await fs.mkdir(REFLECT_REPORTS_DIR, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const scope = meta.workspace ? `-${meta.workspace.replace(/[^a-zA-Z0-9_-]+/g, '_')}` : '';
+  const file = path.join(REFLECT_REPORTS_DIR, `${stamp}${scope}.json`);
+  await fs.writeFile(file, JSON.stringify({ generatedAt: new Date().toISOString(), ...meta, ...report }, null, 2));
+  return file;
 }


### PR DESCRIPTION
Follow-up to #47 — two `reflect` quality-of-life features.

## `reflect --workspace <name>`
Analyze a single workspace by name instead of the N most recent (ignores `--limit`). `gatherReflectionCorpus` filters `getWorkspaceSessions()` to that name; a workspace with no recent Claude/pi session gives a clean, specific error rather than the generic "no sessions".

```bash
nemus reflect --workspace my-app        # just this one
```

## Report saving → `~/.nemus/reflect/`
Each run's report is written as timestamped JSON under `~/.nemus/reflect/` (`CACHE_DIR`-based, so it honors `NEMUS_CACHE_DIR`), with a path-sanitized workspace-scope suffix for single-workspace runs. So runs can be revisited or diffed over time.

- **Best-effort**: wrapped in try/catch, never fails the run.
- **On by default**, disabled with `--no-save`.
- Path printed after a human run; included as `savedTo` in `--json`.

## Verified
- `--workspace` filters to one workspace (dry-run); unknown name → clean error; live run ~27s and wrote `~/.nemus/reflect/2026-…-<workspace>.json`.
- +1 test (save writes + returns path, sanitized scope, JSON content). **476 core** green; typecheck + build clean.

Version **0.3.2 → 0.3.3**.
