### PR TITLE
feat(cloud): Kubernetes Job runner (any cluster, kubectl-based)

### DIFF
--- a/docs/plans/2026-08-26-cloud-iac.md
+++ b/docs/plans/2026-08-26-cloud-iac.md
@@ -184,6 +184,17 @@ in log streams. PAT is always the zero-config fallback.
   summary. Exposed as `nemus-cloud fix-pr --repo --pr --branch` (+ `--max-
   iterations`/`--poll-interval-ms`/`--max-polls`).
 - **P4 — more providers (plugins), optional Slack, optional hosted UI.** _(in progress)_
+  **Kubernetes runner done:** `KubernetesJobRunner` (`kubernetes`) — renders a
+  `batch/v1` **Job** (`backoffLimit: 0` one-shot, `ttlSecondsAfterFinished` GC,
+  `restartPolicy: Never`) and shells `kubectl`: `apply -f - -o json` to launch,
+  `get job -o json` → `Status`, `logs -f job/<name>` streaming, `kubectl exec`
+  into the job's pod (flags before `--`), `delete job` on stop. Targets ANY
+  cluster (EKS/GKE/AKS/k3s/kind/on-prem) from a hand-written descriptor
+  (`extra.namespace`/`context`/`service_account`/`image_pull_secret`) — no IaC
+  required, the proof the runner seam isn't Fargate-shaped. All I/O (kubectl
+  invocation, log stream, manifest write) injected → unit-tested without a
+  cluster. Follow-up: an `iac/kubernetes` OpenTofu module (namespace + SA + RBAC
+  + pull secret) that emits the descriptor.
   **Notification seam done:** a vendor-neutral `Notifier` (best-effort, zero-dep
   via `fetch`) with `SlackNotifier` (incoming webhook), `WebhookNotifier`
   (generic JSON sink), `MultiNotifier`/`NoopNotifier`, and `notifierFromEnv`

--- a/packages/cloud/README.md
+++ b/packages/cloud/README.md
@@ -62,6 +62,32 @@ await runner.status(handle); // { state: 'succeeded' | 'failed' | … }
 The **`docker` runner is the portability boundary's proof**: if a feature can't
 work against a local Docker socket, it doesn't belong in core.
 
+### Built-in runners
+
+| Runner (`TargetDescriptor.runner`) | Backend | Needs | `exec` | `logStream` |
+| --- | --- | --- | --- | --- |
+| `docker` | local Docker/Podman | a Docker socket | ✅ | ✅ |
+| `aws-fargate` | AWS ECS Fargate | `aws` CLI + the `iac/fargate` target | ✖ | ✅ (CloudWatch) |
+| `kubernetes` | a Kubernetes **Job**, any cluster (EKS/GKE/AKS/k3s/kind/on-prem) | `kubectl` + a reachable context | ✅ (`kubectl exec`) | ✅ (`kubectl logs -f`) |
+
+The **`kubernetes`** runner is the clearest proof the seam isn't Fargate-shaped:
+it shells `kubectl`, renders a `batch/v1` Job (`backoffLimit: 0`, one-shot,
+`ttlSecondsAfterFinished` GC), and needs no IaC — hand-write a descriptor to
+target any cluster you already have:
+
+```ts
+const runner = createRunner('kubernetes');
+const handle = await runner.launch(spec, {
+  version: 1,
+  runner: 'kubernetes',
+  extra: { namespace: 'agents', context: 'my-cluster', service_account: 'nemus-agent', image_pull_secret: 'ghcr-pull' },
+});
+```
+
+All of a runner's I/O (`kubectl`/`aws`/`docker` invocation, log streaming, and —
+for k8s — the manifest write) is injectable, so every backend is unit-tested
+without a cloud account or a cluster.
+
 ## The provisioning seam: IaC modules
 
 Provisioning (stand up a place to run) is split from execution (run a task).

--- a/packages/cloud/src/index.ts
+++ b/packages/cloud/src/index.ts
@@ -18,6 +18,8 @@ export { DockerRunner } from './runner/docker';
 export type { DockerRunnerOptions, CommandRunner, LogStreamer } from './runner/docker';
 export { FargateRunner, mapFargateState } from './runner/fargate';
 export type { FargateRunnerOptions } from './runner/fargate';
+export { KubernetesJobRunner, mapJobState, k8sResources } from './runner/kubernetes';
+export type { KubernetesRunnerOptions, ManifestWriter } from './runner/kubernetes';
 export { createRunner, registerRunner, runnerNames } from './runner/registry';
 export type { RunnerFactory } from './runner/registry';
 

--- a/packages/cloud/src/runner/kubernetes.test.ts
+++ b/packages/cloud/src/runner/kubernetes.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest';
+import { KubernetesJobRunner, mapJobState, k8sResources } from './kubernetes';
+import { createRunner, runnerNames } from './registry';
+import { CommandRunner, LogStreamer } from './docker';
+import { TargetDescriptor, TaskSpec, LogLine } from './types';
+
+const target: TargetDescriptor = {
+  version: 1,
+  runner: 'kubernetes',
+  extra: {
+    namespace: 'agents',
+    context: 'prod-cluster',
+    service_account: 'nemus-agent',
+    image_pull_secret: 'ghcr-pull',
+  },
+};
+
+const spec: TaskSpec = {
+  image: 'ghcr.io/acme/agent:latest',
+  env: { NEMUS_TASK: 'do it', GIT_TOKEN: 't' },
+  command: ['nemus-cloud-agent'],
+  resources: { cpu: 0.5, memoryMB: 2048 },
+  labels: { 'nemus.owner': 'octocat', 'nemus.agent': 'pi' },
+};
+
+/** A kubectl mock: returns queued JSON by "verb kind" and records calls +
+ *  the manifest written to disk. */
+function kubectlMock(responses: Record<string, unknown>) {
+  const calls: string[][] = [];
+  let manifest: any;
+  const run: CommandRunner = async (_bin, args) => {
+    calls.push(args);
+    const key = `${args[0]} ${args[1]}`; // e.g. 'apply -f' -> 'apply -f'
+    const resp = responses[`${args[0]} ${args[1]}`] ?? responses[args[0]];
+    // jsonpath (raw) responses come back as plain strings.
+    const body = typeof resp === 'string' ? resp : JSON.stringify(resp ?? {});
+    return { code: 0, stdout: body, stderr: '' };
+  };
+  const writeManifest = async (content: string) => {
+    manifest = JSON.parse(content);
+    return { path: '/tmp/job.json', cleanup: async () => {} };
+  };
+  return { run, writeManifest, calls, getManifest: () => manifest };
+}
+
+describe('KubernetesJobRunner.launch', () => {
+  it('renders a batch/v1 Job manifest and applies it, wiring target + spec', async () => {
+    const { run, writeManifest, calls, getManifest } = kubectlMock({
+      apply: { metadata: { name: 'nemus-agent-deadbeef' } },
+    });
+    const runner = new KubernetesJobRunner({ run, writeManifest });
+    const handle = await runner.launch(spec, target);
+
+    const m = getManifest();
+    expect(m.apiVersion).toBe('batch/v1');
+    expect(m.kind).toBe('Job');
+    expect(m.metadata.namespace).toBe('agents');
+    expect(m.spec.backoffLimit).toBe(0); // one-shot
+    const pod = m.spec.template.spec;
+    expect(pod.restartPolicy).toBe('Never');
+    expect(pod.serviceAccountName).toBe('nemus-agent');
+    expect(pod.imagePullSecrets).toEqual([{ name: 'ghcr-pull' }]);
+    const c = pod.containers[0];
+    expect(c.image).toBe('ghcr.io/acme/agent:latest');
+    expect(c.command).toEqual(['nemus-cloud-agent']);
+    expect(c.env).toContainEqual({ name: 'NEMUS_TASK', value: 'do it' });
+    expect(c.resources.requests.cpu).toBe('500m'); // 0.5 vCPU -> milliCPU
+    expect(c.resources.requests.memory).toBe('2048Mi');
+    expect(c.resources.limits.memory).toBe('2048Mi');
+
+    // kubectl apply argv carries namespace + context.
+    const apply = calls[0];
+    expect(apply.slice(0, 3)).toEqual(['apply', '-f', '/tmp/job.json']);
+    expect(apply).toEqual(expect.arrayContaining(['-o', 'json', '--namespace', 'agents', '--context', 'prod-cluster']));
+
+    // Handle carries the server-assigned name.
+    expect(handle.runner).toBe('kubernetes');
+    expect(handle.id).toBe('nemus-agent-deadbeef');
+  });
+
+  it('rejects a mismatched target and unresolved secrets', async () => {
+    const { run, writeManifest } = kubectlMock({});
+    const runner = new KubernetesJobRunner({ run, writeManifest });
+    await expect(runner.launch(spec, { version: 1, runner: 'docker' })).rejects.toThrow(/target is for "docker"/);
+    await expect(
+      runner.launch({ ...spec, secrets: [{ name: 'X', from: 'dotenv:X' }] }, target),
+    ).rejects.toThrow(/no secret store/);
+  });
+});
+
+describe('KubernetesJobRunner.status', () => {
+  const cases: Array<[Record<string, number>, string, number | undefined]> = [
+    [{ succeeded: 1 }, 'succeeded', 0],
+    [{ failed: 1 }, 'failed', 1],
+    [{ active: 1 }, 'running', undefined],
+    [{}, 'pending', undefined],
+  ];
+  for (const [status, state, exitCode] of cases) {
+    it(`maps job status ${JSON.stringify(status)} -> ${state}`, async () => {
+      const { run } = kubectlMock({ 'get job': { status } });
+      const runner = new KubernetesJobRunner({ run, writeManifest: async () => ({ path: '/x', cleanup: async () => {} }) });
+      const st = await runner.status({ runner: 'kubernetes', id: 'j', raw: { namespace: 'agents', jobName: 'j' } });
+      expect(st.state).toBe(state);
+      expect(st.exitCode).toBe(exitCode);
+    });
+  }
+});
+
+describe('KubernetesJobRunner.exec', () => {
+  it('resolves the job pod then execs argv into it', async () => {
+    const calls: string[][] = [];
+    const run: CommandRunner = async (_bin, args) => {
+      calls.push(args);
+      if (args[0] === 'get' && args[1] === 'pods') return { code: 0, stdout: 'nemus-agent-x-abcde', stderr: '' };
+      return { code: 0, stdout: 'hi', stderr: '' };
+    };
+    const runner = new KubernetesJobRunner({ run, writeManifest: async () => ({ path: '/x', cleanup: async () => {} }) });
+    const res = await runner.exec({ runner: 'kubernetes', id: 'j', raw: { namespace: 'agents', jobName: 'j' } }, ['echo', 'hi']);
+    expect(res).toEqual({ exitCode: 0, stdout: 'hi', stderr: '' });
+    const execCall = calls.find((a) => a[0] === 'exec')!;
+    // Namespace flag MUST come before the `--` separator (else it's an arg to echo).
+    expect(execCall).toEqual(['exec', 'nemus-agent-x-abcde', '--namespace', 'agents', '--', 'echo', 'hi']);
+  });
+});
+
+describe('KubernetesJobRunner.logs / stop', () => {
+  it('streams `logs -f job/<name>` and deletes the job on stop', async () => {
+    const streamed: string[][] = [];
+    const stream: LogStreamer = async function* (_bin, args) {
+      streamed.push(args);
+      yield { stream: 'stdout', line: 'hello' } as LogLine;
+    };
+    const calls: string[][] = [];
+    const run: CommandRunner = async (_bin, args) => (calls.push(args), { code: 0, stdout: '', stderr: '' });
+    const runner = new KubernetesJobRunner({ run, stream, writeManifest: async () => ({ path: '/x', cleanup: async () => {} }) });
+    const handle = { runner: 'kubernetes', id: 'j', raw: { namespace: 'agents', jobName: 'j' } };
+
+    const lines: LogLine[] = [];
+    for await (const l of runner.logs(handle)) lines.push(l);
+    expect(lines).toEqual([{ stream: 'stdout', line: 'hello' }]);
+    expect(streamed[0]).toEqual(expect.arrayContaining(['logs', 'job/j', '--follow', '--namespace', 'agents']));
+
+    await runner.stop(handle);
+    expect(calls[0]).toEqual(expect.arrayContaining(['delete', 'job', 'j', '--wait=false', '--ignore-not-found']));
+  });
+});
+
+describe('kubectl error handling', () => {
+  it('surfaces a non-zero kubectl exit', async () => {
+    const run: CommandRunner = async () => ({ code: 1, stdout: '', stderr: 'Error from server (NotFound)' });
+    const runner = new KubernetesJobRunner({ run, writeManifest: async () => ({ path: '/x', cleanup: async () => {} }) });
+    await expect(runner.status({ runner: 'kubernetes', id: 'j', raw: { namespace: 'agents', jobName: 'j' } })).rejects.toThrow(
+      /kubectl get job failed \(1\): Error from server/,
+    );
+  });
+});
+
+describe('k8sResources', () => {
+  it('maps vCPU + memory, and returns undefined when nothing is set', () => {
+    expect(k8sResources({ cpu: 2, memoryMB: 4096 })).toEqual({ requests: { cpu: '2', memory: '4096Mi' }, limits: { cpu: '2', memory: '4096Mi' } });
+    expect(k8sResources({ cpu: 0.25 })).toEqual({ requests: { cpu: '250m' }, limits: { cpu: '250m' } });
+    expect(k8sResources(undefined)).toBeUndefined();
+    expect(k8sResources({})).toBeUndefined();
+  });
+});
+
+describe('mapJobState', () => {
+  it('prioritizes terminal states over active', () => {
+    expect(mapJobState({ succeeded: 1, active: 1 })).toBe('succeeded');
+    expect(mapJobState({ failed: 1 })).toBe('failed');
+    expect(mapJobState({ active: 2 })).toBe('running');
+    expect(mapJobState({})).toBe('pending');
+  });
+});
+
+describe('registry', () => {
+  it('registers kubernetes and creates it', () => {
+    expect(runnerNames()).toContain('kubernetes');
+    expect(createRunner('kubernetes').id).toBe('kubernetes');
+  });
+});

--- a/packages/cloud/src/runner/kubernetes.ts
+++ b/packages/cloud/src/runner/kubernetes.ts
@@ -1,0 +1,308 @@
+import { spawn } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { CommandRunner, LogStreamer } from './docker';
+import { shellExec } from '../agent/exec';
+import {
+  Capabilities,
+  ExecResult,
+  Handle,
+  LogLine,
+  Runner,
+  Status,
+  TargetDescriptor,
+  TaskSpec,
+} from './types';
+
+/** Writes a manifest to a temp file and returns its path (injectable for tests). */
+export type ManifestWriter = (content: string) => Promise<{ path: string; cleanup: () => Promise<void> }>;
+
+export interface KubernetesRunnerOptions {
+  /** kubectl binary (default 'kubectl'). */
+  bin?: string;
+  run?: CommandRunner;
+  stream?: LogStreamer;
+  writeManifest?: ManifestWriter;
+  /** Job name prefix + container name (default 'nemus-agent'). */
+  namePrefix?: string;
+}
+
+const K8S_CAPS: Capabilities = {
+  exec: true, // kubectl exec into the job's pod
+  logStream: true, // kubectl logs -f
+  persistentDisk: false, // no PVC wired yet (a future opt-in via target.extra)
+  secretStore: false, // resolve TaskSpec.secrets into env before launch (like docker/fargate)
+  portForward: true, // kubectl port-forward
+};
+
+/** Stashed on the Handle so status/logs/exec/stop can reach the cluster. Core
+ *  never reads this. */
+interface K8sHandleRaw {
+  namespace: string;
+  context?: string;
+  jobName: string;
+}
+
+/**
+ * Runs one task as a Kubernetes **Job** (`batch/v1`). Vendor-neutral compute:
+ * the same descriptor works on EKS/GKE/AKS, k3s, kind, or an on-prem cluster —
+ * the litmus test for the runner seam being real and not Fargate-shaped.
+ *
+ * Dependency-free: shells `kubectl` (like DockerRunner shells docker), reads its
+ * target from the descriptor (`extra.namespace`, `extra.context`,
+ * `extra.service_account`, `extra.image_pull_secret`). launch = render a Job
+ * manifest → `kubectl apply -f - -o json`; the manifest write + every kubectl
+ * call are injected, so the JSON parsing + argv are unit-tested without a
+ * cluster.
+ */
+export class KubernetesJobRunner implements Runner {
+  readonly id = 'kubernetes';
+  readonly capabilities = K8S_CAPS;
+  private readonly bin: string;
+  private readonly run: CommandRunner;
+  private readonly stream: LogStreamer;
+  private readonly writeManifest: ManifestWriter;
+  private readonly namePrefix: string;
+
+  constructor(opts: KubernetesRunnerOptions = {}) {
+    this.bin = opts.bin ?? 'kubectl';
+    this.run = opts.run ?? ((b, a) => shellExec(b, a));
+    this.stream = opts.stream ?? defaultKubectlStream;
+    this.writeManifest = opts.writeManifest ?? defaultManifestWriter;
+    this.namePrefix = opts.namePrefix ?? 'nemus-agent';
+  }
+
+  async launch(spec: TaskSpec, target: TargetDescriptor): Promise<Handle> {
+    if (target.runner !== this.id) {
+      throw new Error(`kubernetes runner: target is for "${target.runner}", not "${this.id}"`);
+    }
+    if (spec.secrets?.length) {
+      throw new Error(
+        'kubernetes runner has no secret store wired — resolve TaskSpec.secrets into env before launch',
+      );
+    }
+    const extra = (target.extra ?? {}) as Record<string, unknown>;
+    const namespace = String(extra.namespace ?? 'default');
+    const context = extra.context ? String(extra.context) : undefined;
+
+    const jobName = `${this.namePrefix}-${randomBytes(4).toString('hex')}`;
+    const manifest = this.buildJobManifest(spec, { jobName, namespace, extra });
+
+    const { path, cleanup } = await this.writeManifest(JSON.stringify(manifest));
+    try {
+      const applied = await this.kubectl(
+        ['apply', '-f', path, '-o', 'json'],
+        { namespace, context },
+      );
+      const createdName: string = applied?.metadata?.name ?? jobName;
+      const raw: K8sHandleRaw = { namespace, context, jobName: createdName };
+      return { runner: this.id, id: createdName, raw };
+    } finally {
+      await cleanup().catch(() => undefined);
+    }
+  }
+
+  async status(handle: Handle): Promise<Status> {
+    const raw = handle.raw as K8sHandleRaw;
+    const job = await this.kubectl(['get', 'job', raw.jobName, '-o', 'json'], raw);
+    const st = job?.status ?? {};
+    const state = mapJobState(st);
+    // A Job doesn't carry the container exit code; surface 0/1 by terminal state
+    // so callers relying on exitCode still get a sensible success/failure signal.
+    const exitCode = state === 'succeeded' ? 0 : state === 'failed' ? 1 : undefined;
+    return {
+      state,
+      exitCode,
+      startedAt: parseDate(st.startTime),
+      finishedAt: parseDate(st.completionTime),
+    };
+  }
+
+  logs(handle: Handle): AsyncIterable<LogLine> {
+    const raw = handle.raw as K8sHandleRaw;
+    // `job/<name>` follows the job's pod; --all-containers + --ignore-errors so a
+    // not-yet-scheduled pod doesn't abort the stream.
+    const args = nsArgs(['logs', `job/${raw.jobName}`, '--follow', '--all-containers', '--ignore-errors'], raw);
+    return this.stream(this.bin, args);
+  }
+
+  async exec(handle: Handle, argv: string[]): Promise<ExecResult> {
+    const raw = handle.raw as K8sHandleRaw;
+    // Resolve the job's (first) pod, then exec into it.
+    const pods = await this.kubectl(
+      ['get', 'pods', '-l', `job-name=${raw.jobName}`, '-o', 'jsonpath={.items[0].metadata.name}'],
+      raw,
+      { raw: true },
+    );
+    const pod = String(pods).trim();
+    if (!pod) throw new Error(`kubernetes exec: no pod found for job ${raw.jobName}`);
+    // kubectl flags (`--namespace`/`--context`) MUST precede the `--` separator,
+    // or they'd be passed as arguments to the exec'd command instead.
+    const { code, stdout, stderr } = await this.run(
+      this.bin,
+      [...nsArgs(['exec', pod], raw), '--', ...argv],
+    );
+    return { exitCode: code, stdout, stderr };
+  }
+
+  async stop(handle: Handle): Promise<void> {
+    const raw = handle.raw as K8sHandleRaw;
+    // Delete the Job and its pods; don't block teardown waiting for finalizers.
+    await this.run(this.bin, nsArgs(['delete', 'job', raw.jobName, '--wait=false', '--ignore-not-found'], raw));
+  }
+
+  /** Build the batch/v1 Job manifest (pure → unit-tested). */
+  buildJobManifest(
+    spec: TaskSpec,
+    opts: { jobName: string; namespace: string; extra: Record<string, unknown> },
+  ): Record<string, unknown> {
+    const env = Object.entries(spec.env ?? {}).map(([name, value]) => ({ name, value }));
+    const labels = sanitizeLabels(spec.labels);
+
+    const container: Record<string, unknown> = {
+      name: this.namePrefix,
+      image: spec.image,
+      env,
+      imagePullPolicy: 'IfNotPresent',
+    };
+    if (spec.command?.length) container.command = spec.command;
+    const resources = k8sResources(spec.resources);
+    if (resources) container.resources = resources;
+
+    const podSpec: Record<string, unknown> = {
+      restartPolicy: 'Never',
+      containers: [container],
+    };
+    if (opts.extra.service_account) podSpec.serviceAccountName = String(opts.extra.service_account);
+    if (opts.extra.image_pull_secret) podSpec.imagePullSecrets = [{ name: String(opts.extra.image_pull_secret) }];
+
+    return {
+      apiVersion: 'batch/v1',
+      kind: 'Job',
+      metadata: { name: opts.jobName, namespace: opts.namespace, labels },
+      spec: {
+        backoffLimit: 0, // one shot: don't silently re-run the agent on failure
+        ttlSecondsAfterFinished: 3600, // let the cluster GC finished jobs after 1h
+        template: {
+          metadata: { labels: { ...labels, 'job-name': opts.jobName } },
+          spec: podSpec,
+        },
+      },
+    };
+  }
+
+  /** Run a kubectl subcommand; parse JSON stdout unless `raw`. */
+  private async kubectl(
+    args: string[],
+    scope: { namespace: string; context?: string },
+    opts: { raw?: boolean } = {},
+  ): Promise<any> {
+    const full = nsArgs(args, scope);
+    const { code, stdout, stderr } = await this.run(this.bin, full);
+    if (code !== 0) {
+      throw new Error(`kubectl ${args.slice(0, 2).join(' ')} failed (${code}): ${stderr.trim() || stdout.trim()}`);
+    }
+    if (opts.raw) return stdout;
+    if (!stdout.trim()) return {};
+    try {
+      return JSON.parse(stdout);
+    } catch {
+      throw new Error(`kubectl ${args.slice(0, 2).join(' ')}: could not parse JSON output`);
+    }
+  }
+}
+
+/** Append `--namespace` (+ optional `--context`) to a kubectl argv. Pure. */
+function nsArgs(args: string[], scope: { namespace: string; context?: string }): string[] {
+  const out = [...args, '--namespace', scope.namespace];
+  if (scope.context) out.push('--context', scope.context);
+  return out;
+}
+
+/** Map a Job `.status` to the neutral TaskState. */
+export function mapJobState(status: { succeeded?: number; failed?: number; active?: number }): Status['state'] {
+  if (status.succeeded && status.succeeded > 0) return 'succeeded';
+  if (status.failed && status.failed > 0) return 'failed';
+  if (status.active && status.active > 0) return 'running';
+  return 'pending'; // created, no pod scheduled yet
+}
+
+/** TaskSpec.resources → k8s requests/limits, or undefined if nothing set. */
+export function k8sResources(resources?: TaskSpec['resources']): Record<string, unknown> | undefined {
+  if (!resources || (!resources.cpu && !resources.memoryMB)) return undefined;
+  const req: Record<string, string> = {};
+  if (resources.cpu) req.cpu = cpuQuantity(resources.cpu);
+  if (resources.memoryMB) req.memory = `${Math.round(resources.memoryMB)}Mi`;
+  // requests == limits: the agent box should get what it asks for, and a hard
+  // memory limit prevents one runaway task from evicting neighbours.
+  return { requests: { ...req }, limits: { ...req } };
+}
+
+/** vCPU count → k8s CPU quantity (fractional → milliCPU). */
+function cpuQuantity(cpu: number): string {
+  if (cpu < 1) return `${Math.round(cpu * 1000)}m`;
+  return String(cpu);
+}
+
+/** Labels must be valid k8s label values (alphanumeric, '-', '_', '.', <=63). A
+ *  label that can't be encoded is dropped rather than failing the launch. */
+function sanitizeLabels(labels?: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(labels ?? {})) {
+    const key = k.replace(/[^A-Za-z0-9._/-]/g, '_');
+    const val = v.replace(/[^A-Za-z0-9._-]/g, '_').slice(0, 63);
+    if (key && val) out[key] = val;
+  }
+  return out;
+}
+
+function parseDate(s?: string): Date | undefined {
+  if (!s) return undefined;
+  const t = new Date(s).getTime();
+  return Number.isFinite(t) ? new Date(t) : undefined;
+}
+
+/** Default manifest writer: a temp dir with the JSON, cleaned up after apply. */
+const defaultManifestWriter: ManifestWriter = async (content) => {
+  const dir = await mkdtemp(join(tmpdir(), 'nemus-k8s-'));
+  const path = join(dir, 'job.json');
+  await writeFile(path, content, 'utf8');
+  return { path, cleanup: () => rm(dir, { recursive: true, force: true }) };
+};
+
+/** `kubectl logs -f` streamer (line-split stdout/stderr). */
+const defaultKubectlStream: LogStreamer = async function* (bin, args) {
+  const child = spawn(bin, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+  const queue: LogLine[] = [];
+  let done = false;
+  let failure: Error | undefined;
+  let notify: (() => void) | null = null;
+  const push = (stream: LogLine['stream']) => (buf: Buffer) => {
+    for (const raw of buf.toString().split('\n')) {
+      if (raw === '') continue;
+      queue.push({ stream, line: raw });
+    }
+    notify?.();
+  };
+  child.stdout.on('data', push('stdout'));
+  child.stderr.on('data', push('stderr'));
+  child.on('error', (e) => {
+    failure = e instanceof Error ? e : new Error(String(e));
+    done = true;
+    notify?.();
+  });
+  child.on('close', () => {
+    done = true;
+    notify?.();
+  });
+  while (!done || queue.length) {
+    if (queue.length) yield queue.shift()!;
+    else {
+      await new Promise<void>((r) => (notify = r));
+      notify = null;
+    }
+  }
+  if (failure) throw new Error(`kubectl logs stream failed: ${failure.message}`);
+};

--- a/packages/cloud/src/runner/registry.ts
+++ b/packages/cloud/src/runner/registry.ts
@@ -1,6 +1,7 @@
 import { Runner } from './types';
 import { DockerRunner, DockerRunnerOptions } from './docker';
 import { FargateRunner, FargateRunnerOptions } from './fargate';
+import { KubernetesJobRunner, KubernetesRunnerOptions } from './kubernetes';
 
 /**
  * A runner factory. Third-party backends ship as `@nemus-cli/cloud-<name>` and
@@ -37,3 +38,5 @@ export function createRunner(name: string, opts?: Record<string, unknown>): Runn
 registerRunner('docker', (opts) => new DockerRunner(opts as DockerRunnerOptions));
 // AWS ECS Fargate (pairs with the iac/fargate module). Dependency-free (aws CLI).
 registerRunner('aws-fargate', (opts) => new FargateRunner(opts as FargateRunnerOptions));
+// Kubernetes Job — any cluster (EKS/GKE/AKS/k3s/kind/on-prem). Dependency-free (kubectl).
+registerRunner('kubernetes', (opts) => new KubernetesJobRunner(opts as KubernetesRunnerOptions));


### PR DESCRIPTION
Continues the cloud package (P4 — more providers). Adds a **second real runner** to prove the execution seam is genuinely generic and not Fargate-shaped.

## `KubernetesJobRunner` (`kubernetes`)
Runs one task as a `batch/v1` **Job** on **any** cluster (EKS/GKE/AKS/k3s/kind/on-prem), shelling `kubectl` — the same dependency-free, injected-I/O pattern as the docker/fargate runners.

| Op | How |
|---|---|
| `launch` | render a one-shot Job manifest (`backoffLimit: 0`, `restartPolicy: Never`, `ttlSecondsAfterFinished` GC) → `kubectl apply -f - -o json` |
| `status` | `kubectl get job -o json` → mapped `TaskState` (terminal states beat `active`) |
| `logs` | stream `kubectl logs -f job/<name> --all-containers --ignore-errors` |
| `exec` | resolve the job's pod (jsonpath) → `kubectl exec` |
| `stop` | `kubectl delete job --wait=false --ignore-not-found` |

- **No IaC required**: target any cluster you already have with a hand-written `TargetDescriptor` (`extra.namespace`/`context`/`service_account`/`image_pull_secret`) — the design's "bring your own infra and skip IaC" path.
- CPU → milliCPU, memoryMB → `Mi`, `requests == limits`. Labels sanitized to valid k8s label values.
- **Capabilities:** `exec` ✅ (kubectl exec), `logStream` ✅, `portForward` ✅, `secretStore` ✖ (resolve `TaskSpec.secrets` → env before launch, like docker/fargate), `persistentDisk` ✖ (PVC is a future opt-in).

## Testable without a cluster
Every kubectl invocation, the log stream, and the manifest write are injected, so all paths are unit-tested with mocks — no cluster, no cloud account.

## Self-review
Caught + fixed one real bug before pushing: `exec` appended `--namespace` **after** the `--` separator, so kubectl would have passed it as an argument to the exec'd command instead of treating it as a flag. Moved kubectl flags before `--`, with a test asserting the order.

**+12 tests → 163 cloud.** typecheck + build clean. Registered as `kubernetes`, exported from the package index, README runner table + plan P4 updated.

Follow-up (noted in the plan): an `iac/kubernetes` OpenTofu module (namespace + ServiceAccount + RBAC + pull secret) that emits the descriptor. Cloud package is private/not published, so this doesn't trigger a release.
