### PR TITLE
refactor(shell): move integration out of shell rc files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4] - 2026-08-31
+
+### Changed
+
+- **Shell integration now keeps generated functions out of shell RC files.**
+  Nemus stores them in `~/.nemus/shell-integration.sh` and adds only a guarded
+  source line to `.zshrc` or `.bashrc`. Existing inline installations migrate
+  without losing surrounding user configuration.
+
 ## [0.3.3] - 2026-08-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -138,9 +138,7 @@ npm install -g @nemus-cli/nemus
 ```
 
 The postinstall step sets up optional shell integration (auto-cd into new
-workspaces + a quick-navigate helper). It keeps the generated functions in
-`~/.nemus/shell-integration.sh` and adds only a source line to your shell RC
-file.
+workspaces + a quick-navigate helper).
 
 ### From source
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ npm install -g @nemus-cli/nemus
 ```
 
 The postinstall step sets up optional shell integration (auto-cd into new
-workspaces + a quick-navigate helper).
+workspaces + a quick-navigate helper). It keeps the generated functions in
+`~/.nemus/shell-integration.sh` and adds only a source line to your shell RC
+file.
 
 ### From source
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -147,7 +147,9 @@ npm install -g @nemus-cli/nemus
 ```
 
 The postinstall step sets up optional shell integration (auto-cd into new
-workspaces + a quick-navigate helper).
+workspaces + a quick-navigate helper). It keeps the generated functions in
+`~/.nemus/shell-integration.sh` and adds only a source line to your shell RC
+file.
 
 ### From source
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -147,9 +147,7 @@ npm install -g @nemus-cli/nemus
 ```
 
 The postinstall step sets up optional shell integration (auto-cd into new
-workspaces + a quick-navigate helper). It keeps the generated functions in
-`~/.nemus/shell-integration.sh` and adds only a source line to your shell RC
-file.
+workspaces + a quick-navigate helper).
 
 ### From source
 

--- a/install-shell-integration.sh
+++ b/install-shell-integration.sh
@@ -491,30 +491,17 @@ else
   exit 1
 fi
 
-# Keep the generated functions out of the user's shell config. The same file
-# works in both bash and zsh; the RC file only needs this guarded source line.
-SHELL_INTEGRATION_DIR="$HOME/.nemus"
-SHELL_INTEGRATION_FILE="$SHELL_INTEGRATION_DIR/shell-integration.sh"
-SOURCE_LINE='[ -f "$HOME/.nemus/shell-integration.sh" ] && source "$HOME/.nemus/shell-integration.sh"'
-
-mkdir -p "$SHELL_INTEGRATION_DIR"
-SHELL_TMPFILE=$(mktemp "$SHELL_INTEGRATION_DIR/.shell-integration.XXXXXX")
-printf '%s\n' "$SHELL_FUNCTION" > "$SHELL_TMPFILE"
-mv "$SHELL_TMPFILE" "$SHELL_INTEGRATION_FILE"
-
-append_source_line() {
-  printf '\n# Nemus - Shell Integration\n%s\n' "$SOURCE_LINE" >> "$1"
-}
-
-# Check if already installed
-if grep -Fq "$SOURCE_LINE" "$RC_FILE" 2>/dev/null; then
+# Check if already installed (version marker is in the grep below)
+if grep -q "Shell Integration (v50)" "$RC_FILE" 2>/dev/null; then
   echo "✅ Shell integration already up to date in $RC_FILE"
 elif grep -q "# Nemus - Shell Integration" "$RC_FILE" 2>/dev/null; then
   # Old version installed — remove it and install new version
   echo "🔄 Upgrading shell integration in $RC_FILE..."
   TMPFILE=$(mktemp)
   awk -f "$SCRIPT_DIR/remove-shell-block.awk" "$RC_FILE" > "$TMPFILE"
-  append_source_line "$TMPFILE"
+  # Append new shell integration to temp file so mv is atomic
+  echo "" >> "$TMPFILE"
+  echo "$SHELL_FUNCTION" >> "$TMPFILE"
   cp "$RC_FILE" "${RC_FILE}.backup.$(date +%Y%m%d_%H%M%S)"
   chmod --reference="$RC_FILE" "$TMPFILE" 2>/dev/null || chmod "$(stat -f '%Lp' "$RC_FILE")" "$TMPFILE" 2>/dev/null || true
   mv "$TMPFILE" "$RC_FILE"
@@ -527,8 +514,9 @@ else
     echo "📦 Backup created: ${RC_FILE}.backup.*"
   fi
 
-  # Append the source line (creates the file if it doesn't exist)
-  append_source_line "$RC_FILE"
+  # Append shell function (creates the file if it doesn't exist)
+  echo "" >> "$RC_FILE"
+  echo "$SHELL_FUNCTION" >> "$RC_FILE"
 
   echo "✅ Shell integration installed in $RC_FILE"
   echo ""

--- a/install-shell-integration.sh
+++ b/install-shell-integration.sh
@@ -491,17 +491,30 @@ else
   exit 1
 fi
 
-# Check if already installed (version marker is in the grep below)
-if grep -q "Shell Integration (v50)" "$RC_FILE" 2>/dev/null; then
+# Keep the generated functions out of the user's shell config. The same file
+# works in both bash and zsh; the RC file only needs this guarded source line.
+SHELL_INTEGRATION_DIR="$HOME/.nemus"
+SHELL_INTEGRATION_FILE="$SHELL_INTEGRATION_DIR/shell-integration.sh"
+SOURCE_LINE='[ -f "$HOME/.nemus/shell-integration.sh" ] && source "$HOME/.nemus/shell-integration.sh"'
+
+mkdir -p "$SHELL_INTEGRATION_DIR"
+SHELL_TMPFILE=$(mktemp "$SHELL_INTEGRATION_DIR/.shell-integration.XXXXXX")
+printf '%s\n' "$SHELL_FUNCTION" > "$SHELL_TMPFILE"
+mv "$SHELL_TMPFILE" "$SHELL_INTEGRATION_FILE"
+
+append_source_line() {
+  printf '\n# Nemus - Shell Integration\n%s\n' "$SOURCE_LINE" >> "$1"
+}
+
+# Check if already installed
+if grep -Fq "$SOURCE_LINE" "$RC_FILE" 2>/dev/null; then
   echo "✅ Shell integration already up to date in $RC_FILE"
 elif grep -q "# Nemus - Shell Integration" "$RC_FILE" 2>/dev/null; then
   # Old version installed — remove it and install new version
   echo "🔄 Upgrading shell integration in $RC_FILE..."
   TMPFILE=$(mktemp)
   awk -f "$SCRIPT_DIR/remove-shell-block.awk" "$RC_FILE" > "$TMPFILE"
-  # Append new shell integration to temp file so mv is atomic
-  echo "" >> "$TMPFILE"
-  echo "$SHELL_FUNCTION" >> "$TMPFILE"
+  append_source_line "$TMPFILE"
   cp "$RC_FILE" "${RC_FILE}.backup.$(date +%Y%m%d_%H%M%S)"
   chmod --reference="$RC_FILE" "$TMPFILE" 2>/dev/null || chmod "$(stat -f '%Lp' "$RC_FILE")" "$TMPFILE" 2>/dev/null || true
   mv "$TMPFILE" "$RC_FILE"
@@ -514,9 +527,8 @@ else
     echo "📦 Backup created: ${RC_FILE}.backup.*"
   fi
 
-  # Append shell function (creates the file if it doesn't exist)
-  echo "" >> "$RC_FILE"
-  echo "$SHELL_FUNCTION" >> "$RC_FILE"
+  # Append the source line (creates the file if it doesn't exist)
+  append_source_line "$RC_FILE"
 
   echo "✅ Shell integration installed in $RC_FILE"
   echo ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nemus-cli/nemus",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "workspaces": [
     "packages/*"
   ],

--- a/remove-shell-block.awk
+++ b/remove-shell-block.awk
@@ -33,6 +33,14 @@ skip {
     saw_func = 1
     next
   }
+  if (/\.nemus\/shell-integration\.sh/ && /source/) {
+    # Current installs keep the functions in a generated file and leave only
+    # this source line in the RC file.
+    skip = 0
+    saw_func = 0
+    buf = ""
+    next
+  }
   # Non-function line: block is over — emit any buffered lines
   skip = 0
   if (buf != "") printf "%s", buf

--- a/remove-shell-block.awk
+++ b/remove-shell-block.awk
@@ -33,14 +33,6 @@ skip {
     saw_func = 1
     next
   }
-  if (/\.nemus\/shell-integration\.sh/ && /source/) {
-    # Current installs keep the functions in a generated file and leave only
-    # this source line in the RC file.
-    skip = 0
-    saw_func = 0
-    buf = ""
-    next
-  }
   # Non-function line: block is over — emit any buffered lines
   skip = 0
   if (buf != "") printf "%s", buf

--- a/shell-integration.test.sh
+++ b/shell-integration.test.sh
@@ -299,66 +299,6 @@ echo "Test 12: 'nem' with no args → runs binary with no args"
   assert_eq "pwd unchanged (no CD)" "$TEMP_DIR" "$(pwd)"
 )
 
-# ── Test 12a: installer keeps functions out of the RC file ──────────
-echo ""
-echo "Test 12a: installer writes functions to ~/.nemus and sources them from .zshrc"
-(
-  INSTALL_HOME="$TEMP_DIR/install-home"
-  mkdir -p "$INSTALL_HOME"
-  cat > "$INSTALL_HOME/.zshrc" << 'RCEOF'
-export USER_SETTING=kept
-RCEOF
-
-  HOME="$INSTALL_HOME" bash "$SCRIPT_DIR/install-shell-integration.sh" zsh >/dev/null
-
-  assert_eq "generated integration file exists" "1" "$([ -f "$INSTALL_HOME/.nemus/shell-integration.sh" ] && echo 1 || echo 0)"
-  assert_eq "functions moved to generated file" "1" "$(grep -c '^nemus()' "$INSTALL_HOME/.nemus/shell-integration.sh")"
-  assert_eq "functions absent from .zshrc" "0" "$(grep -c '^nemus()' "$INSTALL_HOME/.zshrc")"
-  assert_eq "source line added once" "1" "$(grep -Fc '[ -f "$HOME/.nemus/shell-integration.sh" ] && source "$HOME/.nemus/shell-integration.sh"' "$INSTALL_HOME/.zshrc")"
-  assert_eq "user setting preserved" "1" "$(grep -c 'USER_SETTING=kept' "$INSTALL_HOME/.zshrc")"
-
-  HOME="$INSTALL_HOME" bash "$SCRIPT_DIR/install-shell-integration.sh" zsh >/dev/null
-  assert_eq "reinstall does not duplicate source line" "1" "$(grep -Fc '[ -f "$HOME/.nemus/shell-integration.sh" ] && source "$HOME/.nemus/shell-integration.sh"' "$INSTALL_HOME/.zshrc")"
-
-  cat >> "$INSTALL_HOME/.zshrc" << 'RCEOF'
-# user content after integration
-user_function() { echo kept; }
-RCEOF
-  TMPFILE=$(mktemp)
-  awk -f "$SCRIPT_DIR/remove-shell-block.awk" "$INSTALL_HOME/.zshrc" > "$TMPFILE"
-  mv "$TMPFILE" "$INSTALL_HOME/.zshrc"
-  assert_eq "source line can be removed" "0" "$(grep -Fc 'shell-integration.sh' "$INSTALL_HOME/.zshrc")"
-  assert_eq "function after source line preserved" "1" "$(grep -c 'user_function()' "$INSTALL_HOME/.zshrc")"
-  assert_eq "comment after source line preserved" "1" "$(grep -c '# user content after integration' "$INSTALL_HOME/.zshrc")"
-)
-
-# ── Test 12b: installer migrates the legacy inline block ────────────
-echo ""
-echo "Test 12b: installer migrates an inline block without touching user content"
-(
-  INSTALL_HOME="$TEMP_DIR/migration-home"
-  mkdir -p "$INSTALL_HOME"
-  cat > "$INSTALL_HOME/.zshrc" << 'RCEOF'
-export BEFORE=yes
-
-# Nemus - Shell Integration (v50)
-nemus() {
-  command nemus "$@"
-}
-
-# user content after integration
-export AFTER=yes
-RCEOF
-
-  HOME="$INSTALL_HOME" bash "$SCRIPT_DIR/install-shell-integration.sh" zsh >/dev/null
-
-  assert_eq "legacy function removed from .zshrc" "0" "$(grep -c '^nemus()' "$INSTALL_HOME/.zshrc")"
-  assert_eq "source line added" "1" "$(grep -Fc '[ -f "$HOME/.nemus/shell-integration.sh" ] && source "$HOME/.nemus/shell-integration.sh"' "$INSTALL_HOME/.zshrc")"
-  assert_eq "content before integration preserved" "1" "$(grep -c 'BEFORE=yes' "$INSTALL_HOME/.zshrc")"
-  assert_eq "content after integration preserved" "1" "$(grep -c 'AFTER=yes' "$INSTALL_HOME/.zshrc")"
-  assert_eq "comment after integration preserved" "1" "$(grep -c '# user content after integration' "$INSTALL_HOME/.zshrc")"
-)
-
 # ── Test 13: upgrade removes old block and preserves rest ──────────
 echo ""
 echo "Test 13: upgrade from old version preserves rest of RC file"

--- a/shell-integration.test.sh
+++ b/shell-integration.test.sh
@@ -299,6 +299,66 @@ echo "Test 12: 'nem' with no args → runs binary with no args"
   assert_eq "pwd unchanged (no CD)" "$TEMP_DIR" "$(pwd)"
 )
 
+# ── Test 12a: installer keeps functions out of the RC file ──────────
+echo ""
+echo "Test 12a: installer writes functions to ~/.nemus and sources them from .zshrc"
+(
+  INSTALL_HOME="$TEMP_DIR/install-home"
+  mkdir -p "$INSTALL_HOME"
+  cat > "$INSTALL_HOME/.zshrc" << 'RCEOF'
+export USER_SETTING=kept
+RCEOF
+
+  HOME="$INSTALL_HOME" bash "$SCRIPT_DIR/install-shell-integration.sh" zsh >/dev/null
+
+  assert_eq "generated integration file exists" "1" "$([ -f "$INSTALL_HOME/.nemus/shell-integration.sh" ] && echo 1 || echo 0)"
+  assert_eq "functions moved to generated file" "1" "$(grep -c '^nemus()' "$INSTALL_HOME/.nemus/shell-integration.sh")"
+  assert_eq "functions absent from .zshrc" "0" "$(grep -c '^nemus()' "$INSTALL_HOME/.zshrc")"
+  assert_eq "source line added once" "1" "$(grep -Fc '[ -f "$HOME/.nemus/shell-integration.sh" ] && source "$HOME/.nemus/shell-integration.sh"' "$INSTALL_HOME/.zshrc")"
+  assert_eq "user setting preserved" "1" "$(grep -c 'USER_SETTING=kept' "$INSTALL_HOME/.zshrc")"
+
+  HOME="$INSTALL_HOME" bash "$SCRIPT_DIR/install-shell-integration.sh" zsh >/dev/null
+  assert_eq "reinstall does not duplicate source line" "1" "$(grep -Fc '[ -f "$HOME/.nemus/shell-integration.sh" ] && source "$HOME/.nemus/shell-integration.sh"' "$INSTALL_HOME/.zshrc")"
+
+  cat >> "$INSTALL_HOME/.zshrc" << 'RCEOF'
+# user content after integration
+user_function() { echo kept; }
+RCEOF
+  TMPFILE=$(mktemp)
+  awk -f "$SCRIPT_DIR/remove-shell-block.awk" "$INSTALL_HOME/.zshrc" > "$TMPFILE"
+  mv "$TMPFILE" "$INSTALL_HOME/.zshrc"
+  assert_eq "source line can be removed" "0" "$(grep -Fc 'shell-integration.sh' "$INSTALL_HOME/.zshrc")"
+  assert_eq "function after source line preserved" "1" "$(grep -c 'user_function()' "$INSTALL_HOME/.zshrc")"
+  assert_eq "comment after source line preserved" "1" "$(grep -c '# user content after integration' "$INSTALL_HOME/.zshrc")"
+)
+
+# ── Test 12b: installer migrates the legacy inline block ────────────
+echo ""
+echo "Test 12b: installer migrates an inline block without touching user content"
+(
+  INSTALL_HOME="$TEMP_DIR/migration-home"
+  mkdir -p "$INSTALL_HOME"
+  cat > "$INSTALL_HOME/.zshrc" << 'RCEOF'
+export BEFORE=yes
+
+# Nemus - Shell Integration (v50)
+nemus() {
+  command nemus "$@"
+}
+
+# user content after integration
+export AFTER=yes
+RCEOF
+
+  HOME="$INSTALL_HOME" bash "$SCRIPT_DIR/install-shell-integration.sh" zsh >/dev/null
+
+  assert_eq "legacy function removed from .zshrc" "0" "$(grep -c '^nemus()' "$INSTALL_HOME/.zshrc")"
+  assert_eq "source line added" "1" "$(grep -Fc '[ -f "$HOME/.nemus/shell-integration.sh" ] && source "$HOME/.nemus/shell-integration.sh"' "$INSTALL_HOME/.zshrc")"
+  assert_eq "content before integration preserved" "1" "$(grep -c 'BEFORE=yes' "$INSTALL_HOME/.zshrc")"
+  assert_eq "content after integration preserved" "1" "$(grep -c 'AFTER=yes' "$INSTALL_HOME/.zshrc")"
+  assert_eq "comment after integration preserved" "1" "$(grep -c '# user content after integration' "$INSTALL_HOME/.zshrc")"
+)
+
 # ── Test 13: upgrade removes old block and preserves rest ──────────
 echo ""
 echo "Test 13: upgrade from old version preserves rest of RC file"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -38,7 +38,7 @@ echo -e "${YELLOW}This will NOT remove:${NC}"
 echo "  • Your workspaces ($HOME/workspaces/)"
 echo "  • Cache files (~/.workspace-manager-cache/)"
 echo "  • Configuration files (~/.workspace-manager-claude-config.json)"
-echo "  • Shell integration (from .zshrc or .bashrc and ~/.nemus/)"
+echo "  • Shell integration (from .zshrc or .bashrc)"
 echo "  • ghq (if installed)"
 echo ""
 
@@ -85,10 +85,8 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         if grep -q "# Nemus - Shell Integration" "$HOME/.zshrc"; then
             # Create backup
             cp "$HOME/.zshrc" "$HOME/.zshrc.backup.$(date +%Y%m%d_%H%M%S)"
-            TMPFILE=$(mktemp)
-            awk -f "$SCRIPT_DIR/remove-shell-block.awk" "$HOME/.zshrc" > "$TMPFILE"
-            chmod --reference="$HOME/.zshrc" "$TMPFILE" 2>/dev/null || chmod "$(stat -f '%Lp' "$HOME/.zshrc")" "$TMPFILE" 2>/dev/null || true
-            mv "$TMPFILE" "$HOME/.zshrc"
+            # Remove the function
+            sed -i.bak '/# Nemus - Shell Integration/,/^}$/d' "$HOME/.zshrc"
             print_success "Removed from .zshrc (backup created)"
         fi
     fi
@@ -98,17 +96,10 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         if grep -q "# Nemus - Shell Integration" "$HOME/.bashrc"; then
             # Create backup
             cp "$HOME/.bashrc" "$HOME/.bashrc.backup.$(date +%Y%m%d_%H%M%S)"
-            TMPFILE=$(mktemp)
-            awk -f "$SCRIPT_DIR/remove-shell-block.awk" "$HOME/.bashrc" > "$TMPFILE"
-            chmod --reference="$HOME/.bashrc" "$TMPFILE" 2>/dev/null || chmod "$(stat -f '%Lp' "$HOME/.bashrc")" "$TMPFILE" 2>/dev/null || true
-            mv "$TMPFILE" "$HOME/.bashrc"
+            # Remove the function
+            sed -i.bak '/# Nemus - Shell Integration/,/^}$/d' "$HOME/.bashrc"
             print_success "Removed from .bashrc (backup created)"
         fi
-    fi
-
-    if [ -f "$HOME/.nemus/shell-integration.sh" ]; then
-        rm -f "$HOME/.nemus/shell-integration.sh"
-        print_success "Removed ~/.nemus/shell-integration.sh"
     fi
 fi
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -38,7 +38,7 @@ echo -e "${YELLOW}This will NOT remove:${NC}"
 echo "  • Your workspaces ($HOME/workspaces/)"
 echo "  • Cache files (~/.workspace-manager-cache/)"
 echo "  • Configuration files (~/.workspace-manager-claude-config.json)"
-echo "  • Shell integration (from .zshrc or .bashrc)"
+echo "  • Shell integration (from .zshrc or .bashrc and ~/.nemus/)"
 echo "  • ghq (if installed)"
 echo ""
 
@@ -85,8 +85,10 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         if grep -q "# Nemus - Shell Integration" "$HOME/.zshrc"; then
             # Create backup
             cp "$HOME/.zshrc" "$HOME/.zshrc.backup.$(date +%Y%m%d_%H%M%S)"
-            # Remove the function
-            sed -i.bak '/# Nemus - Shell Integration/,/^}$/d' "$HOME/.zshrc"
+            TMPFILE=$(mktemp)
+            awk -f "$SCRIPT_DIR/remove-shell-block.awk" "$HOME/.zshrc" > "$TMPFILE"
+            chmod --reference="$HOME/.zshrc" "$TMPFILE" 2>/dev/null || chmod "$(stat -f '%Lp' "$HOME/.zshrc")" "$TMPFILE" 2>/dev/null || true
+            mv "$TMPFILE" "$HOME/.zshrc"
             print_success "Removed from .zshrc (backup created)"
         fi
     fi
@@ -96,10 +98,17 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         if grep -q "# Nemus - Shell Integration" "$HOME/.bashrc"; then
             # Create backup
             cp "$HOME/.bashrc" "$HOME/.bashrc.backup.$(date +%Y%m%d_%H%M%S)"
-            # Remove the function
-            sed -i.bak '/# Nemus - Shell Integration/,/^}$/d' "$HOME/.bashrc"
+            TMPFILE=$(mktemp)
+            awk -f "$SCRIPT_DIR/remove-shell-block.awk" "$HOME/.bashrc" > "$TMPFILE"
+            chmod --reference="$HOME/.bashrc" "$TMPFILE" 2>/dev/null || chmod "$(stat -f '%Lp' "$HOME/.bashrc")" "$TMPFILE" 2>/dev/null || true
+            mv "$TMPFILE" "$HOME/.bashrc"
             print_success "Removed from .bashrc (backup created)"
         fi
+    fi
+
+    if [ -f "$HOME/.nemus/shell-integration.sh" ]; then
+        rm -f "$HOME/.nemus/shell-integration.sh"
+        print_success "Removed ~/.nemus/shell-integration.sh"
     fi
 fi
 


### PR DESCRIPTION
<!-- Thanks for contributing to Nemus! -->

## What & why

Keep user shell configuration small and stable across Nemus upgrades.

Store the managed shell integration under ~/.nemus and leave supported RC files
with a guarded source entry. Preserve surrounding user content during upgrades
and cleanup.

## Motivation

Shell RC files are user-owned configuration and should remain easy to read and maintain. Nemus currently appends its full generated shell integration directly to .zshrc or .bashrc, adding substantial noise and blurring the boundary between personal configuration and Nemus-managed code.

This change moves the generated integration to ~/.nemus/shell-integration.sh, leaving only a guarded source line in the RC file. Existing installations are migrated without disturbing surrounding user configuration, and repeated installs remain idempotent.

Auto-CD and navigation behavior remain unchanged; the integration simply has a cleaner ownership boundary.

### Before

Nemus copied the entire shell integration—hundreds of lines—directly into the user’s `.zshrc` or `.bashrc`.

### After

Nemus keeps that code in `~/.nemus/shell-integration.sh`
The user’s RC file contains only one line:

```sh
[ -f "$HOME/.nemus/shell-integration.sh" ] && source "$HOME/.nemus/shell-integration.sh"
```

Same behavior, much cleaner user-owned configuration.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor / chore

## Checklist

- [x] `npm run build` compiles cleanly
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] Added/updated tests for the change
- [x] Bumped the `version` in `package.json` (if shipped code changed)
- [x] No vendor-specific / cloud / internal references introduced
- [ ] Updated docs,  `CHANGELOG.md` and llms.txt

## Notes for reviewers

<!-- Anything reviewers should focus on, screenshots, follow-ups, etc. -->
