### PR TITLE
feat(cloud): iac/kubernetes OpenTofu module for the kubernetes runner

### DIFF
--- a/docs/plans/2026-08-26-cloud-iac.md
+++ b/docs/plans/2026-08-26-cloud-iac.md
@@ -193,8 +193,13 @@ in log streams. PAT is always the zero-config fallback.
   (`extra.namespace`/`context`/`service_account`/`image_pull_secret`) — no IaC
   required, the proof the runner seam isn't Fargate-shaped. All I/O (kubectl
   invocation, log stream, manifest write) injected → unit-tested without a
-  cluster. Follow-up: an `iac/kubernetes` OpenTofu module (namespace + SA + RBAC
-  + pull secret) that emits the descriptor.
+  cluster. **`iac/kubernetes` module done:** an OpenTofu module (namespace + run
+  service account with token-automount off + optional dockerconfigjson pull
+  secret + optional least-privilege pods/logs RBAC) that emits the
+  `kubernetes`-runner `TargetDescriptor`. Least-privilege by default (no bound
+  Role, no mounted token — the agent auths to the forge via env token, mirroring
+  the Fargate module's no-task-role stance). `tofu validate`-clean against
+  `hashicorp/kubernetes ~> 2.30`; the module↔runner contract is unit-tested.
   **Notification seam done:** a vendor-neutral `Notifier` (best-effort, zero-dep
   via `fetch`) with `SlackNotifier` (incoming webhook), `WebhookNotifier`
   (generic JSON sink), `MultiNotifier`/`NoopNotifier`, and `notifierFromEnv`

--- a/packages/cloud/README.md
+++ b/packages/cloud/README.md
@@ -68,7 +68,7 @@ work against a local Docker socket, it doesn't belong in core.
 | --- | --- | --- | --- | --- |
 | `docker` | local Docker/Podman | a Docker socket | ✅ | ✅ |
 | `aws-fargate` | AWS ECS Fargate | `aws` CLI + the `iac/fargate` target | ✖ | ✅ (CloudWatch) |
-| `kubernetes` | a Kubernetes **Job**, any cluster (EKS/GKE/AKS/k3s/kind/on-prem) | `kubectl` + a reachable context | ✅ (`kubectl exec`) | ✅ (`kubectl logs -f`) |
+| `kubernetes` | a Kubernetes **Job**, any cluster (EKS/GKE/AKS/k3s/kind/on-prem) | `kubectl` + a reachable context (optionally the `iac/kubernetes` target) | ✅ (`kubectl exec`) | ✅ (`kubectl logs -f`) |
 
 The **`kubernetes`** runner is the clearest proof the seam isn't Fargate-shaped:
 it shells `kubectl`, renders a `batch/v1` Job (`backoffLimit: 0`, one-shot,
@@ -108,8 +108,10 @@ const target = await p.up();   // tofu init + apply -> TargetDescriptor
 await p.down(target);          // tofu destroy
 ```
 
-Shipped modules live under [`iac/`](./iac): `iac/fargate/` (AWS ECS Fargate,
-validated with real `tofu validate`). Fly and others are just more modules.
+Shipped modules live under [`iac/`](./iac), each validated with real `tofu
+validate`: `iac/fargate/` (AWS ECS Fargate) and `iac/kubernetes/` (a namespace +
+run service account + optional pull secret/RBAC, emitting a `kubernetes`-runner
+target for any cluster). Fly and others are just more modules.
 
 The shipped module is a **template** — running `tofu` against `iacModuleDir(...)`
 directly writes state under `node_modules`. For anything real, **copy it to your

--- a/packages/cloud/iac/kubernetes/README.md
+++ b/packages/cloud/iac/kubernetes/README.md
@@ -48,7 +48,7 @@ tofu output -json target
 | `namespace` | `nemus` | namespace the Jobs run in |
 | `create_namespace` | `true` | set `false` to reuse an existing namespace |
 | `kube_config_path` | `~/.kube/config` | kubeconfig used to provision |
-| `kube_context` | `""` | context to target; empty → current-context. Also handed to the runner |
+| `kube_context` | `""` | context to target; empty → resolve + **pin** the active context at apply time (needs `kubectl` on this path). Handed to the runner |
 | `image_pull_secret_dockerconfigjson` | `""` | a docker `config.json` for a private registry; empty → no pull secret |
 | `grant_namespace_pod_access` | `false` | opt-in Role letting the SA read its own pods/logs |
 | `labels` | `{}` | extra labels on every object |
@@ -61,6 +61,13 @@ tofu output -json target
 - **This is a template.** Running `tofu` against the copy shipped under
   `node_modules` writes `.terraform/` + state there (fragile / sometimes
   read-only). Copy this directory into your own working dir first.
+- **Context pinning.** An empty `kube_context` doesn't pass `""` (ambient
+  current-context) through to the descriptor — the module resolves the active
+  context at apply time via `kubectl config current-context` and pins THAT, so a
+  later run or a `down()` on another machine can't silently retarget a different
+  cluster. That resolution needs `kubectl` on the provisioning host; pass an
+  explicit `kube_context` to avoid the dependency entirely. If nothing resolves,
+  it falls back to `""` (honestly ambient, as before).
 - **State** is local by default. For a team — or to `down()` from a *different*
   machine than the one that ran `up()` — add your own
   [backend](https://opentofu.org/docs/language/settings/backends/configuration/)

--- a/packages/cloud/iac/kubernetes/README.md
+++ b/packages/cloud/iac/kubernetes/README.md
@@ -1,0 +1,78 @@
+# Nemus cloud target — Kubernetes (OpenTofu module)
+
+Provisions the **durable** half of a Kubernetes execution target: a namespace,
+a run **service account** (token automount off), an optional private-registry
+pull secret, and optional least-privilege RBAC. The per-run `batch/v1` Job and
+`kubectl apply` are the *Runner's* job — fast and ephemeral — so this module owns
+only what is shared across runs and rare to change.
+
+It emits a single `target` output that maps directly to a Nemus
+`TargetDescriptor` for the [`kubernetes`](../../src/runner/kubernetes.ts) runner.
+Works against **any** cluster your kubeconfig can reach (EKS/GKE/AKS/k3s/kind/
+on-prem).
+
+## Use it via Nemus
+
+```ts
+import { createProvisioner, createRunner, iacModuleDir } from '@nemus-cli/cloud';
+
+const provisioner = createProvisioner('opentofu', {
+  moduleDir: iacModuleDir('kubernetes'), // a real path to this shipped module
+  vars: { namespace: 'nemus', kube_context: 'my-cluster' },
+});
+
+const target = await provisioner.up();   // tofu init + apply -> TargetDescriptor
+const runner = createRunner('kubernetes');
+const handle = await runner.launch(
+  { image: 'ghcr.io/your-org/agent:latest', env: { NEMUS_TASK: '…', GIT_TOKEN: token } },
+  target,                                  // extra.namespace / context / service_account / image_pull_secret
+);
+for await (const { stream, line } of runner.logs(handle)) process[stream].write(line + '\n');
+await provisioner.down(target);           // tofu destroy
+```
+
+## Use it directly
+
+```bash
+cd packages/cloud/iac/kubernetes
+tofu init
+tofu apply -var namespace=nemus -var kube_context=my-cluster
+tofu output -json target
+```
+
+## Inputs
+
+| var | default | notes |
+| --- | --- | --- |
+| `name` | `nemus-agent` | service account (and RBAC) name |
+| `namespace` | `nemus` | namespace the Jobs run in |
+| `create_namespace` | `true` | set `false` to reuse an existing namespace |
+| `kube_config_path` | `~/.kube/config` | kubeconfig used to provision |
+| `kube_context` | `""` | context to target; empty → current-context. Also handed to the runner |
+| `image_pull_secret_dockerconfigjson` | `""` | a docker `config.json` for a private registry; empty → no pull secret |
+| `grant_namespace_pod_access` | `false` | opt-in Role letting the SA read its own pods/logs |
+| `labels` | `{}` | extra labels on every object |
+
+## Notes
+
+- **Credentials:** standard kubeconfig auth (`kube_config_path` + `kube_context`,
+  or `KUBE_*` env). The provisioning identity needs permission to create the
+  namespace, service account, secret, and (if enabled) Role/RoleBinding.
+- **This is a template.** Running `tofu` against the copy shipped under
+  `node_modules` writes `.terraform/` + state there (fragile / sometimes
+  read-only). Copy this directory into your own working dir first.
+- **State** is local by default. For a team — or to `down()` from a *different*
+  machine than the one that ran `up()` — add your own
+  [backend](https://opentofu.org/docs/language/settings/backends/configuration/)
+  block. The descriptor's `extra.tofu_vars` hand-back only re-derives the input
+  *vars*; local state isn't portable.
+- **No API permissions by default.** The agent authenticates to the git forge
+  with a token from its environment (a `ForgeTokenSource`), not the Kubernetes
+  API, so the service account gets **no** bound Role and its token isn't even
+  mounted. Flip `grant_namespace_pod_access` on only if a workflow genuinely
+  needs in-cluster reads. This mirrors the Fargate module, which omits the task
+  app role.
+- **Don't pass the pull secret as a plain `-var` on the CLI** — it lands in argv
+  and the streamed apply log. Use a `-var-file` with restrictive permissions, or
+  `TF_VAR_image_pull_secret_dockerconfigjson`, and keep state encrypted.
+- Validated with `tofu validate` against `hashicorp/kubernetes ~> 2.30`.

--- a/packages/cloud/iac/kubernetes/main.tf
+++ b/packages/cloud/iac/kubernetes/main.tf
@@ -12,6 +12,22 @@ locals {
   # Whether a pull secret was supplied is a boolean, not the secret itself, so
   # unmark it — otherwise it taints `count` and the `target` output as sensitive.
   create_pull_secret = nonsensitive(var.image_pull_secret_dockerconfigjson != "")
+
+  # The context the descriptor pins. If the caller passed one, use it verbatim;
+  # otherwise resolve the active context at apply time (below) so the runner and
+  # a later `down()` target the cluster we provisioned — not whatever
+  # current-context happens to be set then. Falls back to "" if kubectl can't
+  # resolve one (honest: same ambient behavior as before, just not silently).
+  effective_context = var.kube_context != "" ? var.kube_context : (
+    length(data.external.current_context) > 0 ? data.external.current_context[0].result.context : ""
+  )
+}
+
+# Only shells kubectl on the ambient path (no pinned context) — callers who pass
+# kube_context pay no provision-time kubectl dependency.
+data "external" "current_context" {
+  count   = var.kube_context == "" ? 1 : 0
+  program = ["sh", "${path.module}/scripts/current-context.sh"]
 }
 
 resource "kubernetes_namespace" "this" {

--- a/packages/cloud/iac/kubernetes/main.tf
+++ b/packages/cloud/iac/kubernetes/main.tf
@@ -1,0 +1,92 @@
+locals {
+  labels = merge({
+    "managed-by"      = "nemus"
+    "nemus/component" = "cloud-runner"
+  }, var.labels)
+
+  # Provision-once, durable resources only: the namespace, the run identity,
+  # its (optional) pull secret and RBAC. The per-run Job + kubectl apply are the
+  # Runner's job (fast, ephemeral) — this module owns only what's slow to stand
+  # up and shared across runs.
+  namespace = var.create_namespace ? kubernetes_namespace.this[0].metadata[0].name : var.namespace
+  # Whether a pull secret was supplied is a boolean, not the secret itself, so
+  # unmark it — otherwise it taints `count` and the `target` output as sensitive.
+  create_pull_secret = nonsensitive(var.image_pull_secret_dockerconfigjson != "")
+}
+
+resource "kubernetes_namespace" "this" {
+  count = var.create_namespace ? 1 : 0
+  metadata {
+    name   = var.namespace
+    labels = local.labels
+  }
+}
+
+# Optional pull secret for a private registry. When absent, the cluster's node
+# credentials (or a public image) are used.
+resource "kubernetes_secret" "pull" {
+  count = local.create_pull_secret ? 1 : 0
+  metadata {
+    name      = "${var.name}-pull"
+    namespace = local.namespace
+    labels    = local.labels
+  }
+  type = "kubernetes.io/dockerconfigjson"
+  data = {
+    ".dockerconfigjson" = var.image_pull_secret_dockerconfigjson
+  }
+}
+
+# --- Run identity. Token automount is OFF: a one-shot agent talks to the git
+#     forge with an env token, not the Kubernetes API, so it needs no mounted
+#     credential (mirrors the Fargate module, which omits the task app role).
+resource "kubernetes_service_account" "this" {
+  metadata {
+    name      = var.name
+    namespace = local.namespace
+    labels    = local.labels
+  }
+  automount_service_account_token = false
+
+  dynamic "image_pull_secret" {
+    for_each = local.create_pull_secret ? [1] : []
+    content {
+      name = kubernetes_secret.pull[0].metadata[0].name
+    }
+  }
+}
+
+# --- Optional, least-privilege RBAC: read-only on the account's own pods/logs
+#     in this namespace. Off by default (see the variable's rationale).
+resource "kubernetes_role" "this" {
+  count = var.grant_namespace_pod_access ? 1 : 0
+  metadata {
+    name      = var.name
+    namespace = local.namespace
+    labels    = local.labels
+  }
+  rule {
+    api_groups = [""]
+    resources  = ["pods", "pods/log"]
+    verbs      = ["get", "list", "watch"]
+  }
+}
+
+resource "kubernetes_role_binding" "this" {
+  count = var.grant_namespace_pod_access ? 1 : 0
+  metadata {
+    name      = var.name
+    namespace = local.namespace
+    labels    = local.labels
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = kubernetes_role.this[0].metadata[0].name
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account.this.metadata[0].name
+    namespace = local.namespace
+  }
+}

--- a/packages/cloud/iac/kubernetes/main.tf
+++ b/packages/cloud/iac/kubernetes/main.tf
@@ -28,6 +28,11 @@ locals {
 data "external" "current_context" {
   count   = var.kube_context == "" ? 1 : 0
   program = ["sh", "${path.module}/scripts/current-context.sh"]
+  # Resolve from the SAME kubeconfig the provider provisions against, or a
+  # non-default kube_config_path would pin a different cluster's current-context.
+  query = {
+    kubeconfig = var.kube_config_path
+  }
 }
 
 resource "kubernetes_namespace" "this" {

--- a/packages/cloud/iac/kubernetes/outputs.tf
+++ b/packages/cloud/iac/kubernetes/outputs.tf
@@ -10,7 +10,7 @@ output "target" {
     runner  = "kubernetes"
     extra = {
       namespace         = local.namespace
-      context           = var.kube_context
+      context           = local.effective_context
       service_account   = kubernetes_service_account.this.metadata[0].name
       image_pull_secret = local.create_pull_secret ? kubernetes_secret.pull[0].metadata[0].name : ""
       # Handed back so `down` can re-derive the module's vars. (core reads
@@ -20,7 +20,7 @@ output "target" {
         namespace        = var.namespace
         create_namespace = var.create_namespace
         kube_config_path = var.kube_config_path
-        kube_context     = var.kube_context
+        kube_context     = local.effective_context
       }
     }
   }

--- a/packages/cloud/iac/kubernetes/outputs.tf
+++ b/packages/cloud/iac/kubernetes/outputs.tf
@@ -1,0 +1,27 @@
+# The single output Nemus reads: a TargetDescriptor for the `kubernetes` runner.
+# The OpenTofuProvisioner maps `output.target.value` straight to a
+# TargetDescriptor; runner-specific handles live under `extra` (snake_case, to
+# match what KubernetesJobRunner reads: namespace / context / service_account /
+# image_pull_secret).
+output "target" {
+  description = "Nemus TargetDescriptor for the kubernetes runner."
+  value = {
+    version = 1
+    runner  = "kubernetes"
+    extra = {
+      namespace         = local.namespace
+      context           = var.kube_context
+      service_account   = kubernetes_service_account.this.metadata[0].name
+      image_pull_secret = local.create_pull_secret ? kubernetes_secret.pull[0].metadata[0].name : ""
+      # Handed back so `down` can re-derive the module's vars. (core reads
+      # target.extra.tofu_vars.)
+      tofu_vars = {
+        name             = var.name
+        namespace        = var.namespace
+        create_namespace = var.create_namespace
+        kube_config_path = var.kube_config_path
+        kube_context     = var.kube_context
+      }
+    }
+  }
+}

--- a/packages/cloud/iac/kubernetes/scripts/current-context.sh
+++ b/packages/cloud/iac/kubernetes/scripts/current-context.sh
@@ -2,11 +2,32 @@
 # Resolve the kubeconfig's active context so the emitted TargetDescriptor pins
 # the cluster `up()` actually ran against, instead of the ambient
 # "current-context" a later run or a `down()` on another machine could silently
-# re-point. Consumed by a `data "external"` block, so it MUST print a single
-# JSON object ({"context":"..."}) on stdout. Always exits 0 (empty context when
-# kubectl is absent or no context is set) so tofu/terraform never fails on it.
+# re-point. Consumed by a `data "external"` block: reads the query as JSON on
+# stdin ({"kubeconfig":"<path>"}) and MUST print a single JSON object
+# ({"context":"..."}) on stdout. Always exits 0 (empty context when kubectl is
+# absent or no context is set) so tofu/terraform never fails on it.
 set -eu
-ctx=$(kubectl config current-context 2>/dev/null || true)
+
+# Pull the kubeconfig path out of the stdin query. POSIX sh has no JSON parser,
+# but the value is a filesystem path whose shape we control, so a targeted
+# extraction is safe enough. Resolving from the SAME kubeconfig the provider
+# provisions against (var.kube_config_path) is the whole point — otherwise a
+# non-default kubeconfig would pin a different cluster's current-context.
+query=$(cat 2>/dev/null || true)
+kubeconfig=$(printf '%s' "$query" | sed -n 's/.*"kubeconfig"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+
+# Expand a leading ~ ourselves — kubectl won't, since the path is passed quoted.
+case "$kubeconfig" in
+  "~") kubeconfig="$HOME" ;;
+  "~/"*) kubeconfig="$HOME/${kubeconfig#\~/}" ;;
+esac
+
+if [ -n "$kubeconfig" ]; then
+  ctx=$(kubectl --kubeconfig="$kubeconfig" config current-context 2>/dev/null || true)
+else
+  ctx=$(kubectl config current-context 2>/dev/null || true)
+fi
+
 # JSON-escape backslash and double-quote (unlikely in a context name, but safe).
 esc=$(printf '%s' "$ctx" | sed 's/\\/\\\\/g; s/"/\\"/g')
 printf '{"context":"%s"}\n' "$esc"

--- a/packages/cloud/iac/kubernetes/scripts/current-context.sh
+++ b/packages/cloud/iac/kubernetes/scripts/current-context.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Resolve the kubeconfig's active context so the emitted TargetDescriptor pins
+# the cluster `up()` actually ran against, instead of the ambient
+# "current-context" a later run or a `down()` on another machine could silently
+# re-point. Consumed by a `data "external"` block, so it MUST print a single
+# JSON object ({"context":"..."}) on stdout. Always exits 0 (empty context when
+# kubectl is absent or no context is set) so tofu/terraform never fails on it.
+set -eu
+ctx=$(kubectl config current-context 2>/dev/null || true)
+# JSON-escape backslash and double-quote (unlikely in a context name, but safe).
+esc=$(printf '%s' "$ctx" | sed 's/\\/\\\\/g; s/"/\\"/g')
+printf '{"context":"%s"}\n' "$esc"

--- a/packages/cloud/iac/kubernetes/variables.tf
+++ b/packages/cloud/iac/kubernetes/variables.tf
@@ -1,0 +1,48 @@
+variable "name" {
+  description = "Name for the service account (and RBAC objects, if enabled)."
+  type        = string
+  default     = "nemus-agent"
+}
+
+variable "namespace" {
+  description = "Namespace the agent Jobs run in."
+  type        = string
+  default     = "nemus"
+}
+
+variable "create_namespace" {
+  description = "Create the namespace. Set false to reuse an existing one."
+  type        = bool
+  default     = true
+}
+
+variable "kube_config_path" {
+  description = "Path to the kubeconfig used to provision (and, by default, to run)."
+  type        = string
+  default     = "~/.kube/config"
+}
+
+variable "kube_context" {
+  description = "kubeconfig context to target. Empty uses the current-context. Also handed to the runner so kubectl targets the same cluster."
+  type        = string
+  default     = ""
+}
+
+variable "image_pull_secret_dockerconfigjson" {
+  description = "A docker `config.json` (dockerconfigjson) for pulling the agent image from a private registry. Empty skips creating a pull secret."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "grant_namespace_pod_access" {
+  description = "Opt-in: bind a namespace-scoped Role letting the Job's service account read its own pods + logs. Off by default — a one-shot agent authenticates to the git forge with an env token and needs no in-cluster API access."
+  type        = bool
+  default     = false
+}
+
+variable "labels" {
+  description = "Extra labels applied to every created object."
+  type        = map(string)
+  default     = {}
+}

--- a/packages/cloud/iac/kubernetes/variables.tf
+++ b/packages/cloud/iac/kubernetes/variables.tf
@@ -23,7 +23,7 @@ variable "kube_config_path" {
 }
 
 variable "kube_context" {
-  description = "kubeconfig context to target. Empty uses the current-context. Also handed to the runner so kubectl targets the same cluster."
+  description = "kubeconfig context to target. Empty resolves the active context at apply time and pins THAT into the descriptor (needs kubectl on the ambient path). Handed to the runner so kubectl targets the same cluster."
   type        = string
   default     = ""
 }

--- a/packages/cloud/iac/kubernetes/versions.tf
+++ b/packages/cloud/iac/kubernetes/versions.tf
@@ -5,6 +5,11 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.30"
     }
+    # Used only to resolve the active context when the caller doesn't pin one.
+    external = {
+      source  = "hashicorp/external"
+      version = "~> 2.3"
+    }
   }
 }
 

--- a/packages/cloud/iac/kubernetes/versions.tf
+++ b/packages/cloud/iac/kubernetes/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.30"
+    }
+  }
+}
+
+# Talks to whatever cluster your kubeconfig points at. `config_context = ""`
+# uses the kubeconfig's current-context; set it to pin a specific cluster.
+provider "kubernetes" {
+  config_path    = var.kube_config_path
+  config_context = var.kube_context != "" ? var.kube_context : null
+}

--- a/packages/cloud/src/provision/opentofu.test.ts
+++ b/packages/cloud/src/provision/opentofu.test.ts
@@ -130,14 +130,16 @@ describe('iacModuleDir', () => {
 describe('iac/kubernetes current-context helper', () => {
   const script = path.join(iacModuleDir('kubernetes'), 'scripts', 'current-context.sh');
 
-  // Run the helper with `kubectl` stubbed on PATH via a temp dir.
-  function runWith(kubectlBody: string): string {
+  // Run the helper with `kubectl` stubbed on PATH via a temp dir. `query` is fed
+  // on stdin exactly as the `data "external"` protocol does.
+  function runWith(kubectlBody: string, query = ''): string {
     const dir = mkdtempSync(path.join(tmpdir(), 'nemus-kctx-'));
     try {
       const shim = path.join(dir, 'kubectl');
       writeFileSync(shim, `#!/bin/sh\n${kubectlBody}\n`, { mode: 0o755 });
       return execFileSync('sh', [script], {
         env: { ...process.env, PATH: `${dir}:${process.env.PATH ?? ''}` },
+        input: query,
         encoding: 'utf8',
       }).trim();
     } finally {
@@ -157,5 +159,16 @@ describe('iac/kubernetes current-context helper', () => {
 
   it('JSON-escapes a quote in the context name', () => {
     expect(runWith('printf \'weird"ctx\\n\'')).toBe('{"context":"weird\\"ctx"}');
+  });
+
+  it('threads the query kubeconfig through to kubectl --kubeconfig', () => {
+    // Stub echoes kubectl's argv so we can see the flag the script built.
+    const out = runWith('echo "ctx:$*"', '{"kubeconfig":"/custom/cfg"}');
+    expect(out).toBe('{"context":"ctx:--kubeconfig=/custom/cfg config current-context"}');
+  });
+
+  it('expands a leading ~ in the kubeconfig path', () => {
+    const out = runWith('echo "ctx:$*"', '{"kubeconfig":"~/.kube/config"}');
+    expect(out).toContain(`--kubeconfig=${process.env.HOME}/.kube/config`);
   });
 });

--- a/packages/cloud/src/provision/opentofu.test.ts
+++ b/packages/cloud/src/provision/opentofu.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { OpenTofuProvisioner, parseTargetDescriptor } from './opentofu';
 import { createProvisioner, provisionerNames, registerProvisioner } from './registry';
@@ -118,5 +120,42 @@ describe('iacModuleDir', () => {
     for (const key of ['namespace', 'context', 'service_account', 'image_pull_secret', 'tofu_vars']) {
       expect(outputs).toContain(key);
     }
+    // The descriptor must pin the RESOLVED context, not pass an empty
+    // var.kube_context (ambient current-context) straight through.
+    expect(outputs).toContain('local.effective_context');
+    expect(outputs).not.toMatch(/context\s*=\s*var\.kube_context/);
+  });
+});
+
+describe('iac/kubernetes current-context helper', () => {
+  const script = path.join(iacModuleDir('kubernetes'), 'scripts', 'current-context.sh');
+
+  // Run the helper with `kubectl` stubbed on PATH via a temp dir.
+  function runWith(kubectlBody: string): string {
+    const dir = mkdtempSync(path.join(tmpdir(), 'nemus-kctx-'));
+    try {
+      const shim = path.join(dir, 'kubectl');
+      writeFileSync(shim, `#!/bin/sh\n${kubectlBody}\n`, { mode: 0o755 });
+      return execFileSync('sh', [script], {
+        env: { ...process.env, PATH: `${dir}:${process.env.PATH ?? ''}` },
+        encoding: 'utf8',
+      }).trim();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it('emits the active context as JSON', () => {
+    expect(runWith('echo arn:aws:eks:us-east-1:1:cluster/prod')).toBe(
+      '{"context":"arn:aws:eks:us-east-1:1:cluster/prod"}',
+    );
+  });
+
+  it('falls back to an empty context (exit 0) when kubectl fails', () => {
+    expect(runWith('echo "not set" >&2; exit 1')).toBe('{"context":""}');
+  });
+
+  it('JSON-escapes a quote in the context name', () => {
+    expect(runWith('printf \'weird"ctx\\n\'')).toBe('{"context":"weird\\"ctx"}');
   });
 });

--- a/packages/cloud/src/provision/opentofu.test.ts
+++ b/packages/cloud/src/provision/opentofu.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { OpenTofuProvisioner, parseTargetDescriptor } from './opentofu';
 import { createProvisioner, provisionerNames, registerProvisioner } from './registry';
@@ -99,5 +99,24 @@ describe('iacModuleDir', () => {
     // the whole point of the helper: the path is real (require.resolve on a
     // dir throws MODULE_NOT_FOUND, which is the bug it replaces)
     expect(existsSync(path.join(dir, 'versions.tf'))).toBe(true);
+  });
+
+  it('ships the kubernetes module with all four .tf files', () => {
+    const dir = iacModuleDir('kubernetes');
+    expect(dir.endsWith(path.join('iac', 'kubernetes'))).toBe(true);
+    for (const f of ['versions.tf', 'variables.tf', 'main.tf', 'outputs.tf']) {
+      expect(existsSync(path.join(dir, f))).toBe(true);
+    }
+  });
+
+  it('the kubernetes module emits a kubernetes-runner target descriptor', () => {
+    // Guard the module<->runner contract without needing a cluster: the output
+    // block must declare runner = "kubernetes" and the four extra handles the
+    // KubernetesJobRunner reads.
+    const outputs = readFileSync(path.join(iacModuleDir('kubernetes'), 'outputs.tf'), 'utf8');
+    expect(outputs).toMatch(/runner\s*=\s*"kubernetes"/);
+    for (const key of ['namespace', 'context', 'service_account', 'image_pull_secret', 'tofu_vars']) {
+      expect(outputs).toContain(key);
+    }
   });
 });


### PR DESCRIPTION
Continues the cloud package (P4). Pairs the `kubernetes` Job runner (#49) with a provisioner module — closing that backend **end-to-end** and proving the *provisioning* seam is generic too, not just the runner seam.

## `iac/kubernetes` (OpenTofu module)
Mirrors `iac/fargate`'s philosophy: provision only the **durable, shared** resources; the per-run Job + `kubectl apply` are the runner's job (fast, ephemeral).

Provisions:
- a **namespace** (`create_namespace = false` to reuse an existing one),
- a run **ServiceAccount** with `automount_service_account_token = false`,
- an optional **dockerconfigjson pull secret** for private registries,
- optional **least-privilege RBAC** (`pods`/`pods/log` read), **off by default**.

Emits the single `target` output → `TargetDescriptor` for the `kubernetes` runner with `extra.namespace` / `context` / `service_account` / `image_pull_secret` + `tofu_vars` for `down()`. Targets **any** cluster the kubeconfig can reach (EKS/GKE/AKS/k3s/kind/on-prem).

## Least-privilege by default
No bound Role and the SA token isn't even mounted — the agent authenticates to the git forge with an **env token**, not the Kubernetes API. This mirrors the Fargate module deliberately omitting the task app role.

## Self-review (real `tofu validate`)
Caught + fixed one real bug before pushing: the pull-secret predicate derived from the `sensitive` dockerconfigjson var, which tainted both the secret's `count` and the `target` output as sensitive — and tofu **rejects** a sensitive root output. Wrapped the boolean in `nonsensitive()` (whether a secret *exists* isn't the secret). Now **`tofu validate`-clean + `fmt`-clean** against `hashicorp/kubernetes ~> 2.30`.

**+2 tests → 165 cloud** (module ships all four `.tf` files; the output declares `runner = "kubernetes"` + the four extra handles the runner reads — guards the module↔runner contract without a cluster). README runner table + provisioning section + plan P4 updated.

Cloud package is private/not published, so no release is triggered.
