### PR TITLE
feat(cloud): nemus-cloud runners — discover registries + capabilities

### DIFF
--- a/packages/cloud/README.md
+++ b/packages/cloud/README.md
@@ -180,6 +180,10 @@ what's available.
 A thin, dependency-free CLI ties the seams together end-to-end:
 
 ```bash
+# 0) see what's registered — runners + their capabilities, provisioners,
+#    shipped IaC modules, and git forges (add --json for machine output)
+nemus-cloud runners
+
 # 1) provision a target (writes .nemus-target.json)
 nemus-cloud up --module fargate --var region=us-east-1 --var name=nemus
 
@@ -195,7 +199,11 @@ nemus-cloud fix-pr --image ghcr.io/acme/agent:latest \
 nemus-cloud down --module fargate
 ```
 
-`up`/`down` drive the `OpenTofuProvisioner`; `run` builds the agent env contract
+`runners` (alias `ls`) is the discovery front door: it instantiates every
+registered runner to read its declared `Capabilities`, lists the provisioners and
+git forges, and maps each shipped IaC module to the runner it targets — so you
+can see what a backend supports before choosing one, and `--json` feeds it to
+scripts. `up`/`down` drive the `OpenTofuProvisioner`; `run` builds the agent env contract
 + a tag-safe `TaskSpec` and launches it via the target's `Runner`, optionally
 streaming logs (`--follow`) and waiting for the exit code (`--wait`). Run
 `nemus-cloud help` for all flags.

--- a/packages/cloud/src/cli/cloud.test.ts
+++ b/packages/cloud/src/cli/cloud.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseArgs, parseVars, buildRunTaskSpec, buildFixPrTaskSpec, main, CloudCliDeps } from './cloud';
+import { parseArgs, parseVars, buildRunTaskSpec, buildFixPrTaskSpec, collectRegistry, main, CloudCliDeps } from './cloud';
 import { TargetDescriptor, LogLine, Status } from '../runner/types';
 
 describe('parseArgs', () => {
@@ -133,6 +133,10 @@ function harness(overrides: Partial<CloudCliDeps> = {}) {
       };
     }) as any,
     iacModuleDir: (n) => `/iac/${n}`,
+    runnerNames: () => ['docker', 'aws-fargate', 'kubernetes'],
+    provisionerNames: () => ['opentofu', 'terraform'],
+    registeredForges: () => ['github', 'gitlab'],
+    listIacModules: () => ['fargate', 'kubernetes'],
     readFile: (p) => { if (!files.has(p)) throw new Error('ENOENT'); return files.get(p)!; },
     writeFile: (p, c) => { files.set(p, c); },
     log: (s) => out.push(s),
@@ -143,6 +147,69 @@ function harness(overrides: Partial<CloudCliDeps> = {}) {
   };
   return { deps, files, out, calls, target };
 }
+
+describe('runners command', () => {
+  // A capability-bearing createRunner so the snapshot reflects real flags.
+  const capsOverride = {
+    createRunner: ((name: string) => ({
+      id: name,
+      capabilities: {
+        exec: name !== 'aws-fargate',
+        logStream: true,
+        persistentDisk: name === 'docker',
+        secretStore: false,
+        portForward: name !== 'aws-fargate',
+      },
+    })) as any,
+  };
+
+  it('collectRegistry reads every registry + per-runner caps + module\u2192runner', () => {
+    const { deps, files } = harness(capsOverride);
+    files.set('/iac/fargate/outputs.tf', 'runner = "aws-fargate"');
+    files.set('/iac/kubernetes/outputs.tf', 'runner = "kubernetes"');
+    const snap = collectRegistry(deps);
+    expect(snap.runners.map((r) => r.name)).toEqual(['aws-fargate', 'docker', 'kubernetes']); // sorted
+    expect(snap.runners.find((r) => r.name === 'docker')!.capabilities!.persistentDisk).toBe(true);
+    expect(snap.provisioners).toEqual(['opentofu', 'terraform']);
+    expect(snap.forges).toEqual(['github', 'gitlab']);
+    expect(snap.modules).toEqual([
+      { name: 'fargate', runner: 'aws-fargate' },
+      { name: 'kubernetes', runner: 'kubernetes' },
+    ]);
+  });
+
+  it('a runner that fails to construct is reported, not fatal', () => {
+    const { deps } = harness({
+      createRunner: ((name: string) => {
+        if (name === 'kubernetes') throw new Error('no kubectl');
+        return { id: name, capabilities: { exec: true, logStream: true, persistentDisk: false, secretStore: false, portForward: false } } as any;
+      }) as any,
+    });
+    const snap = collectRegistry(deps);
+    const k = snap.runners.find((r) => r.name === 'kubernetes')!;
+    expect(k.capabilities).toBeNull();
+    expect(k.error).toMatch(/no kubectl/);
+  });
+
+  it('main runners --json prints the snapshot and exits 0', async () => {
+    const { deps, out } = harness(capsOverride);
+    const code = await main(['runners', '--json'], deps);
+    expect(code).toBe(0);
+    const printed = JSON.parse(out.join('\n'));
+    expect(printed.runners.map((r: any) => r.name)).toContain('kubernetes');
+    expect(printed.forges).toEqual(['github', 'gitlab']);
+  });
+
+  it('main runners prints a human table', async () => {
+    const { deps, out } = harness(capsOverride);
+    const code = await main(['runners'], deps);
+    expect(code).toBe(0);
+    const text = out.join('\n');
+    expect(text).toMatch(/Runners \(where a task executes\)/);
+    expect(text).toMatch(/kubernetes/);
+    expect(text).toMatch(/Git forges/);
+  });
+});
 
 describe('main dispatch', () => {
   it('up: provisions and writes the descriptor file', async () => {

--- a/packages/cloud/src/cli/cloud.test.ts
+++ b/packages/cloud/src/cli/cloud.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
 import { parseArgs, parseVars, buildRunTaskSpec, buildFixPrTaskSpec, collectRegistry, main, CloudCliDeps } from './cloud';
+import { createRunner, runnerNames } from '../runner/registry';
+import { provisionerNames } from '../provision/registry';
+import { iacModuleDir, listIacModules } from '../provision/modules';
+import { registeredForges } from '../gitforge/registry';
 import { TargetDescriptor, LogLine, Status } from '../runner/types';
 
 describe('parseArgs', () => {
@@ -208,6 +213,26 @@ describe('runners command', () => {
     expect(text).toMatch(/Runners \(where a task executes\)/);
     expect(text).toMatch(/kubernetes/);
     expect(text).toMatch(/Git forges/);
+  });
+
+  // Regression guard (review): moduleRunner must parse the REAL shipped
+  // outputs.tf, not just the flat test fixtures. Our modules emit a single
+  // `output "target"` whose value map has `runner = "..."`; if someone reformats
+  // them to the block form this catches the silently-blanked mapping.
+  it('maps the real shipped modules to their runners (real fs + registries)', () => {
+    const realDeps: CloudCliDeps = {
+      ...harness().deps,
+      createRunner,
+      runnerNames,
+      provisionerNames,
+      registeredForges,
+      iacModuleDir,
+      listIacModules,
+      readFile: (p) => readFileSync(p, 'utf8'),
+    };
+    const byName = Object.fromEntries(collectRegistry(realDeps).modules.map((m) => [m.name, m.runner]));
+    expect(byName.fargate).toBe('aws-fargate');
+    expect(byName.kubernetes).toBe('kubernetes');
   });
 });
 

--- a/packages/cloud/src/cli/cloud.ts
+++ b/packages/cloud/src/cli/cloud.ts
@@ -336,11 +336,15 @@ export function collectRegistry(deps: CloudCliDeps): RegistrySnapshot {
 }
 
 /** Best-effort: read a shipped module's `outputs.tf` and pull out the runner it
- *  targets (`runner = "..."`). Returns null if unreadable. */
+ *  targets. Our modules emit a single `output "target"` whose value MAP carries a
+ *  `runner = "..."` entry (see each module's outputs.tf) — NOT the block form
+ *  `output "runner" { value = ... }` — so a flat `runner = "..."` match is
+ *  correct here (guarded against the real files by a test). Returns null if
+ *  unreadable, so a hand-written module without the entry just omits the arrow. */
 function moduleRunner(deps: CloudCliDeps, name: string): string | null {
   try {
     const tf = deps.readFile(`${deps.iacModuleDir(name)}/outputs.tf`);
-    return /runner\s*=\s*"([a-z0-9-]+)"/i.exec(tf)?.[1] ?? null;
+    return /\brunner\s*=\s*"([a-z0-9-]+)"/i.exec(tf)?.[1] ?? null;
   } catch {
     return null;
   }

--- a/packages/cloud/src/cli/cloud.ts
+++ b/packages/cloud/src/cli/cloud.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 import { readFileSync, writeFileSync } from 'node:fs';
-import { createProvisioner } from '../provision/registry';
-import { iacModuleDir } from '../provision/modules';
-import { createRunner } from '../runner/registry';
-import { TargetDescriptor, TaskSpec } from '../runner/types';
+import { createProvisioner, provisionerNames } from '../provision/registry';
+import { iacModuleDir, listIacModules } from '../provision/modules';
+import { createRunner, runnerNames } from '../runner/registry';
+import { registeredForges } from '../gitforge/registry';
+import { Capabilities, TargetDescriptor, TaskSpec } from '../runner/types';
 
 /**
  * `nemus-cloud` — the thin CLI that ties the P2 seams together:
@@ -21,6 +22,10 @@ export interface CloudCliDeps {
   createProvisioner: typeof createProvisioner;
   createRunner: typeof createRunner;
   iacModuleDir: (name: string) => string;
+  runnerNames: () => string[];
+  provisionerNames: () => string[];
+  registeredForges: () => string[];
+  listIacModules: () => string[];
   readFile: (path: string) => string;
   writeFile: (path: string, content: string) => void;
   log: (s: string) => void;
@@ -33,6 +38,10 @@ const defaultDeps: CloudCliDeps = {
   createProvisioner,
   createRunner,
   iacModuleDir,
+  runnerNames,
+  provisionerNames,
+  registeredForges,
+  listIacModules,
   readFile: (p) => readFileSync(p, 'utf8'),
   writeFile: (p, c) => writeFileSync(p, c),
   log: (s) => process.stdout.write(s + '\n'),
@@ -297,9 +306,87 @@ async function launchSpec(spec: TaskSpec, flags: Flags, deps: CloudCliDeps): Pro
   return 0;
 }
 
+// ------------------------------------------------------------- runners/list
+
+export interface RegistrySnapshot {
+  runners: Array<{ name: string; capabilities: Capabilities | null; error?: string }>;
+  provisioners: string[];
+  forges: string[];
+  modules: Array<{ name: string; runner: string | null }>;
+}
+
+/** Read every registry (+ each runner's declared Capabilities, + each shipped
+ *  module's target runner) into a plain object. Pure over the injected deps, so
+ *  it's unit-tested without touching real backends. */
+export function collectRegistry(deps: CloudCliDeps): RegistrySnapshot {
+  const runners = deps.runnerNames().sort().map((name) => {
+    try {
+      return { name, capabilities: deps.createRunner(name).capabilities };
+    } catch (e) {
+      return { name, capabilities: null, error: (e as Error).message };
+    }
+  });
+  const modules = deps.listIacModules().map((name) => ({ name, runner: moduleRunner(deps, name) }));
+  return {
+    runners,
+    provisioners: deps.provisionerNames().sort(),
+    forges: deps.registeredForges().sort(),
+    modules,
+  };
+}
+
+/** Best-effort: read a shipped module's `outputs.tf` and pull out the runner it
+ *  targets (`runner = "..."`). Returns null if unreadable. */
+function moduleRunner(deps: CloudCliDeps, name: string): string | null {
+  try {
+    const tf = deps.readFile(`${deps.iacModuleDir(name)}/outputs.tf`);
+    return /runner\s*=\s*"([a-z0-9-]+)"/i.exec(tf)?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+const CAP_KEYS: Array<[keyof Capabilities, string]> = [
+  ['exec', 'exec'],
+  ['logStream', 'logs'],
+  ['portForward', 'port'],
+  ['persistentDisk', 'disk'],
+  ['secretStore', 'secrets'],
+];
+
+function cmdRunners(flags: Flags, deps: CloudCliDeps): number {
+  const snap = collectRegistry(deps);
+  if (bool(flags, 'json')) {
+    deps.log(JSON.stringify(snap, null, 2));
+    return 0;
+  }
+  const tick = (b: boolean) => (b ? 'yes' : ' - ');
+  const width = Math.max(6, ...snap.runners.map((r) => r.name.length));
+  deps.log('Runners (where a task executes):');
+  for (const r of snap.runners) {
+    if (!r.capabilities) {
+      deps.log(`  ${r.name.padEnd(width)}  (unavailable: ${r.error})`);
+      continue;
+    }
+    const caps = CAP_KEYS.map(([k, label]) => `${label} ${tick(r.capabilities![k])}`).join('  ');
+    deps.log(`  ${r.name.padEnd(width)}  ${caps}`);
+  }
+  deps.log('');
+  deps.log(`Provisioners (stand up a target):  ${snap.provisioners.join(', ') || '(none)'}`);
+  deps.log(`Git forges (code host):            ${snap.forges.join(', ') || '(none)'}`);
+  deps.log('');
+  deps.log('Shipped IaC modules (nemus-cloud up --module <name>):');
+  if (snap.modules.length === 0) deps.log('  (none)');
+  for (const m of snap.modules) {
+    deps.log(`  ${m.name}${m.runner ? ` → ${m.runner} runner` : ''}`);
+  }
+  return 0;
+}
+
 const USAGE = `nemus-cloud — provision + run Nemus agents on your own infra
 
 Usage:
+  nemus-cloud runners [--json]                     list runners + capabilities, provisioners, modules, forges
   nemus-cloud up    --module <name|--module-dir dir> [--var k=v]... [--provisioner opentofu] [--out FILE]
   nemus-cloud down  [--target FILE] --module <name|--module-dir dir> [--var k=v]...
   nemus-cloud run   --image REF --repos a,b --task "..." [--target FILE]
@@ -319,6 +406,9 @@ export async function main(argv: string[], deps: CloudCliDeps = defaultDeps): Pr
   const { cmd, flags } = parseArgs(argv);
   try {
     switch (cmd) {
+      case 'runners':
+      case 'ls':
+        return cmdRunners(flags, deps);
       case 'up':
         return await cmdUp(flags, deps);
       case 'down':

--- a/packages/cloud/src/provision/modules.ts
+++ b/packages/cloud/src/provision/modules.ts
@@ -1,3 +1,4 @@
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 /**
@@ -16,4 +17,29 @@ import * as path from 'node:path';
  */
 export function iacModuleDir(name: string): string {
   return path.join(__dirname, '..', '..', 'iac', name);
+}
+
+/** The directory holding all shipped IaC modules (the parent of every
+ * {@link iacModuleDir}). */
+export function iacModulesRoot(): string {
+  return path.join(__dirname, '..', '..', 'iac');
+}
+
+/**
+ * Names of the shipped IaC modules (a module = a subdir with a `versions.tf`),
+ * sorted. Used by `nemus-cloud runners` to show what `--module <name>` accepts.
+ * Returns `[]` if the directory is missing rather than throwing.
+ */
+export function listIacModules(): string[] {
+  const root = iacModulesRoot();
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((e) => e.isDirectory() && fs.existsSync(path.join(root, e.name, 'versions.tf')))
+    .map((e) => e.name)
+    .sort();
 }

--- a/packages/cloud/src/provision/opentofu.test.ts
+++ b/packages/cloud/src/provision/opentofu.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { OpenTofuProvisioner, parseTargetDescriptor } from './opentofu';
 import { createProvisioner, provisionerNames, registerProvisioner } from './registry';
-import { iacModuleDir } from './modules';
+import { iacModuleDir, listIacModules } from './modules';
 import { Exec, ExecResultRaw } from '../agent/exec';
 
 function recorder(outputs: Record<string, ExecResultRaw> = {}) {
@@ -101,6 +101,10 @@ describe('iacModuleDir', () => {
     // the whole point of the helper: the path is real (require.resolve on a
     // dir throws MODULE_NOT_FOUND, which is the bug it replaces)
     expect(existsSync(path.join(dir, 'versions.tf'))).toBe(true);
+  });
+
+  it('listIacModules discovers the shipped modules (fargate + kubernetes)', () => {
+    expect(listIacModules()).toEqual(expect.arrayContaining(['fargate', 'kubernetes']));
   });
 
   it('ships the kubernetes module with all four .tf files', () => {


### PR DESCRIPTION
Continues the cloud package (P4). Adds a **discovery command** that makes the swappable seams *visible* — the natural "you can see what's available" follow-up now that runners and provisioners each have 2+ real backends.

## `nemus-cloud runners` (alias `ls`)
Instantiates every registered **runner** to read its declared `Capabilities`, lists the **provisioners** and **git forges**, and maps each shipped **IaC module** to the runner it targets. Human table by default; `--json` for scripts.

```
Runners (where a task executes):
  aws-fargate  exec  -   logs yes  port  -   disk  -   secrets  -
  docker       exec yes  logs yes  port yes  disk yes  secrets  -
  kubernetes   exec yes  logs yes  port yes  disk  -   secrets  -

Provisioners (stand up a target):  opentofu, terraform
Git forges (code host):            github, gitlab

Shipped IaC modules (nemus-cloud up --module <name>):
  fargate → aws-fargate runner
  kubernetes → kubernetes runner
```

## Notes
- **`collectRegistry(deps)` is pure** over the injected deps → unit-tested with no real backends. A runner that **fails to construct is reported** (`capabilities: null` + `error`), never fatal — one unavailable backend can't break discovery.
- New `provision/modules.ts` helpers: `iacModulesRoot()` + `listIacModules()` (a module = a subdir with `versions.tf`; sorted; `[]` if absent, never throws).
- `module → runner` is read best-effort from each module's `outputs.tf`; registry names sorted for stable output.

**+5 tests → 175 cloud.** README documents the command as the discovery front door (`# 0)` before `up`/`run`/`fix-pr`). Cloud package is private/not published — no release triggered.
