### PR TITLE
docs: surface Reflect + the optional cloud package

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,20 @@ repos, create/update workspaces, check status, and more directly from a prompt.
 
 Run `nemus --help` for the full command reference.
 
+## Cloud (optional, self-hosted)
+
+Nemus is **local-first** — everything above runs entirely on your machine. If you
+want to hand a task to an agent that runs **headlessly on infrastructure you own**
+(local Docker, AWS Fargate, or any Kubernetes cluster) and opens a PR for you,
+there's an **optional, opt-in** package: [`@nemus-cli/cloud`](./packages/cloud).
+
+It's a separate, vendor-neutral package built from swappable seams — runners
+(`docker`, `aws-fargate`, `kubernetes`), IaC provisioners (OpenTofu/Terraform
+modules), git forges (GitHub/GitLab), a bounded CI-fix loop, and notifiers — with
+no cloud SDK in the core CLI. It is **not published to npm**; it lives in this
+repo for you to build and run yourself. See
+[`packages/cloud/README.md`](./packages/cloud/README.md) to get started.
+
 ## Configuration
 
 `nemus configure` writes `~/.nemus/config.json`. Environment

--- a/docs/index.html
+++ b/docs/index.html
@@ -241,6 +241,10 @@
         <div class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></div>
         <h3>Investigate-first</h3><p>Create an empty workspace and let an agent discover and add the repos it needs.</p>
       </div>
+      <div class="card">
+        <div class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg></div>
+        <h3>Reflect</h3><p>Analyze your recent agent sessions and get concrete tips to improve your skills, context, and prompts.</p>
+      </div>
     </div>
   </div>
 </section>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -251,6 +251,22 @@ nemus snapshot save ws        # (ss) capture exact branches/commits/dirty state
 nemus snapshot restore <id>   # (sr)
 ```
 
+### Reflect — improve your setup over time
+
+```bash
+nemus reflect                 # (retro) analyze your last 10 workspaces' sessions
+nemus reflect --limit 5       # narrow the window
+nemus reflect --json          # structured report for tooling
+nemus reflect --dry-run       # show what the judge sees, without calling the agent
+```
+
+`reflect` reads your recent agent **session transcripts** (Claude + pi), distills
+the prompts you sent, the failures the agent hit, and the tools it used, then asks
+**your own configured agent** (LLM-as-a-judge — no extra API key) to recommend
+concrete improvements: which **skills** to add and where, missing
+**AGENTS.md/context** rules, missing **connectivity/smoke tests**, and
+**prompt/workflow** habits — each with a priority and an example snippet.
+
 ### AI assistant
 
 ```bash
@@ -272,6 +288,17 @@ Nemus exposes an **MCP server** (`nemus-mcp`) so MCP-capable agents can search
 repos, create/update workspaces, check status, and more directly from a prompt.
 
 Run `nemus --help` for the full command reference.
+
+## Cloud (optional, self-hosted)
+
+Nemus is **local-first** — everything above runs on your machine. An **optional,
+opt-in** package, `@nemus-cli/cloud`, lets you run a workspace + coding agent
+**headlessly on infrastructure you own** (local Docker, AWS Fargate, or any
+Kubernetes cluster) and open a PR. It's a separate, vendor-neutral package built
+from swappable seams — runners (`docker`, `aws-fargate`, `kubernetes`), IaC
+provisioners (OpenTofu/Terraform), git forges (GitHub/GitLab), a bounded CI-fix
+loop, and notifiers — with no cloud SDK in the core CLI. It is **not published to
+npm**; it lives in the repo (`packages/cloud/`) for you to build and run yourself.
 
 ## Configuration
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -34,6 +34,13 @@ Key ideas an LLM should know:
 - **Agent-native**: `nemus configure` wires up a coding agent; `nemus -- "<prompt>"`
   runs a task; **investigate-first** creates an empty workspace and lets the agent
   discover and add the repos it needs.
+- **Reflect**: `nemus reflect` reads your recent agent session transcripts and asks
+  your own configured agent (LLM-as-a-judge) to recommend concrete improvements to
+  your skills, `AGENTS.md`/context, connectivity tests, and prompting habits.
+- **Cloud (optional, not on npm)**: `@nemus-cli/cloud` is an opt-in, source-only
+  package (in-repo, unpublished) to run a workspace + agent headlessly on your own
+  infra (Docker / AWS Fargate / Kubernetes) and open a PR. The core CLI stays
+  local-first with no cloud SDK.
 - Install: `npm install -g @nemus-cli/nemus`. Binaries: `nemus` (and the short alias
   `nem`). MCP server: `nemus-mcp`. Requires Node.js >= 22.
 - License: MIT. Repository: https://github.com/me-public/nemus
@@ -62,3 +69,4 @@ Key ideas an LLM should know:
 
 - [npm package](https://www.npmjs.com/package/@nemus-cli/nemus): `@nemus-cli/nemus`, published with provenance.
 - [llms-full.txt](https://me-public.github.io/nemus/llms-full.txt): the full README inlined as a single document for deeper context.
+- [Cloud package](https://github.com/me-public/nemus/blob/main/packages/cloud/README.md): `@nemus-cli/cloud`, the optional self-hosted runner (not published to npm).

--- a/packages/cloud/README.md
+++ b/packages/cloud/README.md
@@ -5,9 +5,12 @@
 > own* infrastructure (local Docker, Fly, Fargate, k8s, …), headlessly, and open
 > a PR.
 
-**Status: P1 in progress.** The forge-auth seam and the execution seam (runners,
-with the in-box Docker runner) are in; the agent OCI image, Provisioners and the
-CI-loop land in later phases. See
+**Status: P1–P4 substantially landed.** In: the forge-auth + execution seams with
+three runners (`docker`, `aws-fargate`, `kubernetes`), OpenTofu provisioners with
+shipped `iac/fargate` + `iac/kubernetes` modules, GitHub/GitLab forges, the agent
+OCI image with `run`/`fix-pr` entry modes, a bounded CI-fix loop, Slack/webhook
+notifiers, and a `nemus-cloud runners` discovery command. Everything is
+dependency-injected and unit-tested with no cloud account. See
 [`docs/plans/2026-08-26-cloud-iac.md`](../../docs/plans/2026-08-26-cloud-iac.md)
 for the full design.
 


### PR DESCRIPTION
Docs-only (no version bump). Surfaces two things that were invisible in public docs.

## Changes
- **README** → new **"Cloud (optional, self-hosted)"** section linking [`packages/cloud`](../../packages/cloud), clearly stated as opt-in + **not published to npm**; the core stays local-first.
- **docs/index.html** (GitHub Pages) → adds a **Reflect** feature card — a shipped, published feature (since 0.3.0) that was missing from the landing page.
- **docs/llms.txt** + **llms-full.txt** → add Reflect (llms-full was missing it entirely) and a cloud pointer, noting it's unpublished/opt-in.
- **packages/cloud/README** → flip the stale *"P1 in progress"* status to what actually shipped (3 runners, OpenTofu + `iac/fargate`/`iac/kubernetes`, GitHub/GitLab forges, `run`/`fix-pr` image, CI-fix loop, notifiers, `runners` discovery).

## Positioning decision
Cloud is **linked from the README/repo but deliberately not featured on the marketing landing page** — the site sells the local-first, bring-your-own-agent story, and cloud is an experimental, unpublished, self-hosted add-on. The landing page instead gains the Reflect card.

## Answers to the questions behind this
- `@nemus-cli/cloud` is **intentionally private/unpublished** — the release workflow only publishes the root `@nemus-cli/nemus` (now 0.4.0). No change to that.
- The README now links the cloud package (in-repo path, since there's no npm page by design).
