### PR TITLE
fix(cloud): k8s logs must wait for the pod + live kind e2e

### DIFF
--- a/docs/plans/2026-08-26-cloud-iac.md
+++ b/docs/plans/2026-08-26-cloud-iac.md
@@ -193,7 +193,12 @@ in log streams. PAT is always the zero-config fallback.
   (`extra.namespace`/`context`/`service_account`/`image_pull_secret`) — no IaC
   required, the proof the runner seam isn't Fargate-shaped. All I/O (kubectl
   invocation, log stream, manifest write) injected → unit-tested without a
-  cluster. **`iac/kubernetes` module done:** an OpenTofu module (namespace + run
+  cluster. **Validated live against a real `kind` cluster** (`e2e/kind-k8s-smoke.mjs`,
+  `npm run -w @nemus-cli/cloud e2e:kind`, gated out of CI): launch → status → exec
+  → logs → stop all pass. This caught a real bug the mocked unit tests couldn't —
+  `logs --follow --ignore-errors` gave up in ~40ms while the container was still
+  `ContainerCreating`; fixed to `--pod-running-timeout` (wait for the pod, then
+  follow to completion). **`iac/kubernetes` module done:** an OpenTofu module (namespace + run
   service account with token-automount off + optional dockerconfigjson pull
   secret + optional least-privilege pods/logs RBAC) that emits the
   `kubernetes`-runner `TargetDescriptor`. Least-privilege by default (no bound

--- a/packages/cloud/README.md
+++ b/packages/cloud/README.md
@@ -91,6 +91,15 @@ All of a runner's I/O (`kubectl`/`aws`/`docker` invocation, log streaming, and �
 for k8s — the manifest write) is injectable, so every backend is unit-tested
 without a cloud account or a cluster.
 
+> **k8s logs failure-contract.** `logs()` waits for the pod to reach Running
+> (`kubectl --pod-running-timeout`, default 5m) before streaming, then follows to
+> exit. The trade-off: a pod that *never* schedules (ImagePullBackOff,
+> unschedulable) blocks the stream for that whole timeout before erroring — a
+> finite, tunable bound. Headless orchestration that awaits `logs()` before
+> polling `status()` should set `target.extra.logs_pod_running_timeout` lower.
+> (`status()` can't shorten it: a Job keeps a stuck pod `active`, so it reads
+> `running` until `backoffLimit` too.)
+
 ### Live end-to-end (real cluster)
 
 The unit tests mock `kubectl`; a separate smoke test drives the **real**

--- a/packages/cloud/README.md
+++ b/packages/cloud/README.md
@@ -91,6 +91,25 @@ All of a runner's I/O (`kubectl`/`aws`/`docker` invocation, log streaming, and �
 for k8s — the manifest write) is injectable, so every backend is unit-tested
 without a cloud account or a cluster.
 
+### Live end-to-end (real cluster)
+
+The unit tests mock `kubectl`; a separate smoke test drives the **real**
+`KubernetesJobRunner` against an actual cluster (launch → status → exec → logs →
+stop). It needs a cluster + a public image, so it's **not** part of `npm test`/CI
+— run it by hand against a throwaway [kind](https://kind.sigs.k8s.io) cluster:
+
+```bash
+kind create cluster --name nemus-e2e
+NEMUS_E2E_CONTEXT=kind-nemus-e2e npm run -w @nemus-cli/cloud e2e:kind
+kind delete cluster --name nemus-e2e
+```
+
+It refuses to run without an explicit `NEMUS_E2E_CONTEXT` (so it can't touch a
+real cluster by accident). This test is what caught the `logs --follow` bug the
+unit tests couldn't: `--ignore-errors` made `--follow` give up in ~40ms when the
+container was still `ContainerCreating`; the runner now uses
+`--pod-running-timeout` to wait for the pod, then follow to completion.
+
 ## The provisioning seam: IaC modules
 
 Provisioning (stand up a place to run) is split from execution (run a task).

--- a/packages/cloud/e2e/kind-k8s-smoke.mjs
+++ b/packages/cloud/e2e/kind-k8s-smoke.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Live end-to-end smoke test for the `kubernetes` runner against a REAL cluster.
+ *
+ * Unlike the unit tests (which mock kubectl), this drives the actual
+ * KubernetesJobRunner through kubectl against whatever cluster your kubeconfig
+ * points at — proving launch → status → exec → logs → stop really work.
+ *
+ * It is deliberately NOT part of `npm test`/CI: it needs a cluster and pulls a
+ * public image. Run it by hand against a throwaway cluster:
+ *
+ *   kind create cluster --name nemus-e2e
+ *   npm run -w @nemus-cli/cloud build
+ *   NEMUS_E2E_CONTEXT=kind-nemus-e2e node packages/cloud/e2e/kind-k8s-smoke.mjs
+ *   kind delete cluster --name nemus-e2e
+ *
+ * Env: NEMUS_E2E_CONTEXT (kube context, required — refuse to run without an
+ * explicit one so we never touch a real cluster by accident),
+ * NEMUS_E2E_NAMESPACE (default "default"), NEMUS_E2E_IMAGE (default busybox).
+ */
+import { createRunner } from '../dist/index.js';
+
+const context = process.env.NEMUS_E2E_CONTEXT;
+const namespace = process.env.NEMUS_E2E_NAMESPACE || 'default';
+const image = process.env.NEMUS_E2E_IMAGE || 'busybox:1.36';
+
+if (!context) {
+  console.error('refusing to run without NEMUS_E2E_CONTEXT (an explicit kube context, e.g. kind-nemus-e2e)');
+  process.exit(2);
+}
+
+const MARKER = `hello-from-nemus-${Date.now()}`;
+let failures = 0;
+const ok = (name, cond, detail = '') => {
+  console.log(`${cond ? '✓' : '✗'} ${name}${detail ? `  — ${detail}` : ''}`);
+  if (!cond) failures++;
+};
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const runner = createRunner('kubernetes');
+const target = { version: 1, runner: 'kubernetes', extra: { namespace, context } };
+const spec = {
+  image,
+  // print a marker, then stay alive briefly so we can exec into the live pod.
+  command: ['sh', '-c', `echo ${MARKER}; sleep 25`],
+  env: { NEMUS_E2E: '1' },
+  labels: { 'nemus.e2e': '1' },
+};
+
+let handle;
+try {
+  console.log(`\n== launching ${image} Job in ${context}/${namespace} ==`);
+  handle = await runner.launch(spec, target);
+  ok('launch returns a handle', !!handle?.id, `job=${handle?.id}`);
+
+  // Wait for the pod to be running (image pull can take a bit on a cold node).
+  let state = 'pending';
+  for (let i = 0; i < 60 && state !== 'running' && state !== 'succeeded'; i++) {
+    await sleep(2000);
+    state = (await runner.status(handle)).state;
+  }
+  ok('status reaches running/succeeded', state === 'running' || state === 'succeeded', `state=${state}`);
+
+  // exec into the live pod. `status: running` = the Job has an active pod, which
+  // can still be ContainerCreating, so retry until the container accepts an exec.
+  if (state === 'running') {
+    let res = { exitCode: 1, stdout: '', stderr: '' };
+    for (let i = 0; i < 15 && res.exitCode !== 0; i++) {
+      try { res = await runner.exec(handle, ['sh', '-c', 'echo exec-works']); } catch { /* pod not ready yet */ }
+      if (res.exitCode !== 0) await sleep(2000);
+    }
+    ok('exec runs in the pod', res.exitCode === 0 && res.stdout.includes('exec-works'), `rc=${res.exitCode}`);
+  } else {
+    console.log('· skipped exec (pod already completed before we could attach)');
+  }
+
+  // stream logs to completion; must contain our marker. The runner waits for the
+  // pod to be Running (--pod-running-timeout) and then follows to exit.
+  let logText = '';
+  for await (const { line } of runner.logs(handle)) logText += line + '\n';
+  ok('logs stream contains the marker', logText.includes(MARKER), `${logText.trim().length} chars`);
+
+  // terminal status — poll briefly, since Job.status.succeeded can lag pod exit.
+  let final = await runner.status(handle);
+  for (let i = 0; i < 10 && final.state === 'running'; i++) {
+    await sleep(1000);
+    final = await runner.status(handle);
+  }
+  ok('final status is succeeded', final.state === 'succeeded', `state=${final.state} exit=${final.exitCode}`);
+  ok('exit code is 0', final.exitCode === 0);
+} catch (e) {
+  console.error('e2e error:', e?.message || e);
+  failures++;
+} finally {
+  if (handle) {
+    try {
+      await runner.stop(handle);
+      const gone = await runner.status(handle).then((s) => s.state).catch(() => 'deleted');
+      ok('stop removes the job', gone === 'deleted' || gone === 'stopped' || gone === 'succeeded', `state=${gone}`);
+    } catch (e) {
+      ok('stop removes the job', false, e?.message || String(e));
+    }
+  }
+}
+
+console.log(`\n${failures === 0 ? 'PASS' : 'FAIL'} — ${failures} failure(s)`);
+process.exit(failures === 0 ? 0 : 1);

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -34,6 +34,7 @@
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
+    "e2e:kind": "npm run build && node e2e/kind-k8s-smoke.mjs",
     "clean": "rm -rf dist"
   }
 }

--- a/packages/cloud/src/runner/kubernetes.test.ts
+++ b/packages/cloud/src/runner/kubernetes.test.ts
@@ -139,6 +139,11 @@ describe('KubernetesJobRunner.logs / stop', () => {
     for await (const l of runner.logs(handle)) lines.push(l);
     expect(lines).toEqual([{ stream: 'stdout', line: 'hello' }]);
     expect(streamed[0]).toEqual(expect.arrayContaining(['logs', 'job/j', '--follow', '--namespace', 'agents']));
+    // Must WAIT for the pod (--pod-running-timeout), not --ignore-errors, which
+    // makes --follow give up in ~40ms when the container is still creating
+    // (proven by the kind e2e). Guard against regressing to the old flag.
+    expect(streamed[0].some((a) => a.startsWith('--pod-running-timeout='))).toBe(true);
+    expect(streamed[0]).not.toContain('--ignore-errors');
 
     await runner.stop(handle);
     expect(calls[0]).toEqual(expect.arrayContaining(['delete', 'job', 'j', '--wait=false', '--ignore-not-found']));

--- a/packages/cloud/src/runner/kubernetes.test.ts
+++ b/packages/cloud/src/runner/kubernetes.test.ts
@@ -148,6 +148,25 @@ describe('KubernetesJobRunner.logs / stop', () => {
     await runner.stop(handle);
     expect(calls[0]).toEqual(expect.arrayContaining(['delete', 'job', 'j', '--wait=false', '--ignore-not-found']));
   });
+
+  it('threads a tunable logs_pod_running_timeout from target.extra onto logs', async () => {
+    const streamed: string[][] = [];
+    const stream: LogStreamer = async function* (_bin, args) {
+      streamed.push(args);
+    };
+    const run: CommandRunner = async () => ({ code: 0, stdout: JSON.stringify({ metadata: { name: 'nemus-agent-x' } }), stderr: '' });
+    const runner = new KubernetesJobRunner({
+      run,
+      stream,
+      writeManifest: async () => ({ path: '/x', cleanup: async () => {} }),
+    });
+    const handle = await runner.launch(
+      { image: 'img' },
+      { version: 1, runner: 'kubernetes', extra: { namespace: 'agents', logs_pod_running_timeout: '45s' } },
+    );
+    for await (const _ of runner.logs(handle)) { /* drain */ }
+    expect(streamed[0]).toContain('--pod-running-timeout=45s');
+  });
 });
 
 describe('kubectl error handling', () => {

--- a/packages/cloud/src/runner/kubernetes.ts
+++ b/packages/cloud/src/runner/kubernetes.ts
@@ -47,6 +47,9 @@ interface K8sHandleRaw {
   namespace: string;
   context?: string;
   jobName: string;
+  /** How long `logs --follow` waits for the pod to be Running (kubectl
+   *  `--pod-running-timeout`). Tunable via target.extra.logs_pod_running_timeout. */
+  logsPodRunningTimeout?: string;
 }
 
 /**
@@ -90,6 +93,9 @@ export class KubernetesJobRunner implements Runner {
     const extra = (target.extra ?? {}) as Record<string, unknown>;
     const namespace = String(extra.namespace ?? 'default');
     const context = extra.context ? String(extra.context) : undefined;
+    const logsPodRunningTimeout = extra.logs_pod_running_timeout
+      ? String(extra.logs_pod_running_timeout)
+      : undefined;
 
     const jobName = `${this.namePrefix}-${randomBytes(4).toString('hex')}`;
     const manifest = this.buildJobManifest(spec, { jobName, namespace, extra });
@@ -101,7 +107,7 @@ export class KubernetesJobRunner implements Runner {
         { namespace, context },
       );
       const createdName: string = applied?.metadata?.name ?? jobName;
-      const raw: K8sHandleRaw = { namespace, context, jobName: createdName };
+      const raw: K8sHandleRaw = { namespace, context, jobName: createdName, logsPodRunningTimeout };
       return { runner: this.id, id: createdName, raw };
     } finally {
       await cleanup().catch(() => undefined);
@@ -131,8 +137,16 @@ export class KubernetesJobRunner implements Runner {
     // completion — NOT --ignore-errors, which (proven by the kind e2e) demotes the
     // "ContainerCreating" state to a swallowed error and makes --follow give up
     // in ~40ms when logs are opened right after launch.
+    //
+    // Trade-off (flipped failure contract): a pod that NEVER reaches Running
+    // (ImagePullBackOff / unschedulable) blocks this stream for the whole timeout
+    // before erroring. That's a finite, tunable bound — set
+    // target.extra.logs_pod_running_timeout lower for headless orchestration that
+    // awaits logs before polling status. (status() can't shorten it: the Job
+    // keeps a stuck pod `active`, so it also reads `running` until backoffLimit.)
+    const timeout = raw.logsPodRunningTimeout ?? LOG_POD_RUNNING_TIMEOUT;
     const args = nsArgs(
-      ['logs', `job/${raw.jobName}`, '--follow', '--all-containers', `--pod-running-timeout=${LOG_POD_RUNNING_TIMEOUT}`],
+      ['logs', `job/${raw.jobName}`, '--follow', '--all-containers', `--pod-running-timeout=${timeout}`],
       raw,
     );
     return this.stream(this.bin, args);

--- a/packages/cloud/src/runner/kubernetes.ts
+++ b/packages/cloud/src/runner/kubernetes.ts
@@ -29,6 +29,10 @@ export interface KubernetesRunnerOptions {
   namePrefix?: string;
 }
 
+/** How long `logs --follow` waits for the pod to reach Running before streaming.
+ *  Covers a cold image pull; if the pod never runs, status() reports the failure. */
+const LOG_POD_RUNNING_TIMEOUT = '5m';
+
 const K8S_CAPS: Capabilities = {
   exec: true, // kubectl exec into the job's pod
   logStream: true, // kubectl logs -f
@@ -122,9 +126,15 @@ export class KubernetesJobRunner implements Runner {
 
   logs(handle: Handle): AsyncIterable<LogLine> {
     const raw = handle.raw as K8sHandleRaw;
-    // `job/<name>` follows the job's pod; --all-containers + --ignore-errors so a
-    // not-yet-scheduled pod doesn't abort the stream.
-    const args = nsArgs(['logs', `job/${raw.jobName}`, '--follow', '--all-containers', '--ignore-errors'], raw);
+    // `job/<name>` follows the job's pod. --pod-running-timeout makes kubectl WAIT
+    // for the container to reach Running before streaming, then follow to
+    // completion — NOT --ignore-errors, which (proven by the kind e2e) demotes the
+    // "ContainerCreating" state to a swallowed error and makes --follow give up
+    // in ~40ms when logs are opened right after launch.
+    const args = nsArgs(
+      ['logs', `job/${raw.jobName}`, '--follow', '--all-containers', `--pod-running-timeout=${LOG_POD_RUNNING_TIMEOUT}`],
+      raw,
+    );
     return this.stream(this.bin, args);
   }
 


### PR DESCRIPTION
Continues the cloud package (P4). Adds a **live end-to-end** smoke test for the `kubernetes` runner against a real cluster — and fixes the real bug it caught.

## Why
The runners were only *unit*-tested (kubectl mocked). This drives the **real** `KubernetesJobRunner` against an actual cluster: **launch → status → exec → logs → stop**.

## The bug it caught (fix included)
`logs()` used `kubectl logs job/<name> --follow --all-containers --ignore-errors`. Called right after launch (as an orchestrator does), the pod is still `ContainerCreating`, and `--ignore-errors` **demotes that to a swallowed error so `--follow` gives up in ~40ms** with no output — instead of waiting for the container.

Proven on a kind cluster:
| flags (called immediately after create) | result |
|---|---|
| `--follow --all-containers --ignore-errors` (old) | exits **0.04s**, empty |
| `--follow --all-containers --pod-running-timeout=…` (new) | **waits** for Running, follows to completion |

Fixed to `--pod-running-timeout=5m` (covers a cold image pull; a pod that never runs is surfaced by `status()`). The unit test now asserts `--pod-running-timeout` is present and `--ignore-errors` is gone, so it can't regress.

## The e2e
`packages/cloud/e2e/kind-k8s-smoke.mjs` — run with `NEMUS_E2E_CONTEXT=kind-nemus-e2e npm run -w @nemus-cli/cloud e2e:kind`.
- **Not in CI** (needs a cluster + a public image).
- **Refuses to run without an explicit `NEMUS_E2E_CONTEXT`** so it can never touch a real cluster by accident.
- Verified locally: **all 7 checks PASS** against `kind`.

176 unit tests still green. Cloud package is private/unpublished — no version bump / release.
