### PR TITLE
test(cloud): live docker-runner e2e smoke test

### DIFF
--- a/packages/cloud/README.md
+++ b/packages/cloud/README.md
@@ -100,24 +100,29 @@ without a cloud account or a cluster.
 > (`status()` can't shorten it: a Job keeps a stuck pod `active`, so it reads
 > `running` until `backoffLimit` too.)
 
-### Live end-to-end (real cluster)
+### Live end-to-end (real backends)
 
-The unit tests mock `kubectl`; a separate smoke test drives the **real**
-`KubernetesJobRunner` against an actual cluster (launch → status → exec → logs →
-stop). It needs a cluster + a public image, so it's **not** part of `npm test`/CI
-— run it by hand against a throwaway [kind](https://kind.sigs.k8s.io) cluster:
+The unit tests mock the CLIs; separate smoke tests drive the **real** runners
+against an actual daemon/cluster (launch → status → exec → logs → stop). They need
+a real backend + pull a public image, so they're **not** part of `npm test`/CI —
+run them by hand:
 
 ```bash
+# in-box docker runner (needs a running Docker/Podman daemon)
+npm run -w @nemus-cli/cloud e2e:docker
+
+# kubernetes runner against a throwaway kind cluster
 kind create cluster --name nemus-e2e
 NEMUS_E2E_CONTEXT=kind-nemus-e2e npm run -w @nemus-cli/cloud e2e:kind
 kind delete cluster --name nemus-e2e
 ```
 
-It refuses to run without an explicit `NEMUS_E2E_CONTEXT` (so it can't touch a
-real cluster by accident). This test is what caught the `logs --follow` bug the
-unit tests couldn't: `--ignore-errors` made `--follow` give up in ~40ms when the
-container was still `ContainerCreating`; the runner now uses
-`--pod-running-timeout` to wait for the pod, then follow to completion.
+The kind test refuses to run without an explicit `NEMUS_E2E_CONTEXT` (so it can't
+touch a real cluster by accident); the docker test refuses if the daemon isn't
+reachable. The kind test is what caught the `logs --follow` bug the unit tests
+couldn't: `--ignore-errors` made `--follow` give up in ~40ms when the container
+was still `ContainerCreating`; the runner now uses `--pod-running-timeout` to wait
+for the pod, then follow to completion.
 
 ## The provisioning seam: IaC modules
 

--- a/packages/cloud/e2e/docker-smoke.mjs
+++ b/packages/cloud/e2e/docker-smoke.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * Live end-to-end smoke test for the in-box `docker` runner against a REAL local
+ * Docker (or Podman) daemon.
+ *
+ * The docker runner is the design's portability proof — "if a feature can't work
+ * against a local Docker socket, it doesn't belong in core" — so it's worth
+ * exercising for real, not just with a mocked CLI. Drives the actual DockerRunner
+ * through launch → status → exec → logs → stop.
+ *
+ * Not part of `npm test`/CI (needs a daemon + pulls a public image). Run it by
+ * hand:
+ *
+ *   npm run -w @nemus-cli/cloud e2e:docker
+ *
+ * Env: NEMUS_E2E_IMAGE (default busybox:1.36), NEMUS_E2E_DOCKER_BIN (default
+ * "docker"; set to "podman" to target Podman).
+ */
+import { execFileSync } from 'node:child_process';
+import { DockerRunner } from '../dist/index.js';
+
+const bin = process.env.NEMUS_E2E_DOCKER_BIN || 'docker';
+const image = process.env.NEMUS_E2E_IMAGE || 'busybox:1.36';
+
+// Refuse to run if the daemon isn't reachable, so the failure is clear.
+try {
+  execFileSync(bin, ['info'], { stdio: 'ignore' });
+} catch {
+  console.error(`refusing to run: \`${bin} info\` failed — is the Docker daemon running?`);
+  process.exit(2);
+}
+
+const MARKER = `hello-from-nemus-${Date.now()}`;
+let failures = 0;
+const ok = (name, cond, detail = '') => {
+  console.log(`${cond ? '✓' : '✗'} ${name}${detail ? `  — ${detail}` : ''}`);
+  if (!cond) failures++;
+};
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const runner = new DockerRunner({ bin });
+const target = { version: 1, runner: 'docker' };
+const spec = {
+  image,
+  command: ['sh', '-c', `echo ${MARKER}; sleep 20`],
+  env: { NEMUS_E2E: '1' },
+  labels: { 'nemus.e2e': '1' },
+};
+
+let handle;
+try {
+  console.log(`\n== launching ${image} via ${bin} ==`);
+  handle = await runner.launch(spec, target);
+  ok('launch returns a container id', !!handle?.id, `id=${handle?.id?.slice(0, 12)}`);
+
+  let state = 'pending';
+  for (let i = 0; i < 30 && state !== 'running' && state !== 'succeeded'; i++) {
+    await sleep(1000);
+    state = (await runner.status(handle)).state;
+  }
+  ok('status reaches running/succeeded', state === 'running' || state === 'succeeded', `state=${state}`);
+
+  if (state === 'running') {
+    const res = await runner.exec(handle, ['sh', '-c', 'echo exec-works']);
+    ok('exec runs in the container', res.exitCode === 0 && res.stdout.includes('exec-works'), `rc=${res.exitCode}`);
+  } else {
+    console.log('· skipped exec (container already exited)');
+  }
+
+  // logs -f follows until the container exits; must contain the marker.
+  let logText = '';
+  for await (const { line } of runner.logs(handle)) logText += line + '\n';
+  ok('logs stream contains the marker', logText.includes(MARKER), `${logText.trim().length} chars`);
+
+  let final = await runner.status(handle);
+  for (let i = 0; i < 10 && final.state === 'running'; i++) {
+    await sleep(1000);
+    final = await runner.status(handle);
+  }
+  ok('final status is succeeded', final.state === 'succeeded', `state=${final.state} exit=${final.exitCode}`);
+  ok('exit code is 0', final.exitCode === 0);
+} catch (e) {
+  console.error('e2e error:', e?.message || e);
+  failures++;
+} finally {
+  if (handle) {
+    try {
+      await runner.stop(handle);
+      const gone = await runner.status(handle).then((s) => s.state).catch(() => 'unknown');
+      ok('stop removes the container', gone === 'unknown' || gone === 'stopped', `state=${gone}`);
+    } catch (e) {
+      ok('stop removes the container', false, e?.message || String(e));
+    }
+  }
+}
+
+console.log(`\n${failures === 0 ? 'PASS' : 'FAIL'} — ${failures} failure(s)`);
+process.exit(failures === 0 ? 0 : 1);

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -35,6 +35,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
     "e2e:kind": "npm run build && node e2e/kind-k8s-smoke.mjs",
+    "e2e:docker": "npm run build && node e2e/docker-smoke.mjs",
     "clean": "rm -rf dist"
   }
 }


### PR DESCRIPTION
Continues the cloud package. Adds a **live end-to-end** smoke test for the in-box `docker` runner — mirroring the kind e2e from #55.

## Why
The `docker` runner is the design's **portability proof** ("if a feature can't work against a local Docker socket, it doesn't belong in core"), so it's worth exercising against a real daemon, not just a mocked CLI. Drives the actual `DockerRunner`: **launch → status → exec → logs → stop**.

## The test
`packages/cloud/e2e/docker-smoke.mjs` — run with `npm run -w @nemus-cli/cloud e2e:docker`.
- **Not in CI** (needs a daemon + pulls a public image).
- **Refuses to run** if `docker info` fails (clear error instead of a confusing one).
- `NEMUS_E2E_DOCKER_BIN=podman` targets Podman.
- Verified locally: **all 7 checks PASS** against a real Docker daemon — no bug this time (unlike k8s in #55, the docker runner was already solid).

177 unit tests still green. Cloud package is private/unpublished — no version bump / release.
