### PR TITLE
feat: --no-color / NO_COLOR and --quiet global flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-09-01
+
+### Added
+
+- **`--no-color` and `-q, --quiet` global flags.** `--no-color` disables ANSI
+  color; Nemus also honors the standard [`NO_COLOR`](https://no-color.org) env
+  var, auto-disables color when stdout isn't a TTY, and respects `FORCE_COLOR=1`.
+  `--quiet` suppresses routine progress logs (info/success/step) while still
+  showing warnings and errors; data output (including `--json`) is unaffected.
+
 ## [0.4.0] - 2026-09-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -243,6 +243,14 @@ The workspace-scoped ones (`status`/`doctor`/`analyze-deps`) need an explicit
 workspace name with `--json` (they never prompt). On failure, `--json` prints a
 parseable `{ "ok": false, "error": … }` to stdout and exits non-zero.
 
+### Global flags
+
+- `--no-color` — disable ANSI color. Nemus also honors the standard
+  [`NO_COLOR`](https://no-color.org) env var and auto-disables color when stdout
+  isn't a TTY (piped/redirected); `FORCE_COLOR=1` forces it on.
+- `-q, --quiet` — suppress routine progress logs (info/success/step) while still
+  showing warnings and errors. Data (including `--json`) is unaffected.
+
 ### Shell completions
 
 Tab-complete subcommands and workspace names. `nemus completion <shell>` prints

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nemus-cli/nemus",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "workspaces": [
     "packages/*"
   ],

--- a/src/program.ts
+++ b/src/program.ts
@@ -1,28 +1,34 @@
 import { Command } from 'commander';
 import * as path from 'path';
 import * as fs from 'fs';
-import { colors } from './utils/colors';
+import { colors, setColorEnabled } from './utils/colors';
+import { setQuiet } from './utils/logger';
 
 // Read version from package.json
 const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf-8'));
 
-const g = colors.green;
-const d = colors.dim;
-const b = colors.bright;
-const r = colors.reset;
+// Apply --no-color / --quiet BEFORE commander parses, so they affect the help
+// banner and every log line (a preAction hook is too late for help output, and
+// ES imports run before any hook). colors.ts already applied NO_COLOR / non-TTY.
+if (process.argv.includes('--no-color')) setColorEnabled(false);
+if (process.argv.includes('--quiet') || process.argv.includes('-q')) setQuiet(true);
 
-const INNER = 38;
-const titleLine = `>_  Nemus`;
-const titlePad = ' '.repeat(Math.max(0, INNER - 2 - titleLine.length));
-const versionLine = `v${pkg.version} · multi-repo workspaces`;
-const versionPad = ' '.repeat(Math.max(0, INNER - 7 - versionLine.length));
-const bar = '─'.repeat(INNER);
-const bannerText = `
+// Rendered live so the pre-scan above (or NO_COLOR) yields a plain banner.
+function renderBanner(): string {
+  const { green: g, dim: d, bright: b, reset: r } = colors;
+  const INNER = 38;
+  const titleLine = `>_  Nemus`;
+  const titlePad = ' '.repeat(Math.max(0, INNER - 2 - titleLine.length));
+  const versionLine = `v${pkg.version} · multi-repo workspaces`;
+  const versionPad = ' '.repeat(Math.max(0, INNER - 7 - versionLine.length));
+  const bar = '─'.repeat(INNER);
+  return `
 ${d}    ╭${bar}╮${r}
 ${d}    │${r}  ${g}>_${r}  ${b}Nemus${r}${titlePad}${d}│${r}
 ${d}    │${r}       ${d}${versionLine}${r}${versionPad}${d}│${r}
 ${d}    ╰${bar}╯${r}
 `;
+}
 
 export const program = new Command();
 
@@ -32,7 +38,9 @@ program
   .version(pkg.version, '-V, --version')
   .option('-f, --force-refresh', 'Force refresh GitHub repos (skip cache)')
   .option('-y, --yes', 'Skip confirmations')
-  .addHelpText('before', bannerText);
+  .option('--no-color', 'Disable colored output (also honors NO_COLOR)')
+  .option('-q, --quiet', 'Suppress progress logs (keep warnings + errors)')
+  .addHelpText('before', () => renderBanner());
 
 // Register top-level commands
 import { registerCreateCommand } from './commands/create';

--- a/src/program.ts
+++ b/src/program.ts
@@ -1,34 +1,20 @@
 import { Command } from 'commander';
 import * as path from 'path';
 import * as fs from 'fs';
-import { colors, setColorEnabled } from './utils/colors';
-import { setQuiet } from './utils/logger';
+import { setColorEnabled } from './utils/colors';
+import { renderHelpBanner } from './utils/banner';
+import { applyGlobalFlags } from './utils/global-flags';
 
 // Read version from package.json
 const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf-8'));
 
-// Apply --no-color / --quiet BEFORE commander parses, so they affect the help
-// banner and every log line (a preAction hook is too late for help output, and
-// ES imports run before any hook). colors.ts already applied NO_COLOR / non-TTY.
+// --no-color must be applied BEFORE commander parses so it reaches the help
+// banner (a preAction hook is too late for help output, and ES imports run
+// before hooks). It's a long flag, so it can't be bundled — an argv scan is
+// sufficient here. colors.ts already applied NO_COLOR / non-TTY at import.
+// --quiet is handled in the preAction hook below (it only affects command
+// logs, never help), which also catches bundled short forms like `-yq`.
 if (process.argv.includes('--no-color')) setColorEnabled(false);
-if (process.argv.includes('--quiet') || process.argv.includes('-q')) setQuiet(true);
-
-// Rendered live so the pre-scan above (or NO_COLOR) yields a plain banner.
-function renderBanner(): string {
-  const { green: g, dim: d, bright: b, reset: r } = colors;
-  const INNER = 38;
-  const titleLine = `>_  Nemus`;
-  const titlePad = ' '.repeat(Math.max(0, INNER - 2 - titleLine.length));
-  const versionLine = `v${pkg.version} · multi-repo workspaces`;
-  const versionPad = ' '.repeat(Math.max(0, INNER - 7 - versionLine.length));
-  const bar = '─'.repeat(INNER);
-  return `
-${d}    ╭${bar}╮${r}
-${d}    │${r}  ${g}>_${r}  ${b}Nemus${r}${titlePad}${d}│${r}
-${d}    │${r}       ${d}${versionLine}${r}${versionPad}${d}│${r}
-${d}    ╰${bar}╯${r}
-`;
-}
 
 export const program = new Command();
 
@@ -40,7 +26,13 @@ program
   .option('-y, --yes', 'Skip confirmations')
   .option('--no-color', 'Disable colored output (also honors NO_COLOR)')
   .option('-q, --quiet', 'Suppress progress logs (keep warnings + errors)')
-  .addHelpText('before', () => renderBanner());
+  .addHelpText('before', () => renderHelpBanner(pkg.version));
+
+// Apply global --quiet / --color from commander's PARSED options (robust to
+// bundled short flags like `-yq` that a raw argv scan misses). Runs before every
+// command action; help output doesn't reach here, which is why --no-color is
+// also pre-scanned above.
+program.hook('preAction', () => applyGlobalFlags(program.opts()));
 
 // Register top-level commands
 import { registerCreateCommand } from './commands/create';

--- a/src/utils/banner.ts
+++ b/src/utils/banner.ts
@@ -22,3 +22,22 @@ ${d}    ╰───────────────────────
 export const printBanner = (): void => {
   console.log(renderBanner());
 };
+
+// The `--help` banner: a boxed splash with the version + tagline, width-fitted.
+// Lives here alongside renderBanner() so the two renderers don't drift; also
+// rendered live so --no-color / NO_COLOR yields a plain box.
+export const renderHelpBanner = (version: string): string => {
+  const { green: g, dim: d, bright: b, reset: r } = colors;
+  const INNER = 38;
+  const titleLine = `>_  Nemus`;
+  const titlePad = ' '.repeat(Math.max(0, INNER - 2 - titleLine.length));
+  const versionLine = `v${version} · multi-repo workspaces`;
+  const versionPad = ' '.repeat(Math.max(0, INNER - 7 - versionLine.length));
+  const bar = '─'.repeat(INNER);
+  return `
+${d}    ╭${bar}╮${r}
+${d}    │${r}  ${g}>_${r}  ${b}Nemus${r}${titlePad}${d}│${r}
+${d}    │${r}       ${d}${versionLine}${r}${versionPad}${d}│${r}
+${d}    ╰${bar}╯${r}
+`;
+};

--- a/src/utils/banner.ts
+++ b/src/utils/banner.ts
@@ -1,17 +1,5 @@
 import { colors } from './colors';
 
-const g = colors.green;
-const d = colors.dim;
-const b = colors.bright;
-const r = colors.reset;
-
-export const BANNER = `
-${d}    ╭──────────────────────────────────────╮${r}
-${d}    │${r}  ${g}>_${r}  ${b}Nemus${r}                           ${d}│${r}
-${d}    │${r}       ${d}multi-repo workspaces${r}          ${d}│${r}
-${d}    ╰──────────────────────────────────────╯${r}
-`;
-
 export const BANNER_PLAIN = `
     ╭──────────────────────────────────────╮
     │  >_  Nemus                           │
@@ -19,6 +7,18 @@ export const BANNER_PLAIN = `
     ╰──────────────────────────────────────╯
 `;
 
+// Rendered live (not captured at import) so --no-color / NO_COLOR applied before
+// this is called produce a plain banner. With color off, every colors.* is ''.
+export const renderBanner = (): string => {
+  const { green: g, dim: d, bright: b, reset: r } = colors;
+  return `
+${d}    ╭──────────────────────────────────────╮${r}
+${d}    │${r}  ${g}>_${r}  ${b}Nemus${r}                           ${d}│${r}
+${d}    │${r}       ${d}multi-repo workspaces${r}          ${d}│${r}
+${d}    ╰──────────────────────────────────────╯${r}
+`;
+};
+
 export const printBanner = (): void => {
-  console.log(BANNER);
+  console.log(renderBanner());
 };

--- a/src/utils/colors.test.ts
+++ b/src/utils/colors.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { colors, colorize, setColorEnabled, isColorEnabled, detectColorEnabled } from './colors';
+
+// Tests toggle global color state; restore a known state afterward.
+afterEach(() => setColorEnabled(true));
+
+describe('setColorEnabled / colorize', () => {
+  it('wraps with ANSI when on, and is plain when off (same call sites)', () => {
+    setColorEnabled(true);
+    expect(isColorEnabled()).toBe(true);
+    const on = colorize('hi', 'green');
+    expect(on).toContain('\x1b[32m');
+    expect(on).toContain('\x1b[0m');
+    expect(on).toContain('hi');
+
+    setColorEnabled(false);
+    expect(isColorEnabled()).toBe(false);
+    expect(colorize('hi', 'green')).toBe('hi'); // no codes at all
+  });
+
+  it('empties inline colors.* codes in place when disabled', () => {
+    setColorEnabled(false);
+    expect(colors.gray).toBe('');
+    expect(colors.reset).toBe('');
+    setColorEnabled(true);
+    expect(colors.gray).toBe('\x1b[90m');
+  });
+});
+
+describe('detectColorEnabled', () => {
+  it('NO_COLOR disables regardless of value (even empty)', () => {
+    expect(detectColorEnabled({ NO_COLOR: '1' }, true)).toBe(false);
+    expect(detectColorEnabled({ NO_COLOR: '' }, true)).toBe(false);
+  });
+
+  it('FORCE_COLOR forces on even without a TTY (but 0/false do not)', () => {
+    expect(detectColorEnabled({ FORCE_COLOR: '1' }, false)).toBe(true);
+    expect(detectColorEnabled({ FORCE_COLOR: '0' }, false)).toBe(false);
+    expect(detectColorEnabled({ FORCE_COLOR: 'false' }, false)).toBe(false);
+  });
+
+  it('NO_COLOR beats FORCE_COLOR', () => {
+    expect(detectColorEnabled({ NO_COLOR: '1', FORCE_COLOR: '1' }, true)).toBe(false);
+  });
+
+  it('otherwise follows the TTY, and TERM=dumb disables', () => {
+    expect(detectColorEnabled({}, true)).toBe(true);
+    expect(detectColorEnabled({}, false)).toBe(false);
+    expect(detectColorEnabled({ TERM: 'dumb' }, true)).toBe(false);
+  });
+});

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -1,4 +1,7 @@
-export const colors = {
+// ANSI escape codes. `colors` starts as a copy of these but is emptied in place
+// when color is disabled (--no-color / NO_COLOR / non-TTY), so BOTH `colorize()`
+// and inline `colors.x` template usage go plain without touching call sites.
+const ANSI = {
   reset: '\x1b[0m',
   bright: '\x1b[1m',
   dim: '\x1b[2m',
@@ -18,8 +21,52 @@ export const colors = {
   bgGreen: '\x1b[42m',
   bgYellow: '\x1b[43m',
   bgBlue: '\x1b[44m',
-};
+} as const;
 
-export const colorize = (text: string, color: keyof typeof colors): string => {
+export type ColorName = keyof typeof ANSI;
+
+// Live map read at every use. Mutated in place by setColorEnabled so previously
+// imported references (e.g. `colors.gray` inside a template) see the change.
+export const colors: Record<ColorName, string> = { ...ANSI };
+
+let enabled = true;
+
+/** Whether colored output is currently on. */
+export const isColorEnabled = (): boolean => enabled;
+
+/** Turn color on/off. When off, every `colors.*` code becomes '' so output is
+ *  plain; when on, the ANSI codes are restored. */
+export function setColorEnabled(on: boolean): void {
+  enabled = on;
+  for (const key of Object.keys(ANSI) as ColorName[]) {
+    colors[key] = on ? ANSI[key] : '';
+  }
+}
+
+/**
+ * Decide whether to use color by default, following the common conventions:
+ * - `NO_COLOR` (any value, even empty) disables — see https://no-color.org
+ * - `FORCE_COLOR` (and not "0"/"false") forces it on, even when not a TTY
+ * - otherwise on only when the stdout stream is a TTY and `TERM` isn't `dumb`
+ */
+export function detectColorEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+  isTTY: boolean = !!process.stdout.isTTY,
+): boolean {
+  if ('NO_COLOR' in env) return false;
+  const force = env.FORCE_COLOR;
+  if (force !== undefined && force !== '' && force !== '0' && force.toLowerCase() !== 'false') {
+    return true;
+  }
+  if (env.TERM === 'dumb') return false;
+  return isTTY;
+}
+
+export const colorize = (text: string, color: ColorName): string => {
   return `${colors[color]}${text}${colors.reset}`;
 };
+
+// Apply the environment default at import time so NO_COLOR / a non-TTY pipe is
+// respected even before any CLI flag is parsed (an explicit --no-color / --color
+// flag overrides this later).
+setColorEnabled(detectColorEnabled());

--- a/src/utils/global-flags.test.ts
+++ b/src/utils/global-flags.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Command } from 'commander';
+import { applyGlobalFlags } from './global-flags';
+
+const spies = () => ({ setColorEnabled: vi.fn(), setQuiet: vi.fn() });
+
+// Mirror the real root-program global options so we test what commander actually
+// parses (esp. bundled short flags), not a hand-built opts object.
+const rootOpts = (argv: string[]) => {
+  const p = new Command();
+  p.option('-y, --yes', '').option('-q, --quiet', '').option('--no-color', '');
+  p.command('list').action(() => {});
+  p.parse(['node', 'nemus', 'list', ...argv]);
+  return p.opts();
+};
+
+describe('applyGlobalFlags', () => {
+  it('does nothing by default (color on, not quiet)', () => {
+    const d = spies();
+    applyGlobalFlags(rootOpts([]), d);
+    expect(d.setColorEnabled).not.toHaveBeenCalled();
+    expect(d.setQuiet).not.toHaveBeenCalled();
+  });
+
+  it('--no-color disables color', () => {
+    const d = spies();
+    applyGlobalFlags(rootOpts(['--no-color']), d);
+    expect(d.setColorEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it('--quiet enables quiet', () => {
+    const d = spies();
+    applyGlobalFlags(rootOpts(['--quiet']), d);
+    expect(d.setQuiet).toHaveBeenCalledWith(true);
+  });
+
+  it('bundled short flags (-yq) still enable quiet', () => {
+    const d = spies();
+    const opts = rootOpts(['-yq']);
+    expect(opts.quiet).toBe(true); // commander expands the bundle
+    applyGlobalFlags(opts, d);
+    expect(d.setQuiet).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/utils/global-flags.ts
+++ b/src/utils/global-flags.ts
@@ -1,0 +1,28 @@
+import { setColorEnabled } from './colors';
+import { setQuiet } from './logger';
+
+/** Global options commander parses off the root program. */
+export interface GlobalFlagOpts {
+  /** commander's negatable `--no-color` yields `color: false` when passed. */
+  color?: boolean;
+  /** `-q`/`--quiet`, including bundled short forms like `-yq`. */
+  quiet?: boolean;
+}
+
+/**
+ * Apply parsed global flags to process-wide state. Kept pure over injected
+ * setters so it's testable without commander — the `preAction` hook in
+ * program.ts is a one-line call into this. Only ever turns features OFF here:
+ * color defaults on (and env/TTY detection already ran at import), so we act
+ * solely on an explicit `--no-color` (`color === false`).
+ */
+export function applyGlobalFlags(
+  opts: GlobalFlagOpts,
+  deps: { setColorEnabled: (on: boolean) => void; setQuiet: (on: boolean) => void } = {
+    setColorEnabled,
+    setQuiet,
+  },
+): void {
+  if (opts.color === false) deps.setColorEnabled(false);
+  if (opts.quiet) deps.setQuiet(true);
+}

--- a/src/utils/logger.test.ts
+++ b/src/utils/logger.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { logInfo, logSuccess, logStep, logWarning, logError, setQuiet, isQuiet } from './logger';
+
+afterEach(() => {
+  setQuiet(false);
+  vi.restoreAllMocks();
+});
+
+describe('--quiet (setQuiet)', () => {
+  it('suppresses info/success/step but keeps warnings + errors', () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    setQuiet(true);
+    expect(isQuiet()).toBe(true);
+
+    logInfo('i');
+    logSuccess('s');
+    logStep('st');
+    expect(err).not.toHaveBeenCalled(); // routine progress silenced
+
+    logWarning('w');
+    logError('e');
+    expect(err).toHaveBeenCalledTimes(2); // warnings + errors still shown
+    expect(err.mock.calls.map((c) => String(c[0])).join('\n')).toMatch(/w[\s\S]*e|e[\s\S]*w/);
+  });
+
+  it('emits everything when not quiet', () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    setQuiet(false);
+    logInfo('i');
+    logSuccess('s');
+    logStep('st');
+    logWarning('w');
+    logError('e');
+    expect(err).toHaveBeenCalledTimes(5);
+  });
+});

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -5,6 +5,14 @@ import { colors, colorize } from './colors';
 // --json | jq …) and for non-TTY consumers. Use `outputJson`/stdout for data.
 const logStream = (line: string): void => console.error(line);
 
+// `--quiet` silences routine progress (info/success/step) while KEEPING warnings
+// and errors, which a script or human still needs to see.
+let quiet = false;
+export const setQuiet = (on: boolean): void => {
+  quiet = on;
+};
+export const isQuiet = (): boolean => quiet;
+
 const getTimestamp = (): string => {
   const now = new Date();
   return now.toLocaleTimeString('en-US', {
@@ -16,10 +24,12 @@ const getTimestamp = (): string => {
 };
 
 export const logInfo = (message: string): void => {
+  if (quiet) return;
   logStream(`${colors.gray}[${getTimestamp()}]${colors.reset} ${message}`);
 };
 
 export const logSuccess = (message: string): void => {
+  if (quiet) return;
   logStream(`${colors.gray}[${getTimestamp()}]${colors.reset} ${colorize('✓', 'green')} ${message}`);
 };
 
@@ -32,6 +42,7 @@ export const logWarning = (message: string): void => {
 };
 
 export const logStep = (stepOrMessage: number | string, total?: number, message?: string): void => {
+  if (quiet) return;
   if (typeof stepOrMessage === 'string') {
     // Single parameter version: just a message
     logStream(`${colors.gray}[${getTimestamp()}]${colors.reset} ${colorize('▸', 'cyan')} ${stepOrMessage}`);


### PR DESCRIPTION
First of the core-CLI polish round (pivoting back to the published `@nemus-cli/nemus`). Adds two standard global flags.

## `--no-color` (+ `NO_COLOR` / TTY auto-detect)
- `colors.ts` now toggles ANSI **in place** (`setColorEnabled`), so **both** `colorize()` and inline `colors.*` template usage go plain when disabled — zero call-site changes across the codebase.
- Auto-detects at import: `NO_COLOR` disables (any value, per [no-color.org](https://no-color.org)), `FORCE_COLOR` forces on (except `0`/`false`), `TERM=dumb` or a **non-TTY stdout** (piped/redirected) disables.
- `--no-color` forces it off, applied via an argv **pre-scan before commander parses** so it affects the **help banner** too (a `preAction` hook is too late for help output, and ES imports run before hooks). Both banners are now rendered live instead of captured at import.

## `-q, --quiet`
- Suppresses routine progress (info/success/step) while **keeping warnings + errors**. Data output (including `--json`) is untouched — diagnostics already go to stderr.

## Tests
- `colors.test.ts` — toggle behavior + detection precedence (`NO_COLOR` > `FORCE_COLOR` > `TERM`/TTY).
- `logger.test.ts` — quiet gates info/success/step, keeps warn/error.
- **483 core tests** green; typecheck clean.

README gains a "Global flags" section; CHANGELOG updated. Version **0.4.0 → 0.5.0**.

### Verified locally
- `FORCE_COLOR=1 --help` → colored banner; `--no-color --help` and `NO_COLOR=1 --help` → plain.
- `--quiet` → info/success/step silenced, warn/error still shown.
