### PR TITLE
feat: reflect --markdown export + severity summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-09-01
+
+### Added
+
+- **`nemus reflect --markdown`** — render the reflection report as clean,
+  severity-grouped Markdown to stdout (pipe into a file or an issue:
+  `nemus reflect --markdown > reflection.md`). Fenced example snippets are
+  escaped so they can't break out of their own code block.
+- The human `reflect` report now prints a **severity summary line**
+  (e.g. `2 high · 1 medium`).
+
 ## [0.6.0] - 2026-09-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -311,8 +311,12 @@ nemus snapshot restore <id>   # (sr)
 nemus reflect                 # (retro) analyze your last 10 workspaces' sessions
 nemus reflect --limit 5       # narrow the window
 nemus reflect --json          # structured report for tooling
+nemus reflect --markdown      # Markdown report (grouped by severity) to paste/save
 nemus reflect --dry-run       # show what the judge sees, without calling the agent
 ```
+
+`--markdown` writes a clean, severity-grouped report to stdout — pipe it into a
+file or an issue: `nemus reflect --markdown > reflection.md`.
 
 `reflect` reads your recent agent **session transcripts** (Claude + pi), distills
 the prompts you sent, the failures the agent hit, and the tools it used, then asks

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nemus-cli/nemus",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "workspaces": [
     "packages/*"
   ],

--- a/src/commands/reflect.ts
+++ b/src/commands/reflect.ts
@@ -6,6 +6,8 @@ import {
   gatherReflectionCorpus,
   parseReflectionReport,
   saveReflectionReport,
+  renderReportMarkdown,
+  severitySummary,
   REFLECT_SCHEMA,
   ReflectionReport,
   ReflectProgress,
@@ -24,6 +26,7 @@ export function registerReflectCommand(parent: Command) {
     .option('--model <model>', 'Judge model override (agent-native pattern/id)')
     .option('--thinking <level>', 'Judge thinking level for pi: off|minimal|low|medium|high|xhigh|max')
     .option('--json', 'Output the report as JSON')
+    .option('--markdown', 'Output the report as Markdown (paste into an issue/PR)')
     .option('--no-save', 'Do not save the report to ~/.nemus/reflect/')
     .option('--dry-run', 'Print the assembled corpus + judge prompt without calling the agent')
     .action(async (opts) => {
@@ -37,12 +40,13 @@ async function handleReflect(opts: {
   model?: string;
   thinking?: string;
   json?: boolean;
+  markdown?: boolean;
   save?: boolean; // commander sets `save: false` for --no-save
   dryRun?: boolean;
 }) {
   const limit = Math.max(1, Number.parseInt(opts.limit ?? '10', 10) || 10);
   try {
-    const showProgress = !opts.json && !opts.dryRun;
+    const showProgress = !opts.json && !opts.markdown && !opts.dryRun;
     if (showProgress) {
       logStep(
         opts.workspace
@@ -85,7 +89,7 @@ async function handleReflect(opts: {
     const timeoutMs = Number.parseInt(process.env.NEMUS_JUDGE_TIMEOUT_MS ?? '', 10) || undefined;
     const model = opts.model ?? process.env.NEMUS_JUDGE_MODEL ?? undefined;
     const thinking = opts.thinking ?? process.env.NEMUS_JUDGE_THINKING ?? undefined;
-    const stopSpinner = opts.json
+    const stopSpinner = opts.json || opts.markdown
       ? () => {}
       : startSpinner(`Judging ${withSessions} session(s) with your configured agent (this can take a minute)…`);
     let parsed: unknown;
@@ -112,6 +116,20 @@ async function handleReflect(opts: {
 
     if (opts.json) {
       outputJson({ analyzed: withSessions, workspaces: corpus.workspaces.length, ...report, savedTo });
+      return;
+    }
+    if (opts.markdown) {
+      // DATA channel: markdown to stdout, nothing else (a 'Saved report' note
+      // would corrupt a redirected .md file), so surface the path on stderr.
+      process.stdout.write(
+        renderReportMarkdown(report, {
+          analyzed: withSessions,
+          workspaces: corpus.workspaces.length,
+          workspace: opts.workspace,
+          generatedAt: new Date().toISOString(),
+        }),
+      );
+      if (savedTo) logInfo(`Saved report to ${colorize(savedTo, 'dim')}`);
       return;
     }
     printReport(report, corpus.workspaces.length, withSessions);
@@ -195,6 +213,8 @@ function printReport(report: ReflectionReport, workspaces: number, analyzed: num
     console.log('\n  ' + colorize('No specific recommendations — looks solid.', 'green') + '\n');
     return;
   }
+
+  console.log('\n  ' + colorize(severitySummary(report.recommendations), 'dim'));
 
   // High priority first.
   const order = { high: 0, medium: 1, low: 2 };

--- a/src/utils/reflect.test.ts
+++ b/src/utils/reflect.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { distillTranscript, parseReflectionReport, classifyAgentsMd, isCorrectionPrompt, saveReflectionReport } from './reflect';
+import { distillTranscript, parseReflectionReport, classifyAgentsMd, isCorrectionPrompt, saveReflectionReport, severityCounts, severitySummary, renderReportMarkdown, ReflectionReport } from './reflect';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
@@ -122,5 +122,63 @@ describe('parseReflectionReport', () => {
   it('tolerates a malformed top-level object', () => {
     expect(parseReflectionReport(null)).toEqual({ summary: '', recommendations: [] });
     expect(parseReflectionReport({ recommendations: 'nope' })).toEqual({ summary: '', recommendations: [] });
+  });
+});
+
+describe('severityCounts / severitySummary', () => {
+  const recs = (ps: Array<'high' | 'medium' | 'low'>) =>
+    ps.map((priority) => ({ kind: 'other' as const, title: 't', detail: 'd', priority }));
+
+  it('counts by priority', () => {
+    expect(severityCounts(recs(['high', 'high', 'low']))).toEqual({ high: 2, medium: 0, low: 1 });
+  });
+  it('summary omits empty buckets and is empty for none', () => {
+    expect(severitySummary(recs(['high', 'medium', 'medium']))).toBe('1 high · 2 medium');
+    expect(severitySummary([])).toBe('');
+  });
+});
+
+describe('renderReportMarkdown', () => {
+  const report: ReflectionReport = {
+    summary: 'Overall fine.',
+    recommendations: [
+      { kind: 'skill', title: 'Add deploy skill', detail: 'manual steps', priority: 'high', target: 'acme/api', example: 'name: deploy' },
+      { kind: 'context', title: 'Doc lint', detail: 'guessed', priority: 'medium' },
+    ],
+  };
+
+  it('groups by severity with a count line and headings', () => {
+    const md = renderReportMarkdown(report, { analyzed: 5, workspaces: 3, generatedAt: '2026-09-01T12:00:00Z' });
+    expect(md).toMatch(/^# Reflection/);
+    expect(md).toContain('_5 sessions across 3 workspaces · 2026-09-01T12:00:00Z_');
+    expect(md).toContain('**1 high · 1 medium**');
+    expect(md).toContain('### High priority');
+    expect(md).toContain('### Medium priority');
+    // high appears before medium
+    expect(md.indexOf('### High priority')).toBeLessThan(md.indexOf('### Medium priority'));
+    expect(md).toContain('- **[Skill] Add deploy skill** (`acme/api`)');
+    expect(md).toContain('- **[Context/AGENTS.md] Doc lint**');
+    expect(md.endsWith('\n')).toBe(true);
+  });
+
+  it('uses a single-workspace scope line', () => {
+    const md = renderReportMarkdown(report, { analyzed: 1, workspaces: 1, workspace: 'my-ws' });
+    expect(md).toContain('_workspace **my-ws**_');
+  });
+
+  it('escapes an example that itself contains a triple-backtick fence', () => {
+    const r: ReflectionReport = {
+      summary: '',
+      recommendations: [{ kind: 'other', title: 'x', detail: '', priority: 'low', example: 'a ```b``` c' }],
+    };
+    const md = renderReportMarkdown(r, { analyzed: 1, workspaces: 1 });
+    expect(md).toContain('````'); // fence longer than the inner run
+    expect(md).toContain('a ```b``` c');
+  });
+
+  it('renders a clean empty state', () => {
+    const md = renderReportMarkdown({ summary: 'All good.', recommendations: [] }, { analyzed: 2, workspaces: 2 });
+    expect(md).toContain('_No specific recommendations — looks solid._');
+    expect(md).not.toContain('### High');
   });
 });

--- a/src/utils/reflect.ts
+++ b/src/utils/reflect.ts
@@ -63,6 +63,95 @@ export interface ReflectionReport {
   recommendations: Recommendation[];
 }
 
+// ------------------------------------------------------------ report rendering
+
+export type Priority = Recommendation['priority'];
+
+/** Count recommendations by priority. */
+export function severityCounts(recs: Recommendation[]): Record<Priority, number> {
+  const counts: Record<Priority, number> = { high: 0, medium: 0, low: 0 };
+  for (const r of recs) counts[r.priority]++;
+  return counts;
+}
+
+/** "3 high · 2 medium · 1 low", omitting zero buckets; '' when there are none. */
+export function severitySummary(recs: Recommendation[]): string {
+  const c = severityCounts(recs);
+  return (['high', 'medium', 'low'] as Priority[])
+    .filter((p) => c[p] > 0)
+    .map((p) => `${c[p]} ${p}`)
+    .join(' · ');
+}
+
+const MD_KIND_LABEL: Record<RecommendationKind, string> = {
+  skill: 'Skill',
+  context: 'Context/AGENTS.md',
+  test: 'Test',
+  prompt: 'Prompt',
+  connectivity: 'Connectivity',
+  workflow: 'Workflow',
+  other: 'Other',
+};
+
+const PRIORITY_HEADING: Record<Priority, string> = {
+  high: 'High priority',
+  medium: 'Medium priority',
+  low: 'Low priority',
+};
+
+/** A fenced code block whose fence is guaranteed longer than any backtick run
+ *  inside `body`, so the snippet can't break out of its own fence. */
+function fencedBlock(body: string): string {
+  const longest = Math.max(0, ...(body.match(/`+/g) ?? []).map((m) => m.length));
+  const fence = '`'.repeat(Math.max(3, longest + 1));
+  return `${fence}\n${body}\n${fence}`;
+}
+
+/**
+ * Render a reflection report as clean Markdown — for pasting into an issue/PR or
+ * saving alongside the JSON. Pure (no color, no I/O) so it's unit-tested.
+ * Recommendations are grouped by severity (high→low); each carries its kind,
+ * optional target, detail, and a fenced example.
+ */
+export function renderReportMarkdown(
+  report: ReflectionReport,
+  meta: { analyzed: number; workspaces: number; workspace?: string; generatedAt?: string },
+): string {
+  const lines: string[] = ['# Reflection', ''];
+  const scope = meta.workspace
+    ? `workspace **${meta.workspace}**`
+    : `${meta.analyzed} session${meta.analyzed === 1 ? '' : 's'} across ${meta.workspaces} workspace${meta.workspaces === 1 ? '' : 's'}`;
+  const stamp = meta.generatedAt ? ` · ${meta.generatedAt}` : '';
+  lines.push(`_${scope}${stamp}_`, '');
+
+  if (report.summary.trim()) lines.push(report.summary.trim(), '');
+
+  if (report.recommendations.length === 0) {
+    lines.push('## Recommendations', '', '_No specific recommendations — looks solid._', '');
+    return lines.join('\n');
+  }
+
+  lines.push('## Recommendations', '', `**${severitySummary(report.recommendations)}**`, '');
+
+  for (const priority of ['high', 'medium', 'low'] as Priority[]) {
+    const group = report.recommendations.filter((r) => r.priority === priority);
+    if (group.length === 0) continue;
+    lines.push(`### ${PRIORITY_HEADING[priority]}`, '');
+    for (const r of group) {
+      const target = r.target ? ` (\`${r.target}\`)` : '';
+      lines.push(`- **[${MD_KIND_LABEL[r.kind]}] ${r.title}**${target}`);
+      if (r.detail.trim()) {
+        lines.push(...r.detail.trim().split('\n').map((l) => `  ${l}`));
+      }
+      if (r.example?.trim()) {
+        lines.push('', ...fencedBlock(r.example.trim()).split('\n').map((l) => `  ${l}`));
+      }
+      lines.push('');
+    }
+  }
+  return lines.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd() + '\n';
+}
+
 // --------------------------------------------------------- transcript distill
 
 // Kept deliberately lean: the judge runs on the user's own (often local, slow)


### PR DESCRIPTION
Third of the core-CLI polish round: `reflect` output polish — a **Markdown export** and a **severity summary**.

## `nemus reflect --markdown`
Renders the reflection report as clean, **severity-grouped** Markdown to stdout — paste into an issue/PR, or save it:
```bash
nemus reflect --markdown > reflection.md
```
- Grouped **high → medium → low** with a count line (`**2 high · 1 medium**`); each recommendation shows its kind, optional `target`, detail, and a fenced example.
- Example snippets are wrapped in a fence **sized longer than any backtick run inside them**, so an example that itself contains ` ``` ` can't break out of its own code block.
- Writes only to the **DATA channel** (stdout); the "Saved report" note stays on stderr so a redirected `.md` isn't corrupted. `--markdown` suppresses the spinner/progress just like `--json`.

## Severity summary
The human report now prints a summary line under the header (e.g. `2 high · 1 medium`), via a shared `severitySummary()` (empty buckets omitted).

## Design
`renderReportMarkdown()` + `severityCounts()`/`severitySummary()` live in `reflect.ts`, **pure** (no color, no I/O) and fully unit-tested — the command layer just picks the channel.

## Tests
- `severityCounts`/`severitySummary` (counts; omit empty buckets; empty→'').
- `renderReportMarkdown`: grouping + high-before-medium order, single-workspace scope line, **triple-backtick example escaping**, clean empty state, trailing newline.
- **508 core tests** green; typecheck clean.

README + CHANGELOG updated. Version **0.6.0 → 0.7.0**.
