### PR TITLE
feat: reflect history/show + --group-by kind|priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-09-01
+
+### Added
+
+- **`nemus reflect history`** and **`nemus reflect show [id]`** to review saved
+  reports (under `~/.nemus/reflect/`) without re-running the judge. `show`
+  defaults to the latest, accepts an id or id-prefix, and supports
+  `--json` / `--markdown` / `--group-by`.
+- **`nemus reflect --group-by kind|priority`** (default `priority`) to control
+  how recommendations are grouped in both the human and Markdown output.
+
 ## [0.7.0] - 2026-09-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -312,11 +312,23 @@ nemus reflect                 # (retro) analyze your last 10 workspaces' session
 nemus reflect --limit 5       # narrow the window
 nemus reflect --json          # structured report for tooling
 nemus reflect --markdown      # Markdown report (grouped by severity) to paste/save
+nemus reflect --group-by kind # group recommendations by kind instead of priority
 nemus reflect --dry-run       # show what the judge sees, without calling the agent
 ```
 
 `--markdown` writes a clean, severity-grouped report to stdout — pipe it into a
-file or an issue: `nemus reflect --markdown > reflection.md`.
+file or an issue: `nemus reflect --markdown > reflection.md`. `--group-by
+kind|priority` (default `priority`) controls how recommendations are grouped in
+both the human and Markdown output.
+
+Every run is saved under `~/.nemus/reflect/`. Review past reports without
+re-running the judge:
+
+```bash
+nemus reflect history            # list saved reports, newest first (--json)
+nemus reflect show               # print the latest saved report
+nemus reflect show <id>          # a specific one (--markdown / --json / --group-by)
+```
 
 `reflect` reads your recent agent **session transcripts** (Claude + pi), distills
 the prompts you sent, the failures the agent hit, and the tools it used, then asks

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nemus-cli/nemus",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "workspaces": [
     "packages/*"
   ],

--- a/src/commands/reflect.ts
+++ b/src/commands/reflect.ts
@@ -8,10 +8,14 @@ import {
   saveReflectionReport,
   renderReportMarkdown,
   severitySummary,
+  groupRecommendations,
+  listSavedReports,
+  loadSavedReport,
   REFLECT_SCHEMA,
   ReflectionReport,
   ReflectProgress,
   Recommendation,
+  GroupBy,
 } from '../utils/reflect';
 import { analyzeCorpus, buildAnalysisPrompt } from '../utils/reflect-analyze';
 import { runAgentJsonAsync } from '../utils/agent-judge';
@@ -20,18 +24,46 @@ export function registerReflectCommand(parent: Command) {
   parent
     .command('reflect')
     .alias('retro')
-    .description('Analyze your recent workspace sessions and suggest skill/prompt/context improvements (LLM-as-a-judge)')
+    .description('Analyze recent sessions for improvements, or review saved reports ("history"/"show")')
+    .argument('[subcommand]', '"history" or "show" — omit to run a new analysis')
+    .argument('[id]', 'report id when using "show" (default: latest)')
     .option('-n, --limit <n>', 'How many recent workspaces to analyze', '10')
     .option('-w, --workspace <name>', 'Analyze a single workspace by name (ignores --limit)')
     .option('--model <model>', 'Judge model override (agent-native pattern/id)')
     .option('--thinking <level>', 'Judge thinking level for pi: off|minimal|low|medium|high|xhigh|max')
     .option('--json', 'Output the report as JSON')
     .option('--markdown', 'Output the report as Markdown (paste into an issue/PR)')
+    .option('--group-by <how>', 'Group recommendations by: priority | kind', 'priority')
     .option('--no-save', 'Do not save the report to ~/.nemus/reflect/')
     .option('--dry-run', 'Print the assembled corpus + judge prompt without calling the agent')
-    .action(async (opts) => {
-      await handleReflect(opts);
+    .addHelpText(
+      'after',
+      '\nSaved reports:\n  nemus reflect history            List saved reports (newest first)\n  nemus reflect show [id]          Print a saved report (default: latest)\n',
+    )
+    // history/show are positional (not commander subcommands) on purpose: as
+    // subcommands they would share --json/--markdown/--group-by with this parent
+    // command, and the only commander fix (enablePositionalOptions on the root)
+    // breaks global flags placed after a subcommand (e.g. `nemus list --quiet`).
+    .action(async (subcommand: string | undefined, id: string | undefined, opts) => {
+      if (subcommand === 'history') return handleHistory(opts);
+      if (subcommand === 'show') return handleShow(id, opts);
+      if (subcommand !== undefined) {
+        const msg = `Unknown reflect subcommand "${subcommand}" (expected "history" or "show").`;
+        if (opts.json) outputJsonError(msg);
+        else logError(msg);
+        process.exit(1);
+      }
+      return handleReflect(opts);
     });
+}
+
+/** Validate --group-by; returns the value or exits non-zero with a clear error. */
+function resolveGroupBy(raw: string | undefined, json?: boolean): GroupBy {
+  if (raw === undefined || raw === 'priority' || raw === 'kind') return (raw ?? 'priority') as GroupBy;
+  const msg = `--group-by must be "priority" or "kind"; got "${raw}"`;
+  if (json) outputJsonError(msg);
+  else logError(msg);
+  process.exit(1);
 }
 
 async function handleReflect(opts: {
@@ -41,10 +73,12 @@ async function handleReflect(opts: {
   thinking?: string;
   json?: boolean;
   markdown?: boolean;
+  groupBy?: string;
   save?: boolean; // commander sets `save: false` for --no-save
   dryRun?: boolean;
 }) {
   const limit = Math.max(1, Number.parseInt(opts.limit ?? '10', 10) || 10);
+  const groupBy = resolveGroupBy(opts.groupBy, opts.json);
   try {
     const showProgress = !opts.json && !opts.markdown && !opts.dryRun;
     if (showProgress) {
@@ -122,17 +156,21 @@ async function handleReflect(opts: {
       // DATA channel: markdown to stdout, nothing else (a 'Saved report' note
       // would corrupt a redirected .md file), so surface the path on stderr.
       process.stdout.write(
-        renderReportMarkdown(report, {
-          analyzed: withSessions,
-          workspaces: corpus.workspaces.length,
-          workspace: opts.workspace,
-          generatedAt: new Date().toISOString(),
-        }),
+        renderReportMarkdown(
+          report,
+          {
+            analyzed: withSessions,
+            workspaces: corpus.workspaces.length,
+            workspace: opts.workspace,
+            generatedAt: new Date().toISOString(),
+          },
+          groupBy,
+        ),
       );
       if (savedTo) logInfo(`Saved report to ${colorize(savedTo, 'dim')}`);
       return;
     }
-    printReport(report, corpus.workspaces.length, withSessions);
+    printReport(report, corpus.workspaces.length, withSessions, groupBy);
     if (savedTo) logInfo(`Saved report to ${colorize(savedTo, 'dim')}`);
   } catch (error) {
     const msg = error instanceof Error ? error.message : 'reflect failed';
@@ -201,7 +239,7 @@ function priorityBadge(p: Recommendation['priority']): string {
   return colorize('● low', 'gray');
 }
 
-function printReport(report: ReflectionReport, workspaces: number, analyzed: number) {
+function printReport(report: ReflectionReport, workspaces: number, analyzed: number, groupBy: GroupBy = 'priority') {
   console.log('');
   console.log(colorize('  Reflection', 'bright') + colorize(`  (${analyzed} sessions across ${workspaces} workspaces)`, 'dim'));
   console.log(colorize('  ' + '─'.repeat(56), 'dim'));
@@ -216,19 +254,88 @@ function printReport(report: ReflectionReport, workspaces: number, analyzed: num
 
   console.log('\n  ' + colorize(severitySummary(report.recommendations), 'dim'));
 
-  // High priority first.
-  const order = { high: 0, medium: 1, low: 2 };
-  const recs = [...report.recommendations].sort((a, b) => order[a.priority] - order[b.priority]);
-
-  console.log('');
-  for (const r of recs) {
-    const target = r.target ? colorize(`  [${r.target}]`, 'cyan') : '';
-    console.log(`  ${priorityBadge(r.priority)}  ${colorize(KIND_LABEL[r.kind], 'bright')}  ${r.title}${target}`);
-    if (r.detail) console.log(`      ${r.detail.replace(/\n/g, '\n      ')}`);
-    if (r.example) {
-      console.log(colorize('      example:', 'dim'));
-      console.log(colorize(r.example.replace(/^/gm, '        '), 'dim'));
+  for (const group of groupRecommendations(report.recommendations, groupBy)) {
+    console.log('\n  ' + colorize(group.heading, 'bright'));
+    for (const r of group.recs) {
+      const target = r.target ? colorize(`  [${r.target}]`, 'cyan') : '';
+      // Under a kind heading show the priority badge; under a priority heading
+      // show the kind label (the heading conveys the other axis).
+      const lead = groupBy === 'kind' ? priorityBadge(r.priority) : colorize(KIND_LABEL[r.kind], 'bright');
+      console.log(`    ${lead}  ${r.title}${target}`);
+      if (r.detail) console.log(`      ${r.detail.replace(/\n/g, '\n      ')}`);
+      if (r.example) {
+        console.log(colorize('      example:', 'dim'));
+        console.log(colorize(r.example.replace(/^/gm, '        '), 'dim'));
+      }
     }
-    console.log('');
   }
+  console.log('');
+}
+
+async function handleHistory(opts: { json?: boolean }) {
+  const reports = await listSavedReports();
+  if (opts.json) {
+    outputJson({
+      count: reports.length,
+      reports: reports.map((r) => ({
+        id: r.id,
+        generatedAt: r.generatedAt,
+        analyzed: r.analyzed,
+        workspaces: r.workspaces,
+        workspace: r.workspace,
+        recommendations: r.report.recommendations.length,
+        severity: severitySummary(r.report.recommendations),
+      })),
+    });
+    return;
+  }
+  if (reports.length === 0) {
+    logInfo('No saved reflection reports yet. Run `nemus reflect` to create one.');
+    return;
+  }
+  console.log('');
+  console.log(colorize('  Saved reflections', 'bright') + colorize(`  (${reports.length})`, 'dim'));
+  console.log(colorize('  ' + '─'.repeat(56), 'dim'));
+  for (const r of reports) {
+    const when = r.generatedAt ? new Date(r.generatedAt).toLocaleString() : r.id;
+    const scope = r.workspace ? colorize(` ${r.workspace}`, 'cyan') : colorize(` ${r.analyzed} sessions`, 'dim');
+    const sev = r.report.recommendations.length
+      ? colorize(`  ${severitySummary(r.report.recommendations)}`, 'dim')
+      : colorize('  no recs', 'green');
+    console.log(`  ${colorize(r.id, 'bright')}${scope}${sev}`);
+    console.log(colorize(`     ${when}`, 'dim'));
+  }
+  console.log('');
+  console.log(colorize('  nemus reflect show <id>   (or `latest`)', 'dim'));
+}
+
+async function handleShow(
+  id: string | undefined,
+  opts: { json?: boolean; markdown?: boolean; groupBy?: string },
+) {
+  const groupBy = resolveGroupBy(opts.groupBy, opts.json);
+  const saved = await loadSavedReport(id);
+  if (!saved) {
+    const msg = id && id !== 'latest'
+      ? `No saved report matching "${id}". Run "nemus reflect history" to list them.`
+      : 'No saved reflection reports yet. Run "nemus reflect" to create one.';
+    if (opts.json) outputJsonError(msg);
+    else logError(msg);
+    process.exit(1);
+  }
+  const meta = {
+    analyzed: saved.analyzed,
+    workspaces: saved.workspaces,
+    workspace: saved.workspace,
+    generatedAt: saved.generatedAt,
+  };
+  if (opts.json) {
+    outputJson({ id: saved.id, ...meta, ...saved.report });
+    return;
+  }
+  if (opts.markdown) {
+    process.stdout.write(renderReportMarkdown(saved.report, meta, groupBy));
+    return;
+  }
+  printReport(saved.report, saved.workspaces, saved.analyzed, groupBy);
 }

--- a/src/commands/reflect.ts
+++ b/src/commands/reflect.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { logError, logInfo, logStep } from '../utils/logger';
+import { logError, logInfo, logStep, logWarning } from '../utils/logger';
 import { outputJson, outputJsonError } from '../utils/output';
 import { colorize } from '../utils/colors';
 import {
@@ -10,7 +10,7 @@ import {
   severitySummary,
   groupRecommendations,
   listSavedReports,
-  loadSavedReport,
+  findSavedMatches,
   REFLECT_SCHEMA,
   ReflectionReport,
   ReflectProgress,
@@ -314,7 +314,8 @@ async function handleShow(
   opts: { json?: boolean; markdown?: boolean; groupBy?: string },
 ) {
   const groupBy = resolveGroupBy(opts.groupBy, opts.json);
-  const saved = await loadSavedReport(id);
+  const matches = findSavedMatches(await listSavedReports(), id);
+  const saved = matches[0];
   if (!saved) {
     const msg = id && id !== 'latest'
       ? `No saved report matching "${id}". Run "nemus reflect history" to list them.`
@@ -322,6 +323,14 @@ async function handleShow(
     if (opts.json) outputJsonError(msg);
     else logError(msg);
     process.exit(1);
+  }
+  // An id-prefix that matches several reports resolves to the newest — say so
+  // (stderr only, so --json/--markdown stdout stays clean) rather than quietly
+  // showing a possibly-unintended report. An exact id / "latest" never multi-matches.
+  if (matches.length > 1 && !opts.json) {
+    logWarning(
+      `"${id}" matched ${matches.length} reports; showing the newest (${saved.id}). Use a longer id to disambiguate.`,
+    );
   }
   const meta = {
     analyzed: saved.analyzed,

--- a/src/utils/reflect.test.ts
+++ b/src/utils/reflect.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { distillTranscript, parseReflectionReport, classifyAgentsMd, isCorrectionPrompt, saveReflectionReport, severityCounts, severitySummary, renderReportMarkdown, ReflectionReport } from './reflect';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { distillTranscript, parseReflectionReport, classifyAgentsMd, isCorrectionPrompt, saveReflectionReport, severityCounts, severitySummary, renderReportMarkdown, groupRecommendations, listSavedReports, loadSavedReport, REFLECT_REPORTS_DIR, ReflectionReport, Recommendation } from './reflect';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
@@ -180,5 +180,61 @@ describe('renderReportMarkdown', () => {
     const md = renderReportMarkdown({ summary: 'All good.', recommendations: [] }, { analyzed: 2, workspaces: 2 });
     expect(md).toContain('_No specific recommendations — looks solid._');
     expect(md).not.toContain('### High');
+  });
+});
+
+describe('groupRecommendations', () => {
+  const mk = (kind: Recommendation['kind'], priority: Recommendation['priority'], title = 't'): Recommendation =>
+    ({ kind, title, detail: 'd', priority });
+
+  it('groups by priority (high→low), omitting empty groups', () => {
+    const groups = groupRecommendations([mk('skill', 'low'), mk('context', 'high')], 'priority');
+    expect(groups.map((g) => g.key)).toEqual(['high', 'low']); // no 'medium'
+    expect(groups[0].heading).toBe('High priority');
+  });
+
+  it('groups by kind in a fixed order, priority-sorted within a kind', () => {
+    const groups = groupRecommendations(
+      [mk('context', 'low'), mk('skill', 'low', 'a'), mk('skill', 'high', 'b')],
+      'kind',
+    );
+    expect(groups.map((g) => g.key)).toEqual(['skill', 'context']); // skill before context
+    expect(groups[0].recs.map((r) => r.title)).toEqual(['b', 'a']); // high before low within skill
+  });
+});
+
+describe('listSavedReports / loadSavedReport', () => {
+  const older = path.join(REFLECT_REPORTS_DIR, '2000-01-01T00-00-00-000Z-vitestA.json');
+  const newer = path.join(REFLECT_REPORTS_DIR, '2000-01-02T00-00-00-000Z-vitestB.json');
+  const idOf = (f: string) => path.basename(f).replace(/\.json$/, '');
+
+  beforeAll(async () => {
+    await fs.mkdir(REFLECT_REPORTS_DIR, { recursive: true });
+    await fs.writeFile(older, JSON.stringify({ generatedAt: '2000-01-01T00:00:00.000Z', analyzed: 4, workspaces: 3, summary: 'old', recommendations: [{ kind: 'skill', title: 'x', detail: 'd', priority: 'high' }] }));
+    await fs.writeFile(newer, JSON.stringify({ generatedAt: '2000-01-02T00:00:00.000Z', analyzed: 1, workspaces: 1, workspace: 'ws', summary: 'new', recommendations: [] }));
+  });
+  afterAll(async () => {
+    await fs.rm(older, { force: true });
+    await fs.rm(newer, { force: true });
+  });
+
+  it('lists my fixtures newest-first', async () => {
+    const all = await listSavedReports();
+    const ids = all.map((r) => r.id).filter((id) => id.endsWith('vitestA') || id.endsWith('vitestB'));
+    expect(ids).toEqual([idOf(newer), idOf(older)]); // newer before older
+    const b = all.find((r) => r.id === idOf(newer))!;
+    expect(b.workspace).toBe('ws');
+    expect(b.report.recommendations).toHaveLength(0);
+  });
+
+  it('loadSavedReport resolves latest, exact id, and prefix', async () => {
+    const latest = await loadSavedReport('latest');
+    // "latest" is global; assert it parsed a report rather than a specific id.
+    expect(latest?.report).toBeDefined();
+    const exact = await loadSavedReport(idOf(older));
+    expect(exact?.workspaces).toBe(3);
+    const byPrefix = await loadSavedReport('2000-01-02T00-00-00');
+    expect(byPrefix?.id).toBe(idOf(newer));
+    expect(await loadSavedReport('definitely-no-such-id-xyz')).toBeNull();
   });
 });

--- a/src/utils/reflect.test.ts
+++ b/src/utils/reflect.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { distillTranscript, parseReflectionReport, classifyAgentsMd, isCorrectionPrompt, saveReflectionReport, severityCounts, severitySummary, renderReportMarkdown, groupRecommendations, listSavedReports, loadSavedReport, REFLECT_REPORTS_DIR, ReflectionReport, Recommendation } from './reflect';
+import { distillTranscript, parseReflectionReport, classifyAgentsMd, isCorrectionPrompt, saveReflectionReport, severityCounts, severitySummary, renderReportMarkdown, groupRecommendations, listSavedReports, loadSavedReport, findSavedMatches, SavedReport, ReflectionReport, Recommendation } from './reflect';
 import * as fs from 'fs/promises';
+import * as os from 'os';
 import * as path from 'path';
 
 const J = (o: unknown) => JSON.stringify(o);
@@ -203,38 +204,50 @@ describe('groupRecommendations', () => {
   });
 });
 
-describe('listSavedReports / loadSavedReport', () => {
-  const older = path.join(REFLECT_REPORTS_DIR, '2000-01-01T00-00-00-000Z-vitestA.json');
-  const newer = path.join(REFLECT_REPORTS_DIR, '2000-01-02T00-00-00-000Z-vitestB.json');
-  const idOf = (f: string) => path.basename(f).replace(/\.json$/, '');
+describe('findSavedMatches (pure)', () => {
+  const mk = (id: string): SavedReport => ({ id, file: `${id}.json`, analyzed: 0, workspaces: 0, report: { summary: '', recommendations: [] } });
+  // newest-first list, as listSavedReports returns it
+  const all = [mk('2000-03'), mk('2000-02b'), mk('2000-02a'), mk('2000-01')];
+
+  it('empty / latest / exact', () => {
+    expect(findSavedMatches([], '2000')).toEqual([]);
+    expect(findSavedMatches(all)[0].id).toBe('2000-03'); // undefined -> newest
+    expect(findSavedMatches(all, 'latest')[0].id).toBe('2000-03');
+    expect(findSavedMatches(all, '2000-02a').map((r) => r.id)).toEqual(['2000-02a']); // exact wins
+  });
+  it('an ambiguous prefix returns every match, newest-first', () => {
+    expect(findSavedMatches(all, '2000-02').map((r) => r.id)).toEqual(['2000-02b', '2000-02a']);
+    expect(findSavedMatches(all, 'nope')).toEqual([]);
+  });
+});
+
+describe('listSavedReports / loadSavedReport (isolated temp dir)', () => {
+  let dir: string;
+  const idA = '2000-01-01T00-00-00-000Z-vitestA';
+  const idB = '2000-01-02T00-00-00-000Z-vitestB';
 
   beforeAll(async () => {
-    await fs.mkdir(REFLECT_REPORTS_DIR, { recursive: true });
-    await fs.writeFile(older, JSON.stringify({ generatedAt: '2000-01-01T00:00:00.000Z', analyzed: 4, workspaces: 3, summary: 'old', recommendations: [{ kind: 'skill', title: 'x', detail: 'd', priority: 'high' }] }));
-    await fs.writeFile(newer, JSON.stringify({ generatedAt: '2000-01-02T00:00:00.000Z', analyzed: 1, workspaces: 1, workspace: 'ws', summary: 'new', recommendations: [] }));
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'nemus-reflect-test-'));
+    await fs.writeFile(path.join(dir, `${idA}.json`), JSON.stringify({ generatedAt: '2000-01-01T00:00:00.000Z', analyzed: 4, workspaces: 3, summary: 'old', recommendations: [{ kind: 'skill', title: 'x', detail: 'd', priority: 'high' }] }));
+    await fs.writeFile(path.join(dir, `${idB}.json`), JSON.stringify({ generatedAt: '2000-01-02T00:00:00.000Z', analyzed: 1, workspaces: 1, workspace: 'ws', summary: 'new', recommendations: [] }));
+    await fs.writeFile(path.join(dir, 'not-json.txt'), 'ignore me');
+    await fs.writeFile(path.join(dir, 'corrupt.json'), '{ not valid json');
   });
   afterAll(async () => {
-    await fs.rm(older, { force: true });
-    await fs.rm(newer, { force: true });
+    await fs.rm(dir, { recursive: true, force: true });
   });
 
-  it('lists my fixtures newest-first', async () => {
-    const all = await listSavedReports();
-    const ids = all.map((r) => r.id).filter((id) => id.endsWith('vitestA') || id.endsWith('vitestB'));
-    expect(ids).toEqual([idOf(newer), idOf(older)]); // newer before older
-    const b = all.find((r) => r.id === idOf(newer))!;
-    expect(b.workspace).toBe('ws');
-    expect(b.report.recommendations).toHaveLength(0);
+  it('lists newest-first, skipping non-json and corrupt files', async () => {
+    const all = await listSavedReports(dir);
+    expect(all.map((r) => r.id)).toEqual([idB, idA]); // exactly two, newer first
+    expect(all[0].workspace).toBe('ws');
+    expect(all[0].report.recommendations).toHaveLength(0);
   });
 
   it('loadSavedReport resolves latest, exact id, and prefix', async () => {
-    const latest = await loadSavedReport('latest');
-    // "latest" is global; assert it parsed a report rather than a specific id.
-    expect(latest?.report).toBeDefined();
-    const exact = await loadSavedReport(idOf(older));
-    expect(exact?.workspaces).toBe(3);
-    const byPrefix = await loadSavedReport('2000-01-02T00-00-00');
-    expect(byPrefix?.id).toBe(idOf(newer));
-    expect(await loadSavedReport('definitely-no-such-id-xyz')).toBeNull();
+    expect((await loadSavedReport('latest', dir))?.id).toBe(idB);
+    expect((await loadSavedReport(idA, dir))?.workspaces).toBe(3);
+    expect((await loadSavedReport('2000-01-02T00-00-00', dir))?.id).toBe(idB);
+    expect(await loadSavedReport('definitely-no-such-id-xyz', dir)).toBeNull();
   });
 });

--- a/src/utils/reflect.ts
+++ b/src/utils/reflect.ts
@@ -601,17 +601,17 @@ export interface SavedReport {
  * with an ISO timestamp, so a reverse name sort is chronological). Unreadable /
  * unparseable files are skipped, not fatal. Returns [] if the dir is absent.
  */
-export async function listSavedReports(): Promise<SavedReport[]> {
+export async function listSavedReports(dir: string = REFLECT_REPORTS_DIR): Promise<SavedReport[]> {
   let names: string[];
   try {
-    names = await fs.readdir(REFLECT_REPORTS_DIR);
+    names = await fs.readdir(dir);
   } catch {
     return [];
   }
   const jsons = names.filter((n) => n.endsWith('.json')).sort().reverse();
   const out: SavedReport[] = [];
   for (const name of jsons) {
-    const file = path.join(REFLECT_REPORTS_DIR, name);
+    const file = path.join(dir, name);
     try {
       const raw = JSON.parse(await fs.readFile(file, 'utf-8'));
       out.push({
@@ -631,13 +631,28 @@ export async function listSavedReports(): Promise<SavedReport[]> {
 }
 
 /**
- * Load one saved report by id. `undefined`/`'latest'` returns the newest. An id
- * is matched exactly, then as a prefix (so a timestamp fragment resolves).
- * Returns null when nothing matches.
+ * Resolve a report reference against an (already newest-first) list. Returns ALL
+ * matches so a caller can detect ambiguity: `undefined`/`'latest'` -> the newest;
+ * an exact id -> that one; otherwise every id with the prefix (newest-first). An
+ * exact id always wins over prefixes, so an id can't be ambiguous with itself.
+ * Pure + unit-tested.
  */
-export async function loadSavedReport(ref?: string): Promise<SavedReport | null> {
-  const all = await listSavedReports();
-  if (all.length === 0) return null;
-  if (!ref || ref === 'latest') return all[0];
-  return all.find((r) => r.id === ref) ?? all.find((r) => r.id.startsWith(ref)) ?? null;
+export function findSavedMatches(all: SavedReport[], ref?: string): SavedReport[] {
+  if (all.length === 0) return [];
+  if (!ref || ref === 'latest') return [all[0]];
+  const exact = all.find((r) => r.id === ref);
+  if (exact) return [exact];
+  return all.filter((r) => r.id.startsWith(ref));
+}
+
+/**
+ * Load one saved report by id. `undefined`/`'latest'` returns the newest; an id
+ * is matched exactly, then as a prefix (newest match wins). Returns null when
+ * nothing matches. For ambiguity-aware callers, use findSavedMatches directly.
+ */
+export async function loadSavedReport(
+  ref?: string,
+  dir: string = REFLECT_REPORTS_DIR,
+): Promise<SavedReport | null> {
+  return findSavedMatches(await listSavedReports(dir), ref)[0] ?? null;
 }

--- a/src/utils/reflect.ts
+++ b/src/utils/reflect.ts
@@ -83,7 +83,7 @@ export function severitySummary(recs: Recommendation[]): string {
     .join(' · ');
 }
 
-const MD_KIND_LABEL: Record<RecommendationKind, string> = {
+export const KIND_LABEL: Record<RecommendationKind, string> = {
   skill: 'Skill',
   context: 'Context/AGENTS.md',
   test: 'Test',
@@ -92,12 +92,49 @@ const MD_KIND_LABEL: Record<RecommendationKind, string> = {
   workflow: 'Workflow',
   other: 'Other',
 };
+// Back-compat alias for existing references.
+const MD_KIND_LABEL = KIND_LABEL;
 
-const PRIORITY_HEADING: Record<Priority, string> = {
+export const PRIORITY_HEADING: Record<Priority, string> = {
   high: 'High priority',
   medium: 'Medium priority',
   low: 'Low priority',
 };
+
+export type GroupBy = 'priority' | 'kind';
+
+const KIND_ORDER: RecommendationKind[] = ['skill', 'context', 'test', 'prompt', 'connectivity', 'workflow', 'other'];
+const PRIORITY_ORDER: Priority[] = ['high', 'medium', 'low'];
+const PRIORITY_RANK: Record<Priority, number> = { high: 0, medium: 1, low: 2 };
+
+export interface RecGroup {
+  key: string;
+  heading: string;
+  recs: Recommendation[];
+}
+
+/**
+ * Split recommendations into ordered, non-empty groups by either priority
+ * (high→low) or kind (a fixed, stable order). When grouping by kind, each
+ * group's recs are sorted high-priority first. Pure + unit-tested; shared by the
+ * Markdown renderer and the human printer so the two never diverge.
+ */
+export function groupRecommendations(recs: Recommendation[], groupBy: GroupBy): RecGroup[] {
+  if (groupBy === 'kind') {
+    return KIND_ORDER.map((k) => ({
+      key: k,
+      heading: KIND_LABEL[k],
+      recs: recs
+        .filter((r) => r.kind === k)
+        .sort((a, b) => PRIORITY_RANK[a.priority] - PRIORITY_RANK[b.priority]),
+    })).filter((g) => g.recs.length > 0);
+  }
+  return PRIORITY_ORDER.map((p) => ({
+    key: p,
+    heading: PRIORITY_HEADING[p],
+    recs: recs.filter((r) => r.priority === p),
+  })).filter((g) => g.recs.length > 0);
+}
 
 /** A fenced code block whose fence is guaranteed longer than any backtick run
  *  inside `body`, so the snippet can't break out of its own fence. */
@@ -116,6 +153,7 @@ function fencedBlock(body: string): string {
 export function renderReportMarkdown(
   report: ReflectionReport,
   meta: { analyzed: number; workspaces: number; workspace?: string; generatedAt?: string },
+  groupBy: GroupBy = 'priority',
 ): string {
   const lines: string[] = ['# Reflection', ''];
   const scope = meta.workspace
@@ -133,13 +171,14 @@ export function renderReportMarkdown(
 
   lines.push('## Recommendations', '', `**${severitySummary(report.recommendations)}**`, '');
 
-  for (const priority of ['high', 'medium', 'low'] as Priority[]) {
-    const group = report.recommendations.filter((r) => r.priority === priority);
-    if (group.length === 0) continue;
-    lines.push(`### ${PRIORITY_HEADING[priority]}`, '');
-    for (const r of group) {
+  for (const group of groupRecommendations(report.recommendations, groupBy)) {
+    lines.push(`### ${group.heading}`, '');
+    for (const r of group.recs) {
       const target = r.target ? ` (\`${r.target}\`)` : '';
-      lines.push(`- **[${MD_KIND_LABEL[r.kind]}] ${r.title}**${target}`);
+      // Under a kind heading the [Kind] prefix is redundant; show a priority tag
+      // instead. Under a priority heading, show the kind.
+      const label = groupBy === 'kind' ? `_${r.priority}_ — ` : `[${KIND_LABEL[r.kind]}] `;
+      lines.push(`- **${label}${r.title}**${target}`);
       if (r.detail.trim()) {
         lines.push(...r.detail.trim().split('\n').map((l) => `  ${l}`));
       }
@@ -543,4 +582,62 @@ export async function saveReflectionReport(
   const file = path.join(REFLECT_REPORTS_DIR, `${stamp}${scope}.json`);
   await fs.writeFile(file, JSON.stringify({ generatedAt: new Date().toISOString(), ...meta, ...report }, null, 2));
   return file;
+}
+
+/** A saved report on disk, with its metadata and parsed report. */
+export interface SavedReport {
+  /** Basename without .json — the id used by `reflect show <id>`. */
+  id: string;
+  file: string;
+  generatedAt?: string;
+  analyzed: number;
+  workspaces: number;
+  workspace?: string;
+  report: ReflectionReport;
+}
+
+/**
+ * List saved reports under `~/.nemus/reflect/`, newest first (filenames start
+ * with an ISO timestamp, so a reverse name sort is chronological). Unreadable /
+ * unparseable files are skipped, not fatal. Returns [] if the dir is absent.
+ */
+export async function listSavedReports(): Promise<SavedReport[]> {
+  let names: string[];
+  try {
+    names = await fs.readdir(REFLECT_REPORTS_DIR);
+  } catch {
+    return [];
+  }
+  const jsons = names.filter((n) => n.endsWith('.json')).sort().reverse();
+  const out: SavedReport[] = [];
+  for (const name of jsons) {
+    const file = path.join(REFLECT_REPORTS_DIR, name);
+    try {
+      const raw = JSON.parse(await fs.readFile(file, 'utf-8'));
+      out.push({
+        id: name.replace(/\.json$/, ''),
+        file,
+        generatedAt: typeof raw.generatedAt === 'string' ? raw.generatedAt : undefined,
+        analyzed: typeof raw.analyzed === 'number' ? raw.analyzed : 0,
+        workspaces: typeof raw.workspaces === 'number' ? raw.workspaces : 0,
+        workspace: typeof raw.workspace === 'string' ? raw.workspace : undefined,
+        report: parseReflectionReport(raw),
+      });
+    } catch {
+      /* skip a corrupt/partial file */
+    }
+  }
+  return out;
+}
+
+/**
+ * Load one saved report by id. `undefined`/`'latest'` returns the newest. An id
+ * is matched exactly, then as a prefix (so a timestamp fragment resolves).
+ * Returns null when nothing matches.
+ */
+export async function loadSavedReport(ref?: string): Promise<SavedReport | null> {
+  const all = await listSavedReports();
+  if (all.length === 0) return null;
+  if (!ref || ref === 'latest') return all[0];
+  return all.find((r) => r.id === ref) ?? all.find((r) => r.id.startsWith(ref)) ?? null;
 }


### PR DESCRIPTION
Option 1 of the follow-ups: **reflect grouping + a saved-report viewer**.

## Grouping
- `nemus reflect --group-by kind|priority` (default `priority`) — controls how recommendations are grouped in **both** the human and Markdown output. Under a *kind* heading each rec shows a priority tag; under a *priority* heading it shows its kind (no redundant repeat of the grouping axis).

## Saved-report viewer
Every run already saves JSON under `~/.nemus/reflect/`. Now you can review past reports without re-running the judge:
```bash
nemus reflect history            # list saved reports, newest first (--json)
nemus reflect show               # print the latest
nemus reflect show <id>          # a specific one (--markdown / --json / --group-by)
```
`show` accepts a full id or an **id-prefix** (a timestamp fragment resolves), defaulting to latest.

## Why positional args, not commander subcommands
`history`/`show` are **positional arguments** on the single `reflect` command, deliberately *not* commander subcommands. As subcommands they'd share `--json`/`--markdown`/`--group-by` with the parent `reflect` command, and commander binds shared names to the parent — the child sees defaults. The only commander fix (`enablePositionalOptions()` on the **root**) makes options positional program-wide, which **breaks global flags placed after a subcommand** (e.g. `nemus list --quiet` → *unknown option*). I verified that regression and avoided it: defining every option once on the one command means no parent/child collision, and `nemus list --quiet` still works.

## Tests
- `groupRecommendations` — priority order (omit empty groups); kind order + within-kind priority sort.
- `listSavedReports`/`loadSavedReport` — newest-first, exact + prefix match, null when absent, skips corrupt files (fixtures written to the real dir + cleaned up).
- **512 core tests** green; typecheck clean.

Verified locally: `history --json`, `show latest --group-by kind`, `show <prefix> --markdown`, unknown-subcommand exit 1, bad `--group-by` exit 1, analysis path (`reflect --dry-run`) intact, and the `list --quiet` regression check.

README + CHANGELOG. Version **0.7.0 → 0.8.0**.
