### PR TITLE
feat: config edit ($EDITOR) + environment-variable docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-09-01
+
+### Added
+
+- **`nemus config edit`** opens the config file in `$VISUAL`/`$EDITOR` (seeding
+  it with the current resolved config on first run) and re-validates the JSON
+  afterward, warning about unrecognized keys. Refuses to run without an
+  interactive terminal.
+- **Environment-variable reference** in the README documenting every variable
+  Nemus reads (`NEMUS_*`, `WORKSPACE_*`, `NO_COLOR`/`FORCE_COLOR`,
+  `VISUAL`/`EDITOR`).
+
 ## [0.8.0] - 2026-09-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -259,6 +259,25 @@ nemus config path                     # print the config file location
 
 `get`/`list` also accept `--json`. An unknown key or an invalid value exits
 non-zero with a clear message (e.g. `cloneProtocol must be one of: ssh, https`).
+`config edit` opens the file in `$VISUAL`/`$EDITOR` (seeding it with the current
+resolved config first) and re-validates the JSON afterward.
+
+### Environment variables
+
+Everything Nemus reads from the environment (all optional):
+
+| Variable | Effect |
+| --- | --- |
+| `NEMUS_DIR` | Override where workspaces are created (also `WORKSPACE_MANAGER_DIR`). |
+| `NEMUS_CACHE_DIR` | Override the cache/config/state dir, default `~/.nemus` (also `WORKSPACE_MANAGER_CACHE_DIR`). |
+| `NEMUS_JUDGE_MODEL` | Model for the `reflect` judge (overrides `--model`'s default). |
+| `NEMUS_JUDGE_THINKING` | Thinking level for the `reflect` judge on pi (`off`…`max`). |
+| `NEMUS_JUDGE_TIMEOUT_MS` | Timeout for the `reflect` judge call. |
+| `NEMUS_BUG_REPORT_REPO` | Repo that `report-bug` files issues against. |
+| `NEMUS_SKIP_CONFIGURE` | Skip the one-time post-install `configure` prompt. |
+| `WORKSPACE_CLONE_TIMEOUT_MS` | Git clone timeout (default 15 min). |
+| `NO_COLOR` / `FORCE_COLOR` | Disable / force ANSI color (see [Global flags](#global-flags)). |
+| `VISUAL` / `EDITOR` | Editor launched by `nemus config edit`. |
 
 ### Global flags
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nemus-cli/nemus",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "workspaces": [
     "packages/*"
   ],

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,5 +1,7 @@
 import { Command } from 'commander';
+import * as fs from 'fs';
 import { getUserConfig, saveUserConfig, CONFIG_PATH } from '../utils/config';
+import { openInEditor } from '../utils/editor';
 import {
   CONFIG_KEYS,
   CONFIG_SCHEMA,
@@ -9,7 +11,7 @@ import {
   formatConfigValue,
 } from '../utils/config-schema';
 import { outputJson, outputJsonError } from '../utils/output';
-import { logSuccess, logError } from '../utils/logger';
+import { logSuccess, logError, logWarning } from '../utils/logger';
 import { colorize } from '../utils/colors';
 
 /**
@@ -93,6 +95,45 @@ export function registerConfigCommand(parent: Command): void {
     .action(() => {
       process.stdout.write(CONFIG_PATH + '\n');
     });
+
+  config
+    .command('edit')
+    .description('Open the config file in $EDITOR (or $VISUAL)')
+    .action(() => {
+      handleEdit();
+    });
+}
+
+function handleEdit(): void {
+  if (!process.stdout.isTTY) {
+    logError('`config edit` needs an interactive terminal. Use `config set <key> <value>` in scripts.');
+    process.exitCode = 1;
+    return;
+  }
+  // Seed the file with the fully-resolved config so there's something complete
+  // to edit on a first run (getUserConfig merges defaults + any overrides).
+  if (!fs.existsSync(CONFIG_PATH)) saveUserConfig(getUserConfig());
+
+  const result = openInEditor(CONFIG_PATH);
+  if (!result.ok) {
+    logError(result.error ?? `editor exited with code ${result.code}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  // Re-validate: a hand-edit can produce invalid JSON, which getUserConfig would
+  // silently ignore (falling back to defaults). Surface that instead.
+  try {
+    const raw = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf-8'));
+    const unknown = Object.keys(raw).filter((k) => !(k in getUserConfig()));
+    if (unknown.length > 0) {
+      logWarning(`Ignoring unrecognized key(s): ${unknown.join(', ')}`);
+    }
+    logSuccess('Config saved.');
+  } catch {
+    logError(`${CONFIG_PATH} is not valid JSON after editing — changes are kept, but Nemus will use defaults until it parses.`);
+    process.exitCode = 1;
+  }
 }
 
 function printAll(cfg: ReturnType<typeof getUserConfig>, json?: boolean): void {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -8,6 +8,7 @@ import {
   isConfigKey,
   applyConfigSet,
   applyConfigUnset,
+  reviewConfigFileText,
   formatConfigValue,
 } from '../utils/config-schema';
 import { outputJson, outputJsonError } from '../utils/output';
@@ -121,19 +122,28 @@ function handleEdit(): void {
     return;
   }
 
-  // Re-validate: a hand-edit can produce invalid JSON, which getUserConfig would
-  // silently ignore (falling back to defaults). Surface that instead.
-  try {
-    const raw = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf-8'));
-    const unknown = Object.keys(raw).filter((k) => !(k in getUserConfig()));
-    if (unknown.length > 0) {
-      logWarning(`Ignoring unrecognized key(s): ${unknown.join(', ')}`);
-    }
-    logSuccess('Config saved.');
-  } catch {
+  // Re-validate: a hand-edit can produce invalid JSON or invalid values, which
+  // getUserConfig would silently ignore (falling back to defaults). Surface that
+  // instead, using the SAME schema `config set` uses so both write paths agree.
+  const review = reviewConfigFileText(fs.readFileSync(CONFIG_PATH, 'utf-8'));
+  if (review.parseError) {
     logError(`${CONFIG_PATH} is not valid JSON after editing — changes are kept, but Nemus will use defaults until it parses.`);
     process.exitCode = 1;
+    return;
   }
+  if (review.notObject) {
+    logError(`${CONFIG_PATH} must contain a JSON object — changes are kept, but Nemus will use defaults until it does.`);
+    process.exitCode = 1;
+    return;
+  }
+  if (review.unknownKeys.length > 0) logWarning(`Ignoring unrecognized key(s): ${review.unknownKeys.join(', ')}`);
+  if (!review.ok) {
+    for (const e of review.invalid) logWarning(e);
+    logError('Some values are invalid and will fall back to their defaults until fixed.');
+    process.exitCode = 1;
+    return;
+  }
+  logSuccess('Config saved.');
 }
 
 function printAll(cfg: ReturnType<typeof getUserConfig>, json?: boolean): void {

--- a/src/utils/config-schema.test.ts
+++ b/src/utils/config-schema.test.ts
@@ -7,6 +7,8 @@ import {
   parseConfigValue,
   applyConfigSet,
   applyConfigUnset,
+  validateTypedValue,
+  reviewConfigFileText,
   formatConfigValue,
 } from './config-schema';
 
@@ -92,6 +94,53 @@ describe('applyConfigSet / applyConfigUnset (pure, immutable)', () => {
     const r = applyConfigUnset(base, 'githubOrg');
     expect(r.ok).toBe(true);
     if (r.ok) expect(r.next.githubOrg).toBe(CONFIG_DEFAULTS.githubOrg);
+  });
+});
+
+describe('validateTypedValue (already-typed, as from the JSON file)', () => {
+  it('accepts correctly-typed values', () => {
+    expect(validateTypedValue('autoReportBugs', true)).toEqual({ ok: true });
+    expect(validateTypedValue('cloneProtocol', 'https')).toEqual({ ok: true });
+    expect(validateTypedValue('githubOrg', '')).toEqual({ ok: true }); // allowEmpty
+    expect(validateTypedValue('workspacesDir', '/x')).toEqual({ ok: true });
+  });
+  it('rejects wrong types and bad enum/empty values', () => {
+    expect(validateTypedValue('autoReportBugs', 'yes').ok).toBe(false); // string, not boolean
+    expect(validateTypedValue('cloneProtocol', 'ftp').ok).toBe(false);
+    expect(validateTypedValue('cloneProtocol', 42 as unknown).ok).toBe(false);
+    expect(validateTypedValue('workspacesDir', '   ').ok).toBe(false); // required, blank
+    expect(validateTypedValue('installMcp', 1 as unknown).ok).toBe(false);
+  });
+});
+
+describe('reviewConfigFileText (for `config edit`)', () => {
+  it('flags unparseable JSON', () => {
+    const r = reviewConfigFileText('{ not json');
+    expect(r.parseError).toBe(true);
+    expect(r.ok).toBe(false);
+  });
+  it('flags non-object JSON (null / array / scalar) without throwing', () => {
+    for (const t of ['null', '42', '"str"', '[1,2]']) {
+      const r = reviewConfigFileText(t);
+      expect(r.notObject).toBe(true);
+      expect(r.ok).toBe(false);
+      expect(r.unknownKeys).toEqual([]); // no numeric-index "keys" from an array
+    }
+  });
+  it('reports unknown keys but stays ok if known values are valid', () => {
+    const r = reviewConfigFileText(JSON.stringify({ githubOrg: 'acme', bogus: 1, nope: true }));
+    expect(r.unknownKeys.sort()).toEqual(['bogus', 'nope']);
+    expect(r.ok).toBe(true);
+  });
+  it('catches invalid VALUES the same way config set would', () => {
+    const r = reviewConfigFileText(JSON.stringify({ cloneProtocol: 'ftp', autoReportBugs: 'yes' }));
+    expect(r.ok).toBe(false);
+    expect(r.invalid.join('\n')).toMatch(/cloneProtocol must be one of/);
+    expect(r.invalid.join('\n')).toMatch(/autoReportBugs must be a boolean/);
+  });
+  it('accepts a clean object', () => {
+    const r = reviewConfigFileText(JSON.stringify({ cloneProtocol: 'https', installMcp: true }));
+    expect(r).toMatchObject({ parseError: false, notObject: false, unknownKeys: [], invalid: [], ok: true });
   });
 });
 

--- a/src/utils/config-schema.ts
+++ b/src/utils/config-schema.ts
@@ -80,6 +80,29 @@ export function parseConfigValue(key: ConfigKey, raw: string): ParseResult {
   return { ok: true, value: trimmed };
 }
 
+/**
+ * Validate an already-typed value (as it appears in the JSON config file) for
+ * `key` against its field spec. This is the parse-free sibling of
+ * parseConfigValue (which coerces a CLI string): it checks that a boolean field
+ * holds a boolean, an enum holds an allowed string, and a string field holds a
+ * (non-empty, unless allowEmpty) string. Used by `config edit` so a hand-edit
+ * is validated the same way `config set` validates. Pure + unit-tested.
+ */
+export function validateTypedValue(key: ConfigKey, value: unknown): { ok: true } | { ok: false; error: string } {
+  const spec: FieldSpec = CONFIG_SCHEMA[key];
+  if (spec.type === 'boolean') {
+    return typeof value === 'boolean' ? { ok: true } : { ok: false, error: `${key} must be a boolean` };
+  }
+  if (spec.type === 'enum') {
+    return typeof value === 'string' && (spec.values as readonly string[]).includes(value)
+      ? { ok: true }
+      : { ok: false, error: `${key} must be one of: ${spec.values.join(', ')}` };
+  }
+  if (typeof value !== 'string') return { ok: false, error: `${key} must be a string` };
+  if (!spec.allowEmpty && value.trim() === '') return { ok: false, error: `${key} cannot be empty` };
+  return { ok: true };
+}
+
 /** Apply a `set` to a config object, returning a NEW config or an error. Pure. */
 export function applyConfigSet(
   current: UserConfig,
@@ -109,4 +132,46 @@ export function applyConfigUnset(
 /** Render a config value for plain (scriptable) stdout output. */
 export function formatConfigValue(value: unknown): string {
   return typeof value === 'boolean' ? String(value) : String(value ?? '');
+}
+
+export interface ConfigFileReview {
+  /** JSON.parse failed. */
+  parseError: boolean;
+  /** Parsed, but not a plain object (null / array / scalar). */
+  notObject: boolean;
+  /** Keys present in the file that aren't recognized config keys. */
+  unknownKeys: string[];
+  /** Validation error messages for known keys holding invalid values. */
+  invalid: string[];
+  /** True when the file is a usable config object (may still have warnings). */
+  ok: boolean;
+}
+
+/**
+ * Review the raw text of a hand-edited config file the same way `config set`
+ * validates: it must parse, be a plain object, only use known keys, and every
+ * known key present must hold a schema-valid value. Pure so `config edit` can be
+ * fully unit-tested without spawning an editor.
+ */
+export function reviewConfigFileText(text: string): ConfigFileReview {
+  const base = { parseError: false, notObject: false, unknownKeys: [] as string[], invalid: [] as string[] };
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch {
+    return { ...base, parseError: true, ok: false };
+  }
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ...base, notObject: true, ok: false };
+  }
+  const obj = raw as Record<string, unknown>;
+  const known = new Set<string>(CONFIG_KEYS);
+  const unknownKeys = Object.keys(obj).filter((k) => !known.has(k));
+  const invalid: string[] = [];
+  for (const key of CONFIG_KEYS) {
+    if (!(key in obj)) continue;
+    const res = validateTypedValue(key, obj[key]);
+    if (!res.ok) invalid.push(res.error);
+  }
+  return { parseError: false, notObject: false, unknownKeys, invalid, ok: invalid.length === 0 };
 }

--- a/src/utils/editor.test.ts
+++ b/src/utils/editor.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resolveEditor, openInEditor } from './editor';
+
+describe('resolveEditor', () => {
+  it('prefers $VISUAL over $EDITOR', () => {
+    expect(resolveEditor({ VISUAL: 'code --wait', EDITOR: 'vim' }, 'darwin')).toEqual(['code', '--wait']);
+  });
+  it('falls back to $EDITOR, splitting flags', () => {
+    expect(resolveEditor({ EDITOR: 'emacs -nw' }, 'linux')).toEqual(['emacs', '-nw']);
+  });
+  it('platform default when neither is set', () => {
+    expect(resolveEditor({}, 'win32')).toEqual(['notepad']);
+    expect(resolveEditor({}, 'linux')).toEqual(['vi']);
+    expect(resolveEditor({ EDITOR: '   ' }, 'darwin')).toEqual(['vi']); // blank ignored
+  });
+});
+
+describe('openInEditor', () => {
+  it('launches editor argv[0] + flags + file, inheriting stdio', () => {
+    const spawn = vi.fn().mockReturnValue({ status: 0 }) as any;
+    const res = openInEditor('/tmp/config.json', { spawn, env: { EDITOR: 'code --wait' }, platform: 'darwin' });
+    expect(spawn).toHaveBeenCalledWith('code', ['--wait', '/tmp/config.json'], { stdio: 'inherit' });
+    expect(res).toEqual({ ok: true, editor: 'code', code: 0 });
+  });
+
+  it('reports a non-zero editor exit as not-ok', () => {
+    const spawn = vi.fn().mockReturnValue({ status: 1 }) as any;
+    expect(openInEditor('/f', { spawn, env: { EDITOR: 'vi' } }).ok).toBe(false);
+  });
+
+  it('reports a missing editor (ENOENT) with a clear message', () => {
+    const spawn = vi.fn().mockReturnValue({ error: Object.assign(new Error('x'), { code: 'ENOENT' }) }) as any;
+    const res = openInEditor('/f', { spawn, env: { EDITOR: 'nope' } });
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/not found/);
+  });
+});

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -1,0 +1,48 @@
+import { spawnSync } from 'child_process';
+
+/**
+ * Resolve the user's preferred editor as an argv array. Honors `$VISUAL` then
+ * `$EDITOR` (the long-standing Unix convention — `VISUAL` wins for full-screen
+ * editors), falling back to `notepad` on Windows and `vi` elsewhere. The env
+ * value may include flags (e.g. `code --wait`, `emacs -nw`), so it's split on
+ * whitespace into a command + args. Pure + unit-tested.
+ */
+export function resolveEditor(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): string[] {
+  const raw = (env.VISUAL || env.EDITOR || '').trim();
+  if (raw) return raw.split(/\s+/);
+  return platform === 'win32' ? ['notepad'] : ['vi'];
+}
+
+export interface EditorResult {
+  ok: boolean;
+  /** Editor argv[0] that was launched. */
+  editor: string;
+  /** Process exit code, when the editor ran and exited normally. */
+  code?: number;
+  /** Populated when the editor couldn't be launched at all. */
+  error?: string;
+}
+
+/**
+ * Open `file` in the resolved editor, inheriting the terminal so the editor is
+ * interactive. Returns a structured result rather than throwing so the caller
+ * controls messaging/exit. `spawn` is injected for tests.
+ */
+export function openInEditor(
+  file: string,
+  deps: { spawn?: typeof spawnSync; env?: NodeJS.ProcessEnv; platform?: NodeJS.Platform } = {},
+): EditorResult {
+  const spawn = deps.spawn ?? spawnSync;
+  const [cmd, ...args] = resolveEditor(deps.env, deps.platform);
+  const res = spawn(cmd, [...args, file], { stdio: 'inherit' });
+  if (res.error) {
+    const err = res.error as NodeJS.ErrnoException;
+    const reason = err.code === 'ENOENT' ? `editor "${cmd}" not found` : err.message;
+    return { ok: false, editor: cmd, error: reason };
+  }
+  const code = typeof res.status === 'number' ? res.status : 1;
+  return { ok: code === 0, editor: cmd, code };
+}


### PR DESCRIPTION
Option 2 of the follow-ups: **`config edit`** and an **environment-variable reference**.

## `nemus config edit`
Opens the config file in `$VISUAL`/`$EDITOR` for a hand-edit:
- Seeds the file with the current **resolved** config on first run (so you edit a complete document, not an empty one).
- **Re-validates** the JSON after the editor exits and **warns about unrecognized keys** — `getUserConfig` would otherwise silently fall back to defaults on invalid JSON, hiding the mistake.
- **Refuses without an interactive terminal** (exit 1), pointing scripts at `config set <key> <value>`.

Editor resolution + launch live in a pure, injectable `utils/editor.ts`:
- `resolveEditor` honors `$VISUAL` over `$EDITOR` (the Unix convention), splits flags (`code --wait`, `emacs -nw`), and falls back to `notepad` (Windows) / `vi`.
- `openInEditor` inherits the terminal (interactive), returns a structured result, and maps `ENOENT` to a clear "editor not found".

## Environment-variable reference
A README table documenting **every** variable Nemus reads: `NEMUS_DIR`/`NEMUS_CACHE_DIR` (+ legacy `WORKSPACE_MANAGER_*`), `NEMUS_JUDGE_MODEL`/`_THINKING`/`_TIMEOUT_MS`, `NEMUS_BUG_REPORT_REPO`, `NEMUS_SKIP_CONFIGURE`, `WORKSPACE_CLONE_TIMEOUT_MS`, `NO_COLOR`/`FORCE_COLOR`, `VISUAL`/`EDITOR`.

## Tests
- `editor.test.ts` — `VISUAL`>`EDITOR` precedence, flag splitting, platform defaults, exact argv + `stdio: 'inherit'`, non-zero exit → not-ok, `ENOENT` → clear message.
- **520 core tests** green; typecheck clean.
- Verified live: the non-TTY guard exits 1 with guidance; `edit` appears in `config --help`.

README Configuration + Environment variables; CHANGELOG. Version **0.8.0 → 0.9.0**.
