### PR TITLE
docs(cloud): refresh plan status + fix README backend list

### DIFF
--- a/docs/plans/2026-08-26-cloud-iac.md
+++ b/docs/plans/2026-08-26-cloud-iac.md
@@ -1,6 +1,14 @@
 # Cloud / IaC for Nemus — design plan
 
-**Status:** P0 design + P1 scaffold started (`packages/cloud`, forge-auth seam).
+**Status:** P0–P2 complete; P3–P4 substantially landed. Shipped: forge-auth +
+execution seams; three runners (`docker`, `aws-fargate`, `kubernetes`); OpenTofu
+provisioners with `iac/fargate` + `iac/kubernetes` modules; GitHub + GitLab
+forges; the agent OCI image with `run`/`fix-pr` modes; a bounded CI-fix loop;
+Slack/webhook notifiers; and a `nemus-cloud runners` discovery command.
+Everything is dependency-injected and unit-tested with no cloud account, plus
+three live smoke tests (`docker`, `kind`, and the agent image) gated out of CI.
+Remaining/out-of-scope: a Fly.io provider (deferred, see P4) and a hosted UI
+(out of scope for OSS core).
 **Goal:** give Nemus an *optional* way to run a workspace + coding agent on the
 user's own infrastructure — clone repos, run the agent, open a PR, drive it to
 green — vendor-neutral, provider-pluggable, defined as IaC. The value of
@@ -148,7 +156,7 @@ in log streams. PAT is always the zero-config fallback.
   exit code), and a Dockerfile (node + git + gh + pi/claude, non-root). **← done
   (P1 complete).** Follow-ups: two-phase plan/execute in the invoker; log +
   `result.json` upload; then the CI-loop (P3).
-- **P2 — IaC + first cloud provider.** _(in progress)_ **Provisioning seam done:**
+- **P2 — IaC + first cloud provider.** _(complete)_ **Provisioning seam done:**
   a single generic `OpenTofuProvisioner` (shells `tofu`/`terraform`, injectable
   exec, maps the module's `target` output → `TargetDescriptor`) + a provisioner
   **registry** (`opentofu`/`terraform`), unit-tested; and the **first module**,
@@ -167,7 +175,7 @@ in log streams. PAT is always the zero-config fallback.
   `up`/`down` drive the Provisioner, `run` builds the agent env contract + a
   tag-safe `TaskSpec` and launches it via the target's Runner (`--follow` logs,
   `--wait` for the exit code). All I/O injected → unit-tested. **P2 complete.**
-- **P3 — report-back (draft PR) + bounded CI-loop** over `GitForge`. _(in progress)_
+- **P3 — report-back (draft PR) + bounded CI-loop** over `GitForge`. _(substantially landed)_
   **Bounded CI-loop done:** `runCiLoop` — vendor-neutral over `GitForge`/
   `AgentInvoker`/`GitOps`: poll checks by branch head, and on failure run a fix
   pass → commit → push → re-check. Anti-runaway guards: `maxIterations` cap, a
@@ -183,7 +191,7 @@ in log streams. PAT is always the zero-config fallback.
   writes the same versioned `result.json` with `mode: 'fix-pr'` + a compact `ci`
   summary. Exposed as `nemus-cloud fix-pr --repo --pr --branch` (+ `--max-
   iterations`/`--poll-interval-ms`/`--max-polls`).
-- **P4 — more providers (plugins), optional Slack, optional hosted UI.** _(in progress)_
+- **P4 — more providers (plugins), optional Slack, optional hosted UI.** _(substantially landed; Fly deferred, hosted UI out of scope)_
   **Kubernetes runner done:** `KubernetesJobRunner` (`kubernetes`) — renders a
   `batch/v1` **Job** (`backoffLimit: 0` one-shot, `ttlSecondsAfterFinished` GC,
   `restartPolicy: Never`) and shells `kubectl`: `apply -f - -o json` to launch,
@@ -217,7 +225,16 @@ in log streams. PAT is always the zero-config fallback.
   Machines REST API. **CI-loop + notifier now wired into the agent image**
   (`fix-pr` mode; `notifierFromEnv` passes `SLACK_WEBHOOK_URL`/`NEMUS_WEBHOOK_URL`
   through the CLI), so P3+P4 are usable end-to-end in a container. Optional
-  hosted UI remains out of scope for OSS core.
+  hosted UI remains out of scope for OSS core. **GitLab forge done:** a second
+  `GitForge` (`registerForge`/`createForge`, `NEMUS_FORGE_HOST` for self-managed)
+  alongside GitHub. **Discovery command done:** `nemus-cloud runners` (alias
+  `ls`) enumerates registered runners + their capabilities, provisioners,
+  forges, and shipped IaC modules (human table or `--json`); a backend that
+  fails to construct is reported, never fatal. **Live smoke tests done:** beyond
+  the mocked unit suite, gated-out-of-CI e2es drive the real `DockerRunner`
+  (`e2e:docker`), the real `KubernetesJobRunner` against `kind` (`e2e:kind`),
+  and the built agent OCI image through the Docker runner (`e2e:image` — build,
+  entrypoint, env contract, `result.json`, exit-code → status, token redaction).
 
 ## Decisions (locked / open)
 
@@ -225,9 +242,12 @@ in log streams. PAT is always the zero-config fallback.
   OCI image as portability boundary; provision/execution split via Target
   Descriptor; capability-based degradation; forge auth via `ForgeTokenSource`
   with A/B/C key placement.
-- **Open (pick before P2):** IaC tool (**OpenTofu** recommended vs Pulumi/CDK);
-  first cloud provider (**Fly** for OSS simplicity vs **Fargate** for
-  enterprise); agent auth in cloud (API-keys-in-secrets vs cloud-native IAM).
+- **Resolved (were open before P2):** IaC tool → **OpenTofu** (with a
+  `terraform` alias); first cloud provider → **Fargate** (chosen over Fly for a
+  solid, `tofu validate`-able provider; the provisioner is generic so Fly is
+  just another module); agent auth in cloud → **env-token, least-privilege by
+  default** (no bound task/pod role; the agent authenticates to the forge via a
+  short-lived token, not cloud-native IAM).
 
 ## Anti-patterns to avoid
 

--- a/packages/cloud/README.md
+++ b/packages/cloud/README.md
@@ -2,8 +2,8 @@
 
 > **Optional, vendor-neutral cloud/IaC runners for Nemus.** Not required for
 > local Nemus — this package lets you run a workspace + coding agent on *your
-> own* infrastructure (local Docker, Fly, Fargate, k8s, …), headlessly, and open
-> a PR.
+> own* infrastructure (local Docker, AWS Fargate, Kubernetes today; other
+> backends are pluggable), headlessly, and open a PR.
 
 **Status: P1–P4 substantially landed.** In: the forge-auth + execution seams with
 three runners (`docker`, `aws-fargate`, `kubernetes`), OpenTofu provisioners with


### PR DESCRIPTION
**Docs-only consolidation** of the cloud package, returning to cloud after the config/reflect polish.

The cloud plan doc had drifted from reality: its header still read *"P0 design + P1 scaffold started"* while its own body — and the shipped code — is well past that (3 runners, 2 IaC modules, 2 forges, agent image, CI-loop, notifiers, discovery command, three live e2es). This reconciles the docs with what's actually shipped. **No code or behavior changes.**

## `docs/plans/2026-08-26-cloud-iac.md`
- **Status header** rewritten: P0–P2 complete, P3–P4 substantially landed; enumerates what shipped and names what's out (Fly deferred, hosted UI out of scope).
- **Phase tags** flipped to match the body: P2 → *complete*, P3/P4 → *substantially landed*.
- **P4** now also records the **GitLab forge**, the **`nemus-cloud runners` discovery command**, and the **`e2e:docker` + `e2e:image`** smoke tests — all added after the doc's last update.
- The stale **"Open (pick before P2)" decisions** block is resolved: OpenTofu, Fargate-first, and env-token least-privilege auth are long decided.

## `packages/cloud/README.md`
- The intro listed **"Fly"** among shipped backends though there's no Fly runner (it's explicitly deferred). Now lists the actual three (`docker`/`aws-fargate`/`kubernetes`) and notes others are pluggable.

Docs-only → no version bump. Why this and not more features: the cloud package is substantial but unpublished/experimental, so making an evaluator's first read (the plan doc) accurate is higher value than adding more surface area right now.
