### PR TITLE
build(cloud): publish @nemus-cli/cloud as experimental (approval-gated)

### DIFF
--- a/.github/workflows/release-cloud.yml
+++ b/.github/workflows/release-cloud.yml
@@ -1,0 +1,116 @@
+name: Release cloud
+
+# Publishes @nemus-cli/cloud to npm and creates a GitHub Release.
+#
+# Trigger: a push to main that changes packages/cloud/package.json's version, OR
+# a manual workflow_dispatch. The actual publish runs in the `release` GitHub
+# Environment (REQUIRED REVIEWERS), so publishing always waits for a maintainer
+# to click "Approve" before anything is pushed to npm. Independent of the core
+# CLI's release.yml — the two packages version and ship separately.
+
+on:
+  push:
+    branches: [main]
+    paths: ['packages/cloud/package.json']
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Why are you cutting this cloud release?'
+        required: false
+        default: 'manual release'
+
+concurrency:
+  group: release-cloud-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  # 1) Decide whether there is a new cloud version to publish.
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 2
+      - id: check
+        run: |
+          VERSION=$(node -p "require('./packages/cloud/package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "should_release=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          git show HEAD~1:packages/cloud/package.json > /tmp/prev.json 2>/dev/null || echo '{}' > /tmp/prev.json
+          PREV=$(node -p "JSON.parse(require('fs').readFileSync('/tmp/prev.json','utf8')).version || 'none'")
+          echo "previous=$PREV current=$VERSION"
+          if [ "$VERSION" != "$PREV" ]; then
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # 2) Build + test the cloud package as a gate before we ever ask for approval.
+  verify:
+    needs: detect
+    if: needs.detect.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run -w @nemus-cli/cloud build
+      - run: npm run -w @nemus-cli/cloud typecheck
+      - run: npm run -w @nemus-cli/cloud test
+      - run: npm pack -w @nemus-cli/cloud --dry-run
+
+  # 3) Publish — runs ONLY after a maintainer approves the `release` environment.
+  publish:
+    needs: [detect, verify]
+    if: needs.detect.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://www.npmjs.com/package/@nemus-cli/cloud
+    permissions:
+      contents: write   # create tag + GitHub Release
+      id-token: write   # npm provenance
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - run: npm ci
+      - run: npm run -w @nemus-cli/cloud build
+
+      - name: Publish to npm (with provenance)
+        run: npm publish -w @nemus-cli/cloud --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # GitHub-owned CLI (org policy: GitHub-owned actions only). Idempotent.
+      # Cloud releases are tagged `cloud-v<version>` so they never collide with
+      # the core CLI's `v<version>` tags.
+      - name: Create / update GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.detect.outputs.version }}
+        run: |
+          NOTES=$(printf '## @nemus-cli/cloud v%s\n\n```bash\nnpm install -g @nemus-cli/cloud@%s\n```\n\nOptional, experimental cloud/IaC runners for Nemus. See the [package README](https://github.com/%s/blob/main/packages/cloud/README.md).\n' "$VERSION" "$VERSION" "$GITHUB_REPOSITORY")
+          if gh release view "cloud-v$VERSION" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release edit "cloud-v$VERSION" --repo "$GITHUB_REPOSITORY" \
+              --title "@nemus-cli/cloud v$VERSION" --notes "$NOTES" --draft=false --prerelease=true
+          else
+            gh release create "cloud-v$VERSION" --repo "$GITHUB_REPOSITORY" \
+              --title "@nemus-cli/cloud v$VERSION" --notes "$NOTES" --prerelease
+          fi

--- a/.github/workflows/release-cloud.yml
+++ b/.github/workflows/release-cloud.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          fetch-depth: 2
+          fetch-depth: 0   # full history so we can diff the whole push, not just HEAD~1
       - id: check
         run: |
           VERSION=$(node -p "require('./packages/cloud/package.json').version")
@@ -44,8 +44,18 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "should_release=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
-          git show HEAD~1:packages/cloud/package.json > /tmp/prev.json 2>/dev/null || echo '{}' > /tmp/prev.json
-          PREV=$(node -p "JSON.parse(require('fs').readFileSync('/tmp/prev.json','utf8')).version || 'none'")
+          # Compare against the commit BEFORE the whole push (github.event.before),
+          # not HEAD~1 — a push can carry several commits, and if the version bump
+          # isn't the last one, HEAD~1 already shows the new version and the
+          # release would be silently skipped. `before` is all-zeros on a new
+          # branch (nothing prior) -> treat as a release.
+          BEFORE='${{ github.event.before }}'
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            PREV=none
+          else
+            git show "$BEFORE:packages/cloud/package.json" > /tmp/prev.json 2>/dev/null || echo '{}' > /tmp/prev.json
+            PREV=$(node -p "JSON.parse(require('fs').readFileSync('/tmp/prev.json','utf8')).version || 'none'")
+          fi
           echo "previous=$PREV current=$VERSION"
           if [ "$VERSION" != "$PREV" ]; then
             echo "should_release=true" >> "$GITHUB_OUTPUT"
@@ -94,9 +104,19 @@ jobs:
       - run: npm run -w @nemus-cli/cloud build
 
       - name: Publish to npm (with provenance)
-        run: npm publish -w @nemus-cli/cloud --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          VERSION: ${{ needs.detect.outputs.version }}
+        run: |
+          # Idempotent: a re-run/re-approval (esp. via workflow_dispatch, which
+          # always sets should_release=true) must not die on npm's
+          # "cannot publish over an existing version" — mirror the GitHub Release
+          # step's idempotency and no-op if this version is already on npm.
+          if npm view "@nemus-cli/cloud@$VERSION" version >/dev/null 2>&1; then
+            echo "@nemus-cli/cloud@$VERSION is already on npm — skipping publish."
+            exit 0
+          fi
+          npm publish -w @nemus-cli/cloud --provenance --access public
 
       # GitHub-owned CLI (org policy: GitHub-owned actions only). Idempotent.
       # Cloud releases are tagged `cloud-v<version>` so they never collide with

--- a/README.md
+++ b/README.md
@@ -389,9 +389,14 @@ there's an **optional, opt-in** package: [`@nemus-cli/cloud`](./packages/cloud).
 It's a separate, vendor-neutral package built from swappable seams — runners
 (`docker`, `aws-fargate`, `kubernetes`), IaC provisioners (OpenTofu/Terraform
 modules), git forges (GitHub/GitLab), a bounded CI-fix loop, and notifiers — with
-no cloud SDK in the core CLI. It is **not published to npm**; it lives in this
-repo for you to build and run yourself. See
-[`packages/cloud/README.md`](./packages/cloud/README.md) to get started.
+no cloud SDK in the core CLI. It's published separately as **experimental**
+(`0.x`), so installing the core CLI pulls in none of it:
+
+```bash
+npm install -g @nemus-cli/cloud
+```
+
+See [`packages/cloud/README.md`](./packages/cloud/README.md) to get started.
 
 ## Configuration
 

--- a/packages/cloud/CHANGELOG.md
+++ b/packages/cloud/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog — @nemus-cli/cloud
+
+All notable changes to the optional cloud package are documented here. It
+versions independently of the core `@nemus-cli/nemus` CLI.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this package adheres to [Semantic Versioning](https://semver.org/) — while
+pre-1.0 (`0.x`), minor versions may include breaking changes.
+
+## [0.1.0] - 2026-09-01
+
+First published release — **experimental**. Previously in-repo only.
+
+### Added
+
+- **Execution seam**: `Runner`/`Provisioner` interfaces over a neutral
+  `TaskSpec`/`TargetDescriptor`/`Capabilities`, with a name-resolved registry.
+- **Runners**: `docker` (in-box, no cloud account), `aws-fargate`, and
+  `kubernetes` (renders a one-shot `batch/v1` Job). docker + kubernetes have
+  live smoke tests; fargate is unit-tested (not yet validated against a live AWS
+  account).
+- **Provisioners**: a generic `OpenTofuProvisioner` (`opentofu`/`terraform`)
+  with shipped `iac/fargate` and `iac/kubernetes` modules (`tofu validate`-clean).
+- **Forges**: token-based, dependency-free `GitHub` and `GitLab` (`openPR` /
+  `getChecks` / `comment`), with `NEMUS_FORGE_HOST` for self-managed hosts.
+- **Forge auth**: `ForgeTokenSource` with `pat` and least-privilege,
+  auto-refreshing `github-app` installation tokens (dependency-free RS256).
+- **Agent image**: an OCI image + `nemus-cloud-agent` entrypoint with `run`
+  (clone → agent → PR) and `fix-pr` (drive an existing PR to green) modes,
+  writing a versioned `result.json`.
+- **CI-fix loop**: a bounded, vendor-neutral loop over the `GitForge` seam with
+  anti-runaway guards, plus optional Slack/webhook notifiers.
+- **CLI**: `nemus-cloud` (`up`/`down`/`run`/`fix-pr`) and a `runners` discovery
+  command (`--json`).
+- Zero runtime dependencies; standalone (no dependency on the core CLI).

--- a/packages/cloud/LICENSE
+++ b/packages/cloud/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Nemus contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cloud/README.md
+++ b/packages/cloud/README.md
@@ -5,14 +5,30 @@
 > own* infrastructure (local Docker, Fly, Fargate, k8s, …), headlessly, and open
 > a PR.
 
+> [!NOTE]
+> **Experimental / pre-1.0 (`0.x`).** The seams are stable and unit-tested, but
+> APIs may change before `1.0`, the `aws-fargate` runner hasn't been validated
+> against a live AWS account (docker + kubernetes have live smoke tests), and a
+> hosted UI is out of scope. Pin an exact version.
+
 **Status: P1–P4 substantially landed.** In: the forge-auth + execution seams with
 three runners (`docker`, `aws-fargate`, `kubernetes`), OpenTofu provisioners with
 shipped `iac/fargate` + `iac/kubernetes` modules, GitHub/GitLab forges, the agent
 OCI image with `run`/`fix-pr` entry modes, a bounded CI-fix loop, Slack/webhook
 notifiers, and a `nemus-cloud runners` discovery command. Everything is
 dependency-injected and unit-tested with no cloud account. See
-[`docs/plans/2026-08-26-cloud-iac.md`](../../docs/plans/2026-08-26-cloud-iac.md)
+[the design plan](https://github.com/me-public/nemus/blob/main/docs/plans/2026-08-26-cloud-iac.md)
 for the full design.
+
+## Install
+
+```bash
+npm install -g @nemus-cli/cloud   # provides `nemus-cloud` + `nemus-cloud-agent`
+```
+
+Standalone (no dependency on the core `@nemus-cli/nemus` CLI) and
+zero-runtime-dependency. Requires Node ≥ 22, plus whatever a given backend shells
+out to (`docker`, `kubectl`, `aws`, `tofu`/`terraform`, `git`, `gh`).
 
 ## Why a separate package
 

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -13,7 +13,19 @@
   ],
   "author": "Nemus contributors",
   "license": "MIT",
-  "private": true,
+  "homepage": "https://github.com/me-public/nemus/tree/main/packages/cloud#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/me-public/nemus.git",
+    "directory": "packages/cloud"
+  },
+  "bugs": {
+    "url": "https://github.com/me-public/nemus/issues"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "type": "commonjs",
   "engines": {
     "node": ">=22"
@@ -28,7 +40,9 @@
     "dist/**/*",
     "image/**/*",
     "iac/**/*",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",


### PR DESCRIPTION
Makes the previously in-repo-only `@nemus-cli/cloud` package **publishable to npm as experimental (`0.x`)** — gated behind the same manual `release`-environment approval as the core CLI, so **nothing reaches npm without a maintainer clicking Approve**.

## Package manifest (`packages/cloud/package.json`)
- Drop `"private": true`; add `publishConfig` (`access: public` + `provenance`), `repository`/`homepage`/`bugs`.
- Ship `LICENSE` (MIT) + a new `CHANGELOG.md` (0.1.0, experimental). Version stays **0.1.0**.
- Still **zero runtime dependencies** and **standalone** (no dependency on the core `@nemus-cli/nemus`).

## Release automation (`.github/workflows/release-cloud.yml`)
A **separate, approval-gated** workflow mirroring `release.yml`:
- Triggers on `packages/cloud/package.json` version changes (or `workflow_dispatch`).
- `detect` → `verify` (build + typecheck + test + `npm pack --dry-run`) → `publish`, where **publish runs only after the `release` environment is approved** (same required-reviewers gate the core CLI uses — reuses the existing environment, no new setup).
- `npm publish -w @nemus-cli/cloud --provenance --access public`.
- GitHub Releases tagged **`cloud-v<version>`** + marked **prerelease**, so they never collide with the core CLI's `v<version>` tags.

## Docs
- Core README cloud section: "not published to npm" → "published as **experimental** (`0.x`)" with an install line.
- Package README: an **experimental / pre-1.0** note (APIs may change; `aws-fargate` not yet validated against a live AWS account; hosted UI out of scope), an **Install** section, and repo-relative links **absolutized** so they resolve on the npm page.

## Tarball is clean
`npm pack --dry-run` → **85 files, 69 kB**: `dist/**` + `image/Dockerfile` + both `iac/` modules + README/CHANGELOG/LICENSE. **No** `src/`, tests, `e2e/`, or `node_modules/`. 177 cloud tests pass; root build/tests unaffected.

## ⚠️ First publish is manual (by design)
Merging this PR **does not publish** — the version-change trigger can't fire because `0.1.0` is already the current version. To cut the first release: **run the "Release cloud" workflow via *Run workflow* (workflow_dispatch), then approve the `release` environment.** Subsequent releases auto-trigger on a cloud version bump.

This reverses the earlier deliberate "cloud stays unpublished" positioning — intentionally, per the decision to publish it as an experimental adjunct.
