### PR TITLE
ci: generate GitHub Release notes from the CHANGELOG section

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,11 +126,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.detect.outputs.version }}
         run: |
-          NOTES=$(printf '## Nemus v%s\n\n```bash\nnpm install -g @nemus-cli/nemus@%s\n```\n\nSee the [CHANGELOG](https://github.com/%s/blob/main/CHANGELOG.md) for details.\n' "$VERSION" "$VERSION" "$GITHUB_REPOSITORY")
+          # Build notes from this version's CHANGELOG section (falls back to a
+          # minimal note if the entry is missing, so a release never blocks).
+          node scripts/release-notes.mjs "$VERSION" "$GITHUB_REPOSITORY" > /tmp/release-notes.md
           if gh release view "v$VERSION" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh release edit "v$VERSION" --repo "$GITHUB_REPOSITORY" \
-              --title "Nemus v$VERSION" --notes "$NOTES" --draft=false --prerelease=false
+              --title "Nemus v$VERSION" --notes-file /tmp/release-notes.md --draft=false --prerelease=false
           else
             gh release create "v$VERSION" --repo "$GITHUB_REPOSITORY" \
-              --title "Nemus v$VERSION" --notes "$NOTES" --latest
+              --title "Nemus v$VERSION" --notes-file /tmp/release-notes.md --latest
           fi

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// Emit GitHub Release notes for a given version by extracting that version's
+// section from CHANGELOG.md (newest-first "Keep a Changelog" format), prepended
+// with an install snippet and followed by a compare link to the previous tag.
+//
+// Usage: node scripts/release-notes.mjs <version> [repo]
+//   repo defaults to $GITHUB_REPOSITORY or "me-public/nemus".
+//
+// If the version has no CHANGELOG section, prints a minimal fallback (so a
+// release is never blocked on a missing entry). Dependency-free; prints to
+// stdout so the workflow can redirect it into `gh release --notes-file`.
+import { readFileSync } from 'node:fs';
+
+const version = (process.argv[2] || '').trim();
+const repo = (process.argv[3] || process.env.GITHUB_REPOSITORY || 'me-public/nemus').trim();
+if (!version) {
+  process.stderr.write('usage: release-notes.mjs <version> [repo]\n');
+  process.exit(2);
+}
+
+const install = `\`\`\`bash\nnpm install -g @nemus-cli/nemus@${version}\n\`\`\``;
+
+let body = '';
+let prev = null;
+try {
+  const changelog = readFileSync(new URL('../CHANGELOG.md', import.meta.url), 'utf8');
+  const lines = changelog.split('\n');
+  // Collect version headers in file order (newest first) with their line index.
+  const heads = [];
+  lines.forEach((line, i) => {
+    const m = line.match(/^## \[(\d+\.\d+\.\d+)\]/);
+    if (m) heads.push({ version: m[1], line: i });
+  });
+  const idx = heads.findIndex((h) => h.version === version);
+  if (idx !== -1) {
+    const start = heads[idx].line + 1;
+    const end = idx + 1 < heads.length ? heads[idx + 1].line : lines.length;
+    body = lines.slice(start, end).join('\n').trim();
+    // Newest-first: the NEXT header in the file is the previous release.
+    prev = idx + 1 < heads.length ? heads[idx + 1].version : null;
+  }
+} catch {
+  // fall through to fallback
+}
+
+const compare = prev
+  ? `[\`v${prev}...v${version}\`](https://github.com/${repo}/compare/v${prev}...v${version})`
+  : `[\`v${version}\`](https://github.com/${repo}/releases/tag/v${version})`;
+
+const parts = [`## Nemus v${version}`, '', install];
+if (body) parts.push('', body);
+parts.push('', '---', '', `**Full diff:** ${compare} · [Full changelog](https://github.com/${repo}/blob/main/CHANGELOG.md)`);
+
+process.stdout.write(parts.join('\n') + '\n');


### PR DESCRIPTION
Part of the adoption-polish pass. Every GitHub Release body was the same boilerplate — `## Nemus vX.Y.Z` + install line + *"See the CHANGELOG for details."* — so the [Releases page](https://github.com/me-public/nemus/releases) told a visitor nothing about what actually shipped in each version.

## Change
- **New `scripts/release-notes.mjs`** (dependency-free ESM): extracts a version's section from `CHANGELOG.md` (newest-first *Keep a Changelog* format), prepends the `npm install` snippet, and appends a **compare link** to the previous tag. If the version has no CHANGELOG entry it prints a minimal fallback, so a release is **never blocked** on missing notes.
- **`release.yml`** now runs that script and passes the result via `gh release ... --notes-file` (the publish job already checks out the repo + sets up Node before this step, so `scripts/` and `CHANGELOG.md` are present).

## Also done out-of-band
All **22 existing releases** (v0.2.1 → v0.10.0) were backfilled with the same format via `gh release edit`, so the Releases page is already rich — this PR keeps *future* releases that way automatically.

## Verification
- `node scripts/release-notes.mjs 0.10.0` → full Changed section + `v0.9.0...v0.10.0` compare link.
- `node scripts/release-notes.mjs 99.0.0` → clean fallback (no section).
- `release.yml` parses as valid YAML.

No `src/`/`bin/` change → no version bump.
