### PR TITLE
ci(dependabot): exclude major bumps from the grouped dev-deps PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,12 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: development
+        # Only bundle minor/patch into the routine grouped PR. Majors (e.g. a
+        # TypeScript major that removes a tsconfig option) get their own PR so a
+        # breaking upgrade is reviewed deliberately, not merged as a group bump.
+        update-types:
+          - minor
+          - patch
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
**Why:** the routine grouped `dev-dependencies` update (PR #63) bundled a safe `@types/node` 26.3→26.4 minor with a **TypeScript major** (5.9.3 → **7.0.2**). TS 7 removed `moduleResolution: "node10"`, so both tsconfigs fail to compile (`error TS5108`) — a breaking toolchain change riding inside what looks like a routine bump.

**Change:** restrict the `dev-dependencies` group to `minor`+`patch`. Majors then get their **own individual PR** — clearly a major, reviewed deliberately (and the group PR stays green/mergeable).

CI/config only — no version bump.