### PR TITLE
refactor(shell): move integration out of RC files into ~/.nemus (ports #50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-09-02
+
+### Changed
+
+- **Shell integration now keeps its generated functions out of your shell RC
+  files.** Nemus writes them to `~/.nemus/shell-integration.sh` and adds only a
+  single guarded `source` line to `.zshrc`/`.bashrc`, so upgrades no longer
+  churn hundreds of lines in your personal shell config. Existing inline
+  installations migrate automatically without disturbing surrounding user
+  content, and reinstalls stay idempotent. Uninstall removes the generated file
+  too. Thanks to @uzikilon for the idea and original implementation (#50).
+
 ## [0.13.0] - 2026-09-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ npm install -g @nemus-cli/nemus
 ```
 
 The postinstall step sets up optional shell integration (auto-cd into new
-workspaces + a quick-navigate helper).
+workspaces + a quick-navigate helper). It keeps the generated functions in
+`~/.nemus/shell-integration.sh` and adds only a guarded source line to your
+shell RC file, so upgrades don't churn your `.zshrc`/`.bashrc`.
 
 ### From source
 

--- a/install-shell-integration.sh
+++ b/install-shell-integration.sh
@@ -491,17 +491,30 @@ else
   exit 1
 fi
 
-# Check if already installed (version marker is in the grep below)
-if grep -q "Shell Integration (v50)" "$RC_FILE" 2>/dev/null; then
+# Keep the generated functions out of the user's shell config. The same file
+# works in both bash and zsh; the RC file only needs this guarded source line.
+SHELL_INTEGRATION_DIR="$HOME/.nemus"
+SHELL_INTEGRATION_FILE="$SHELL_INTEGRATION_DIR/shell-integration.sh"
+SOURCE_LINE='[ -f "$HOME/.nemus/shell-integration.sh" ] && source "$HOME/.nemus/shell-integration.sh"'
+
+mkdir -p "$SHELL_INTEGRATION_DIR"
+SHELL_TMPFILE=$(mktemp "$SHELL_INTEGRATION_DIR/.shell-integration.XXXXXX")
+printf '%s\n' "$SHELL_FUNCTION" > "$SHELL_TMPFILE"
+mv "$SHELL_TMPFILE" "$SHELL_INTEGRATION_FILE"
+
+append_source_line() {
+  printf '\n# Nemus - Shell Integration\n%s\n' "$SOURCE_LINE" >> "$1"
+}
+
+# Check if already installed
+if grep -Fq "$SOURCE_LINE" "$RC_FILE" 2>/dev/null; then
   echo "✅ Shell integration already up to date in $RC_FILE"
 elif grep -q "# Nemus - Shell Integration" "$RC_FILE" 2>/dev/null; then
-  # Old version installed — remove it and install new version
+  # Old inline version installed — remove it and leave only the source line
   echo "🔄 Upgrading shell integration in $RC_FILE..."
   TMPFILE=$(mktemp)
   awk -f "$SCRIPT_DIR/remove-shell-block.awk" "$RC_FILE" > "$TMPFILE"
-  # Append new shell integration to temp file so mv is atomic
-  echo "" >> "$TMPFILE"
-  echo "$SHELL_FUNCTION" >> "$TMPFILE"
+  append_source_line "$TMPFILE"
   cp "$RC_FILE" "${RC_FILE}.backup.$(date +%Y%m%d_%H%M%S)"
   chmod --reference="$RC_FILE" "$TMPFILE" 2>/dev/null || chmod "$(stat -f '%Lp' "$RC_FILE")" "$TMPFILE" 2>/dev/null || true
   mv "$TMPFILE" "$RC_FILE"
@@ -514,9 +527,8 @@ else
     echo "📦 Backup created: ${RC_FILE}.backup.*"
   fi
 
-  # Append shell function (creates the file if it doesn't exist)
-  echo "" >> "$RC_FILE"
-  echo "$SHELL_FUNCTION" >> "$RC_FILE"
+  # Append the source line (creates the file if it doesn't exist)
+  append_source_line "$RC_FILE"
 
   echo "✅ Shell integration installed in $RC_FILE"
   echo ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nemus-cli/nemus",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "workspaces": [
     "packages/*"
   ],

--- a/remove-shell-block.awk
+++ b/remove-shell-block.awk
@@ -33,6 +33,14 @@ skip {
     saw_func = 1
     next
   }
+  if (/\.nemus\/shell-integration\.sh/ && /source/) {
+    # Current installs keep the functions in a generated file and leave only
+    # this source line in the RC file.
+    skip = 0
+    saw_func = 0
+    buf = ""
+    next
+  }
   # Non-function line: block is over — emit any buffered lines
   skip = 0
   if (buf != "") printf "%s", buf

--- a/shell-integration.test.sh
+++ b/shell-integration.test.sh
@@ -299,6 +299,66 @@ echo "Test 12: 'nem' with no args → runs binary with no args"
   assert_eq "pwd unchanged (no CD)" "$TEMP_DIR" "$(pwd)"
 )
 
+# ── Test 12a: installer keeps functions out of the RC file ──────────
+echo ""
+echo "Test 12a: installer writes functions to ~/.nemus and sources them from .zshrc"
+(
+  INSTALL_HOME="$TEMP_DIR/install-home"
+  mkdir -p "$INSTALL_HOME"
+  cat > "$INSTALL_HOME/.zshrc" << 'RCEOF'
+export USER_SETTING=kept
+RCEOF
+
+  HOME="$INSTALL_HOME" bash "$SCRIPT_DIR/install-shell-integration.sh" zsh >/dev/null
+
+  assert_eq "generated integration file exists" "1" "$([ -f "$INSTALL_HOME/.nemus/shell-integration.sh" ] && echo 1 || echo 0)"
+  assert_eq "functions moved to generated file" "1" "$(grep -c '^nemus()' "$INSTALL_HOME/.nemus/shell-integration.sh")"
+  assert_eq "functions absent from .zshrc" "0" "$(grep -c '^nemus()' "$INSTALL_HOME/.zshrc")"
+  assert_eq "source line added once" "1" "$(grep -Fc '[ -f "$HOME/.nemus/shell-integration.sh" ] && source "$HOME/.nemus/shell-integration.sh"' "$INSTALL_HOME/.zshrc")"
+  assert_eq "user setting preserved" "1" "$(grep -c 'USER_SETTING=kept' "$INSTALL_HOME/.zshrc")"
+
+  HOME="$INSTALL_HOME" bash "$SCRIPT_DIR/install-shell-integration.sh" zsh >/dev/null
+  assert_eq "reinstall does not duplicate source line" "1" "$(grep -Fc '[ -f "$HOME/.nemus/shell-integration.sh" ] && source "$HOME/.nemus/shell-integration.sh"' "$INSTALL_HOME/.zshrc")"
+
+  cat >> "$INSTALL_HOME/.zshrc" << 'RCEOF'
+# user content after integration
+user_function() { echo kept; }
+RCEOF
+  TMPFILE=$(mktemp)
+  awk -f "$SCRIPT_DIR/remove-shell-block.awk" "$INSTALL_HOME/.zshrc" > "$TMPFILE"
+  mv "$TMPFILE" "$INSTALL_HOME/.zshrc"
+  assert_eq "source line can be removed" "0" "$(grep -Fc 'shell-integration.sh' "$INSTALL_HOME/.zshrc")"
+  assert_eq "function after source line preserved" "1" "$(grep -c 'user_function()' "$INSTALL_HOME/.zshrc")"
+  assert_eq "comment after source line preserved" "1" "$(grep -c '# user content after integration' "$INSTALL_HOME/.zshrc")"
+)
+
+# ── Test 12b: installer migrates the legacy inline block ────────────
+echo ""
+echo "Test 12b: installer migrates an inline block without touching user content"
+(
+  INSTALL_HOME="$TEMP_DIR/migration-home"
+  mkdir -p "$INSTALL_HOME"
+  cat > "$INSTALL_HOME/.zshrc" << 'RCEOF'
+export BEFORE=yes
+
+# Nemus - Shell Integration (v50)
+nemus() {
+  command nemus "$@"
+}
+
+# user content after integration
+export AFTER=yes
+RCEOF
+
+  HOME="$INSTALL_HOME" bash "$SCRIPT_DIR/install-shell-integration.sh" zsh >/dev/null
+
+  assert_eq "legacy function removed from .zshrc" "0" "$(grep -c '^nemus()' "$INSTALL_HOME/.zshrc")"
+  assert_eq "source line added" "1" "$(grep -Fc '[ -f "$HOME/.nemus/shell-integration.sh" ] && source "$HOME/.nemus/shell-integration.sh"' "$INSTALL_HOME/.zshrc")"
+  assert_eq "content before integration preserved" "1" "$(grep -c 'BEFORE=yes' "$INSTALL_HOME/.zshrc")"
+  assert_eq "content after integration preserved" "1" "$(grep -c 'AFTER=yes' "$INSTALL_HOME/.zshrc")"
+  assert_eq "comment after integration preserved" "1" "$(grep -c '# user content after integration' "$INSTALL_HOME/.zshrc")"
+)
+
 # ── Test 13: upgrade removes old block and preserves rest ──────────
 echo ""
 echo "Test 13: upgrade from old version preserves rest of RC file"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -38,7 +38,7 @@ echo -e "${YELLOW}This will NOT remove:${NC}"
 echo "  • Your workspaces ($HOME/workspaces/)"
 echo "  • Cache files (~/.workspace-manager-cache/)"
 echo "  • Configuration files (~/.workspace-manager-claude-config.json)"
-echo "  • Shell integration (from .zshrc or .bashrc)"
+echo "  • Shell integration (from .zshrc or .bashrc and ~/.nemus/)"
 echo "  • ghq (if installed)"
 echo ""
 
@@ -85,8 +85,11 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         if grep -q "# Nemus - Shell Integration" "$HOME/.zshrc"; then
             # Create backup
             cp "$HOME/.zshrc" "$HOME/.zshrc.backup.$(date +%Y%m%d_%H%M%S)"
-            # Remove the function
-            sed -i.bak '/# Nemus - Shell Integration/,/^}$/d' "$HOME/.zshrc"
+            # Remove the block/source line (awk handles both formats safely)
+            TMPFILE=$(mktemp)
+            awk -f "$SCRIPT_DIR/remove-shell-block.awk" "$HOME/.zshrc" > "$TMPFILE"
+            chmod --reference="$HOME/.zshrc" "$TMPFILE" 2>/dev/null || chmod "$(stat -f '%Lp' "$HOME/.zshrc")" "$TMPFILE" 2>/dev/null || true
+            mv "$TMPFILE" "$HOME/.zshrc"
             print_success "Removed from .zshrc (backup created)"
         fi
     fi
@@ -96,10 +99,18 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         if grep -q "# Nemus - Shell Integration" "$HOME/.bashrc"; then
             # Create backup
             cp "$HOME/.bashrc" "$HOME/.bashrc.backup.$(date +%Y%m%d_%H%M%S)"
-            # Remove the function
-            sed -i.bak '/# Nemus - Shell Integration/,/^}$/d' "$HOME/.bashrc"
+            # Remove the block/source line (awk handles both formats safely)
+            TMPFILE=$(mktemp)
+            awk -f "$SCRIPT_DIR/remove-shell-block.awk" "$HOME/.bashrc" > "$TMPFILE"
+            chmod --reference="$HOME/.bashrc" "$TMPFILE" 2>/dev/null || chmod "$(stat -f '%Lp' "$HOME/.bashrc")" "$TMPFILE" 2>/dev/null || true
+            mv "$TMPFILE" "$HOME/.bashrc"
             print_success "Removed from .bashrc (backup created)"
         fi
+    fi
+
+    if [ -f "$HOME/.nemus/shell-integration.sh" ]; then
+        rm -f "$HOME/.nemus/shell-integration.sh"
+        print_success "Removed ~/.nemus/shell-integration.sh"
     fi
 fi
 


### PR DESCRIPTION
Ports **#50** (by @uzikilon) onto current `main`. That PR was opened at `0.3.3` and is now ~10 minors behind (`main` is `0.13.0`), from a fork's `main` branch, with the required CI never run and heavy conflicts in `package.json`/`package-lock`/`CHANGELOG`/`README`. The shell-script logic itself was sound, so I re-applied the substantive parts on a fresh branch with a correct version bump, crediting the original author via `Co-authored-by`.

## What & why
Nemus previously appended its **entire** generated shell integration (auto-cd + quick-navigate helper — hundreds of lines) straight into `.zshrc`/`.bashrc`, churning the user's personal config on every upgrade. Now it writes those functions to **`~/.nemus/shell-integration.sh`** and adds only a **single guarded `source` line** to the RC file — a clean ownership boundary. Auto-cd/navigation behavior is unchanged.

## Changes
- **`install-shell-integration.sh`** — write functions to `~/.nemus/shell-integration.sh` (atomic `mktemp`+`mv`), append only the source line; a legacy inline block is stripped via the awk remover and replaced with the source line; idempotent (`grep -Fq` the source line, no duplicate on reinstall).
- **`remove-shell-block.awk`** — also recognises and strips the new source-line format (in addition to the legacy inline function block), preserving user content after the block.
- **`uninstall.sh`** — uses the awk remover instead of `sed -i '/marker/,/^}$/d'` (the old range would **over-delete** now that there's no closing brace to anchor on), and `rm -f`s the generated file.
- **`shell-integration.test.sh`** — **+Test 12a** (functions land in `~/.nemus`, source line idempotent + removable, user content preserved) and **+Test 12b** (legacy inline block migrates without touching surrounding content). **94 pass, 0 fail.**
- README + CHANGELOG documented.

## Verification
- Bash integration suite: **94 passed / 0 failed** (incl. the new migration + idempotency tests).
- Core JS suite: **557 passed**. `awk -f` parses clean.
- **0.13.0 → 0.14.0** (install script changed).

Closes #50.

Co-authored-by: uzikilon <uzikilon@users.noreply.github.com>
