### PR TITLE
feat(config): respect XDG base directories for config/state (#77)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-09-02
+
+### Added
+
+- **XDG base-directory support for config/state (Linux).** A fresh install now
+  stores its config/state under `$XDG_CONFIG_HOME/nemus` (default
+  `~/.config/nemus`) on Linux, making Nemus a better Linux citizen. Precedence
+  (first match wins): `NEMUS_CACHE_DIR`/`WORKSPACE_MANAGER_CACHE_DIR` override →
+  an existing `~/.nemus` with state (kept on every platform, never moved) →
+  an absolute `XDG_CONFIG_HOME` → Linux default `~/.config/nemus` → `~/.nemus`
+  (macOS/Windows). Existing `~/.nemus` installs are untouched. (#77)
+
 ## [0.14.0] - 2026-09-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -433,8 +433,10 @@ location is migrated to the resolved config dir automatically.)
 designed so existing installs are never silently moved:
 
 1. `NEMUS_CACHE_DIR` / `WORKSPACE_MANAGER_CACHE_DIR` (explicit override).
-2. An existing `~/.nemus` that already holds state (`config.json` / `suites.json`
-   / `history.jsonl`) — kept on every platform.
+2. An existing `~/.nemus` that holds durable state (anything beyond regenerable
+   caches like `repos-cache.json` / `last-version-check.json` and the
+   `shell-integration.sh` file — e.g. `config.json`, `suites.json`, the
+   `reflect/` reports) — kept on every platform, never moved.
 3. `XDG_CONFIG_HOME/nemus`, when `XDG_CONFIG_HOME` is set to an absolute path.
 4. Linux with no prior install → `~/.config/nemus` (the XDG default).
 5. Otherwise (macOS/Windows, fresh install) → `~/.nemus`.

--- a/README.md
+++ b/README.md
@@ -284,7 +284,8 @@ Everything Nemus reads from the environment (all optional):
 | Variable | Effect |
 | --- | --- |
 | `NEMUS_DIR` | Override where workspaces are created (also `WORKSPACE_MANAGER_DIR`). |
-| `NEMUS_CACHE_DIR` | Override the cache/config/state dir, default `~/.nemus` (also `WORKSPACE_MANAGER_CACHE_DIR`). |
+| `NEMUS_CACHE_DIR` | Override the config/state dir. Default: `~/.nemus`, or `$XDG_CONFIG_HOME/nemus` (→ `~/.config/nemus`) on Linux. Also `WORKSPACE_MANAGER_CACHE_DIR`. |
+| `XDG_CONFIG_HOME` | On Linux (or when set explicitly), a fresh install stores config/state under `$XDG_CONFIG_HOME/nemus`. An existing `~/.nemus` is always kept as-is. |
 | `NEMUS_JUDGE_MODEL` | Model for the `reflect` judge (overrides `--model`'s default). |
 | `NEMUS_JUDGE_THINKING` | Thinking level for the `reflect` judge on pi (`off`…`max`). |
 | `NEMUS_JUDGE_TIMEOUT_MS` | Timeout for the `reflect` judge call. |
@@ -426,7 +427,17 @@ export NEMUS_CACHE_DIR="$HOME/.cache/nemus"   # default: ~/.nemus
 
 (The legacy `WORKSPACE_MANAGER_DIR` / `WORKSPACE_MANAGER_CACHE_DIR` names still
 work as fallbacks. On first run, state from the old `~/.workspace-manager-cache`
-location is migrated to `~/.nemus` automatically.)
+location is migrated to the resolved config dir automatically.)
+
+**Config/state location (XDG-aware).** Resolution order, first match wins —
+designed so existing installs are never silently moved:
+
+1. `NEMUS_CACHE_DIR` / `WORKSPACE_MANAGER_CACHE_DIR` (explicit override).
+2. An existing `~/.nemus` that already holds state (`config.json` / `suites.json`
+   / `history.jsonl`) — kept on every platform.
+3. `XDG_CONFIG_HOME/nemus`, when `XDG_CONFIG_HOME` is set to an absolute path.
+4. Linux with no prior install → `~/.config/nemus` (the XDG default).
+5. Otherwise (macOS/Windows, fresh install) → `~/.nemus`.
 
 Key settings: `githubOrg` (which org's repos to list — leave empty to list your
 own), `cloneProtocol` (`ssh`|`https`), `aiAgent`, `primaryAgent`, `installMcp`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nemus-cli/nemus",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "workspaces": [
     "packages/*"
   ],

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -286,50 +286,67 @@ describe('config', () => {
 
   describe('resolveNemusHome precedence', () => {
     const home = '/home/u';
-    const noState = () => false;
+    const branded = path.join(home, '.nemus');
+    // A readDir that reports the given entries for ~/.nemus and "absent" elsewhere.
+    const brandedHas = (...entries: string[]) => (p: string): string[] => {
+      if (p === branded) return entries;
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    };
+    const empty = (): string[] => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    };
 
     it('explicit NEMUS_CACHE_DIR / legacy override wins over everything', async () => {
       const { resolveNemusHome } = await loadModule();
       expect(
-        resolveNemusHome({ env: { NEMUS_CACHE_DIR: '/x', XDG_CONFIG_HOME: '/c' }, home, platform: 'linux', exists: () => true }),
+        resolveNemusHome({ env: { NEMUS_CACHE_DIR: '/x', XDG_CONFIG_HOME: '/c' }, home, platform: 'linux', readDir: brandedHas('config.json') }),
       ).toBe('/x');
       expect(
-        resolveNemusHome({ env: { WORKSPACE_MANAGER_CACHE_DIR: '/y' }, home, platform: 'linux', exists: () => true }),
+        resolveNemusHome({ env: { WORKSPACE_MANAGER_CACHE_DIR: '/y' }, home, platform: 'linux', readDir: brandedHas('config.json') }),
       ).toBe('/y');
     });
 
-    it('an existing ~/.nemus with state wins over XDG, on any platform', async () => {
+    it('an existing ~/.nemus with durable state wins over XDG, on any platform', async () => {
       const { resolveNemusHome } = await loadModule();
-      const exists = (p: string) => p === path.join(home, '.nemus', 'config.json');
-      expect(resolveNemusHome({ env: { XDG_CONFIG_HOME: '/c' }, home, platform: 'linux', exists })).toBe(
-        path.join(home, '.nemus'),
-      );
+      expect(resolveNemusHome({ env: { XDG_CONFIG_HOME: '/c' }, home, platform: 'linux', readDir: brandedHas('config.json') })).toBe(branded);
     });
 
-    it('a ~/.nemus holding only shell-integration.sh does NOT count as state', async () => {
+    it('counts reflect/ (and any non-cache entry) as durable state — not just the classic 3', async () => {
       const { resolveNemusHome } = await loadModule();
-      const exists = (p: string) => p === path.join(home, '.nemus', 'shell-integration.sh');
-      expect(resolveNemusHome({ env: {}, home, platform: 'linux', exists })).toBe(path.join(home, '.config', 'nemus'));
+      // a reflect-only user has no config.json/suites.json/history.jsonl
+      expect(resolveNemusHome({ env: {}, home, platform: 'linux', readDir: brandedHas('reflect') })).toBe(branded);
+    });
+
+    it('a ~/.nemus holding only regenerable caches / the shell artifact does NOT count', async () => {
+      const { resolveNemusHome } = await loadModule();
+      expect(
+        resolveNemusHome({
+          env: {},
+          home,
+          platform: 'linux',
+          readDir: brandedHas('shell-integration.sh', 'last-version-check.json', 'repos-cache.json', 'last-error.json', '.DS_Store'),
+        }),
+      ).toBe(path.join(home, '.config', 'nemus'));
     });
 
     it('honors an absolute XDG_CONFIG_HOME on a fresh install (any platform)', async () => {
       const { resolveNemusHome } = await loadModule();
-      expect(resolveNemusHome({ env: { XDG_CONFIG_HOME: '/cfg' }, home, platform: 'linux', exists: noState })).toBe('/cfg/nemus');
-      expect(resolveNemusHome({ env: { XDG_CONFIG_HOME: '/cfg' }, home, platform: 'darwin', exists: noState })).toBe('/cfg/nemus');
+      expect(resolveNemusHome({ env: { XDG_CONFIG_HOME: '/cfg' }, home, platform: 'linux', readDir: empty })).toBe('/cfg/nemus');
+      expect(resolveNemusHome({ env: { XDG_CONFIG_HOME: '/cfg' }, home, platform: 'darwin', readDir: empty })).toBe('/cfg/nemus');
     });
 
     it('ignores a relative XDG_CONFIG_HOME (per spec)', async () => {
       const { resolveNemusHome } = await loadModule();
-      expect(resolveNemusHome({ env: { XDG_CONFIG_HOME: 'rel/path' }, home, platform: 'linux', exists: noState })).toBe(
+      expect(resolveNemusHome({ env: { XDG_CONFIG_HOME: 'rel/path' }, home, platform: 'linux', readDir: empty })).toBe(
         path.join(home, '.config', 'nemus'),
       );
     });
 
     it('fresh-install default: Linux -> ~/.config/nemus, macOS/Windows -> ~/.nemus', async () => {
       const { resolveNemusHome } = await loadModule();
-      expect(resolveNemusHome({ env: {}, home, platform: 'linux', exists: noState })).toBe(path.join(home, '.config', 'nemus'));
-      expect(resolveNemusHome({ env: {}, home, platform: 'darwin', exists: noState })).toBe(path.join(home, '.nemus'));
-      expect(resolveNemusHome({ env: {}, home, platform: 'win32', exists: noState })).toBe(path.join(home, '.nemus'));
+      expect(resolveNemusHome({ env: {}, home, platform: 'linux', readDir: empty })).toBe(path.join(home, '.config', 'nemus'));
+      expect(resolveNemusHome({ env: {}, home, platform: 'darwin', readDir: empty })).toBe(branded);
+      expect(resolveNemusHome({ env: {}, home, platform: 'win32', readDir: empty })).toBe(branded);
     });
   });
 });

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -202,12 +202,21 @@ describe('config', () => {
   });
 
   describe('cache dir location + legacy migration', () => {
-    it('defaults CACHE_DIR to ~/.nemus when no env override is set', async () => {
+    // With XDG support a fresh install resolves to ~/.config/nemus on Linux and
+    // ~/.nemus elsewhere. Delete XDG_CONFIG_HOME so resolution is homedir-based
+    // (and stays inside the tempDir sandbox on any CI host).
+    const defaultHome = () =>
+      process.platform === 'linux'
+        ? path.join(tempDir, '.config', 'nemus')
+        : path.join(tempDir, '.nemus');
+
+    it('defaults CACHE_DIR to the platform default when no env override is set', async () => {
       delete process.env.NEMUS_CACHE_DIR;
       delete process.env.WORKSPACE_MANAGER_CACHE_DIR;
+      delete process.env.XDG_CONFIG_HOME;
       vi.resetModules();
       const { CACHE_DIR } = await loadModule();
-      expect(CACHE_DIR).toBe(path.join(tempDir, '.nemus'));
+      expect(CACHE_DIR).toBe(defaultHome());
     });
 
     it('prefers NEMUS_CACHE_DIR, then legacy WORKSPACE_MANAGER_CACHE_DIR', async () => {
@@ -222,41 +231,105 @@ describe('config', () => {
       expect((await loadModule()).CACHE_DIR).toBe(path.join(tempDir, '.workspace-manager-cache'));
     });
 
-    it('migrates state from ~/.workspace-manager-cache to ~/.nemus on first run', async () => {
+    it('migrates state from ~/.workspace-manager-cache to the default dir on first run', async () => {
       delete process.env.NEMUS_CACHE_DIR;
       delete process.env.WORKSPACE_MANAGER_CACHE_DIR;
+      delete process.env.XDG_CONFIG_HOME;
       // legacy dir (created by beforeEach) holds prior state; new dir absent
       fs.writeFileSync(path.join(tempDir, '.workspace-manager-cache', 'suites.json'), '{"x":1}');
-      expect(fs.existsSync(path.join(tempDir, '.nemus'))).toBe(false);
+      expect(fs.existsSync(defaultHome())).toBe(false);
       vi.resetModules();
       const { CACHE_DIR } = await loadModule();
-      expect(CACHE_DIR).toBe(path.join(tempDir, '.nemus'));
+      expect(CACHE_DIR).toBe(defaultHome());
       // copied, not moved: file exists in the new dir AND the legacy dir survives
-      expect(fs.readFileSync(path.join(tempDir, '.nemus', 'suites.json'), 'utf-8')).toBe('{"x":1}');
+      expect(fs.readFileSync(path.join(defaultHome(), 'suites.json'), 'utf-8')).toBe('{"x":1}');
       expect(fs.existsSync(path.join(tempDir, '.workspace-manager-cache', 'suites.json'))).toBe(true);
     });
 
     it('does not migrate last-version-check.json (avoids inheriting a foreign latest)', async () => {
       delete process.env.NEMUS_CACHE_DIR;
       delete process.env.WORKSPACE_MANAGER_CACHE_DIR;
+      delete process.env.XDG_CONFIG_HOME;
       const legacy = path.join(tempDir, '.workspace-manager-cache');
       fs.writeFileSync(path.join(legacy, 'suites.json'), '{"x":1}');
       fs.writeFileSync(path.join(legacy, 'last-version-check.json'), '{"latestVersion":"99.0.0"}');
       vi.resetModules();
       await loadModule();
       // other state migrates, but the version-check cache is left behind
-      expect(fs.existsSync(path.join(tempDir, '.nemus', 'suites.json'))).toBe(true);
-      expect(fs.existsSync(path.join(tempDir, '.nemus', 'last-version-check.json'))).toBe(false);
+      expect(fs.existsSync(path.join(defaultHome(), 'suites.json'))).toBe(true);
+      expect(fs.existsSync(path.join(defaultHome(), 'last-version-check.json'))).toBe(false);
     });
 
     it('does not migrate when the new dir already exists', async () => {
       delete process.env.NEMUS_CACHE_DIR;
       delete process.env.WORKSPACE_MANAGER_CACHE_DIR;
-      fs.mkdirSync(path.join(tempDir, '.nemus'), { recursive: true });
+      delete process.env.XDG_CONFIG_HOME;
+      fs.mkdirSync(defaultHome(), { recursive: true });
       fs.writeFileSync(path.join(tempDir, '.workspace-manager-cache', 'suites.json'), '{"x":1}');
       vi.resetModules();
       await loadModule();
-      expect(fs.existsSync(path.join(tempDir, '.nemus', 'suites.json'))).toBe(false);
+      expect(fs.existsSync(path.join(defaultHome(), 'suites.json'))).toBe(false);
+    });
+
+    it('keeps an existing ~/.nemus install even on Linux (no surprise XDG move)', async () => {
+      delete process.env.NEMUS_CACHE_DIR;
+      delete process.env.WORKSPACE_MANAGER_CACHE_DIR;
+      delete process.env.XDG_CONFIG_HOME;
+      const branded = path.join(tempDir, '.nemus');
+      fs.mkdirSync(branded, { recursive: true });
+      fs.writeFileSync(path.join(branded, 'config.json'), '{}'); // real prior state
+      vi.resetModules();
+      const { CACHE_DIR } = await loadModule();
+      expect(CACHE_DIR).toBe(branded);
+    });
+  });
+
+  describe('resolveNemusHome precedence', () => {
+    const home = '/home/u';
+    const noState = () => false;
+
+    it('explicit NEMUS_CACHE_DIR / legacy override wins over everything', async () => {
+      const { resolveNemusHome } = await loadModule();
+      expect(
+        resolveNemusHome({ env: { NEMUS_CACHE_DIR: '/x', XDG_CONFIG_HOME: '/c' }, home, platform: 'linux', exists: () => true }),
+      ).toBe('/x');
+      expect(
+        resolveNemusHome({ env: { WORKSPACE_MANAGER_CACHE_DIR: '/y' }, home, platform: 'linux', exists: () => true }),
+      ).toBe('/y');
+    });
+
+    it('an existing ~/.nemus with state wins over XDG, on any platform', async () => {
+      const { resolveNemusHome } = await loadModule();
+      const exists = (p: string) => p === path.join(home, '.nemus', 'config.json');
+      expect(resolveNemusHome({ env: { XDG_CONFIG_HOME: '/c' }, home, platform: 'linux', exists })).toBe(
+        path.join(home, '.nemus'),
+      );
+    });
+
+    it('a ~/.nemus holding only shell-integration.sh does NOT count as state', async () => {
+      const { resolveNemusHome } = await loadModule();
+      const exists = (p: string) => p === path.join(home, '.nemus', 'shell-integration.sh');
+      expect(resolveNemusHome({ env: {}, home, platform: 'linux', exists })).toBe(path.join(home, '.config', 'nemus'));
+    });
+
+    it('honors an absolute XDG_CONFIG_HOME on a fresh install (any platform)', async () => {
+      const { resolveNemusHome } = await loadModule();
+      expect(resolveNemusHome({ env: { XDG_CONFIG_HOME: '/cfg' }, home, platform: 'linux', exists: noState })).toBe('/cfg/nemus');
+      expect(resolveNemusHome({ env: { XDG_CONFIG_HOME: '/cfg' }, home, platform: 'darwin', exists: noState })).toBe('/cfg/nemus');
+    });
+
+    it('ignores a relative XDG_CONFIG_HOME (per spec)', async () => {
+      const { resolveNemusHome } = await loadModule();
+      expect(resolveNemusHome({ env: { XDG_CONFIG_HOME: 'rel/path' }, home, platform: 'linux', exists: noState })).toBe(
+        path.join(home, '.config', 'nemus'),
+      );
+    });
+
+    it('fresh-install default: Linux -> ~/.config/nemus, macOS/Windows -> ~/.nemus', async () => {
+      const { resolveNemusHome } = await loadModule();
+      expect(resolveNemusHome({ env: {}, home, platform: 'linux', exists: noState })).toBe(path.join(home, '.config', 'nemus'));
+      expect(resolveNemusHome({ env: {}, home, platform: 'darwin', exists: noState })).toBe(path.join(home, '.nemus'));
+      expect(resolveNemusHome({ env: {}, home, platform: 'win32', exists: noState })).toBe(path.join(home, '.nemus'));
     });
   });
 });

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -6,16 +6,38 @@ const HOME_DIR = os.homedir();
 
 const LEGACY_CACHE_DIR = path.join(HOME_DIR, '.workspace-manager-cache');
 
-// Files that mark a directory as a real Nemus state dir (as opposed to a
-// ~/.nemus that only holds shell-integration.sh). Used to decide whether an
-// existing install keeps its current location rather than switching to XDG.
-const STATE_MARKER_FILES = ['config.json', 'suites.json', 'history.jsonl'];
+// Entries in ~/.nemus that do NOT make it a "real install": regenerable caches
+// and the shell-integration artifact. Anything else (config.json, suites.json,
+// history.jsonl, the reflect/ report dir, or any future state) marks the dir as
+// an existing install to keep in place. Denylisting the throwaways — a small,
+// stable set — is exhaustive for durable state by construction, which is safer
+// than allowlisting state files (that could miss e.g. reflect/ and wrongly
+// relocate a real install to XDG on upgrade).
+const REGENERABLE_ENTRIES = new Set([
+  'last-version-check.json', // update-check cache
+  'repos-cache.json', // GitHub repo-list cache
+  'last-error.json', // last error, for report-bug
+  'shell-integration.sh', // shell installer artifact — not Nemus state
+  '.DS_Store',
+]);
 
 export interface NemusHomeEnv {
   env: NodeJS.ProcessEnv;
   home: string;
   platform: NodeJS.Platform;
-  exists: (p: string) => boolean;
+  /** List a directory's entries; throw (or return []) when it doesn't exist. */
+  readDir: (p: string) => string[];
+}
+
+/** True if ~/.nemus holds anything beyond regenerable caches / the shell artifact. */
+function hasDurableState(dir: string, readDir: (p: string) => string[]): boolean {
+  let entries: string[];
+  try {
+    entries = readDir(dir);
+  } catch {
+    return false; // dir doesn't exist
+  }
+  return entries.some((e) => !REGENERABLE_ENTRIES.has(e));
 }
 
 /**
@@ -23,8 +45,8 @@ export interface NemusHomeEnv {
  * match wins), designed so existing users are never silently moved:
  *
  *   1. Explicit override — NEMUS_CACHE_DIR (or legacy WORKSPACE_MANAGER_CACHE_DIR).
- *   2. An existing ~/.nemus that already holds Nemus state (config/suites/history)
- *      — keep using it, on every platform.
+ *   2. An existing ~/.nemus that holds durable state (anything beyond
+ *      regenerable caches / the shell-integration file) — kept on every platform.
  *   3. XDG_CONFIG_HOME, when set to an absolute path — $XDG_CONFIG_HOME/nemus.
  *   4. Linux with no prior install — the XDG default ~/.config/nemus.
  *   5. Otherwise (macOS/Windows, fresh install) — ~/.nemus.
@@ -34,13 +56,12 @@ export interface NemusHomeEnv {
  * XDG_CACHE_HOME, because it holds real config (config.json) — not disposable
  * cache a cleaner may wipe. A relative XDG_CONFIG_HOME is ignored per the spec.
  */
-export function resolveNemusHome({ env, home, platform, exists }: NemusHomeEnv): string {
+export function resolveNemusHome({ env, home, platform, readDir }: NemusHomeEnv): string {
   const explicit = env.NEMUS_CACHE_DIR || env.WORKSPACE_MANAGER_CACHE_DIR;
   if (explicit) return explicit;
 
   const branded = path.join(home, '.nemus');
-  const hasState = STATE_MARKER_FILES.some((f) => exists(path.join(branded, f)));
-  if (hasState) return branded;
+  if (hasDurableState(branded, readDir)) return branded;
 
   const xdg = env.XDG_CONFIG_HOME;
   if (xdg && path.isAbsolute(xdg)) return path.join(xdg, 'nemus');
@@ -85,7 +106,7 @@ const CACHE_DIR_RESOLVED = resolveNemusHome({
   env: process.env,
   home: HOME_DIR,
   platform: process.platform,
-  exists: fs.existsSync,
+  readDir: (p) => fs.readdirSync(p),
 });
 migrateLegacyCacheDir(CACHE_DIR_RESOLVED, EXPLICIT_OVERRIDE);
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -4,11 +4,51 @@ import * as fs from 'fs';
 
 const HOME_DIR = os.homedir();
 
-// Cache/config/state directory. Prefer the branded NEMUS_* env vars; fall back
-// to the legacy WORKSPACE_MANAGER_* names for backward compatibility; else the
-// default ~/.nemus home.
-const DEFAULT_CACHE_DIR = path.join(HOME_DIR, '.nemus');
 const LEGACY_CACHE_DIR = path.join(HOME_DIR, '.workspace-manager-cache');
+
+// Files that mark a directory as a real Nemus state dir (as opposed to a
+// ~/.nemus that only holds shell-integration.sh). Used to decide whether an
+// existing install keeps its current location rather than switching to XDG.
+const STATE_MARKER_FILES = ['config.json', 'suites.json', 'history.jsonl'];
+
+export interface NemusHomeEnv {
+  env: NodeJS.ProcessEnv;
+  home: string;
+  platform: NodeJS.Platform;
+  exists: (p: string) => boolean;
+}
+
+/**
+ * Resolve the directory that holds Nemus config + state. Precedence (first
+ * match wins), designed so existing users are never silently moved:
+ *
+ *   1. Explicit override — NEMUS_CACHE_DIR (or legacy WORKSPACE_MANAGER_CACHE_DIR).
+ *   2. An existing ~/.nemus that already holds Nemus state (config/suites/history)
+ *      — keep using it, on every platform.
+ *   3. XDG_CONFIG_HOME, when set to an absolute path — $XDG_CONFIG_HOME/nemus.
+ *   4. Linux with no prior install — the XDG default ~/.config/nemus.
+ *   5. Otherwise (macOS/Windows, fresh install) — ~/.nemus.
+ *
+ * Config + state are kept together in one dir (a later change may split cache
+ * out under XDG_CACHE_HOME). The dir is chosen under XDG_CONFIG_HOME, not
+ * XDG_CACHE_HOME, because it holds real config (config.json) — not disposable
+ * cache a cleaner may wipe. A relative XDG_CONFIG_HOME is ignored per the spec.
+ */
+export function resolveNemusHome({ env, home, platform, exists }: NemusHomeEnv): string {
+  const explicit = env.NEMUS_CACHE_DIR || env.WORKSPACE_MANAGER_CACHE_DIR;
+  if (explicit) return explicit;
+
+  const branded = path.join(home, '.nemus');
+  const hasState = STATE_MARKER_FILES.some((f) => exists(path.join(branded, f)));
+  if (hasState) return branded;
+
+  const xdg = env.XDG_CONFIG_HOME;
+  if (xdg && path.isAbsolute(xdg)) return path.join(xdg, 'nemus');
+
+  if (platform === 'linux') return path.join(home, '.config', 'nemus');
+
+  return branded;
+}
 
 /**
  * One-time, best-effort migration of state from the pre-0.2.2 cache location
@@ -21,11 +61,15 @@ const LEGACY_CACHE_DIR = path.join(HOME_DIR, '.workspace-manager-cache');
  * shared by another tool whose "latest version" is unrelated to nemus, and
  * copying it would make the update check report a wrong version until the entry
  * expires. Skipping it just forces one fresh lookup.
+ *
+ * Skipped when an explicit env override is in effect (don't copy into a path the
+ * user deliberately chose). Runs into whatever default location was resolved,
+ * including a new XDG dir on Linux.
  */
 const MIGRATION_SKIP = new Set(['last-version-check.json']);
-function migrateLegacyCacheDir(targetDir: string): void {
+function migrateLegacyCacheDir(targetDir: string, isExplicitOverride: boolean): void {
   try {
-    if (targetDir === DEFAULT_CACHE_DIR && !fs.existsSync(targetDir) && fs.existsSync(LEGACY_CACHE_DIR)) {
+    if (!isExplicitOverride && !fs.existsSync(targetDir) && fs.existsSync(LEGACY_CACHE_DIR)) {
       fs.cpSync(LEGACY_CACHE_DIR, targetDir, {
         recursive: true,
         filter: (src) => !MIGRATION_SKIP.has(path.basename(src)),
@@ -36,9 +80,14 @@ function migrateLegacyCacheDir(targetDir: string): void {
   }
 }
 
-const CACHE_DIR_RESOLVED =
-  process.env.NEMUS_CACHE_DIR || process.env.WORKSPACE_MANAGER_CACHE_DIR || DEFAULT_CACHE_DIR;
-migrateLegacyCacheDir(CACHE_DIR_RESOLVED);
+const EXPLICIT_OVERRIDE = !!(process.env.NEMUS_CACHE_DIR || process.env.WORKSPACE_MANAGER_CACHE_DIR);
+const CACHE_DIR_RESOLVED = resolveNemusHome({
+  env: process.env,
+  home: HOME_DIR,
+  platform: process.platform,
+  exists: fs.existsSync,
+});
+migrateLegacyCacheDir(CACHE_DIR_RESOLVED, EXPLICIT_OVERRIDE);
 
 // Config file lives inside the cache dir.
 const CONFIG_FILE = path.join(CACHE_DIR_RESOLVED, 'config.json');


### PR DESCRIPTION
Closes #77.

On Linux, a fresh install now stores config/state under **`$XDG_CONFIG_HOME/nemus`** (default `~/.config/nemus`) instead of `~/.nemus`, per the [XDG Base Directory spec](https://specifications.freedesktop.org/basedir-spec/latest/). **Existing installs are never silently moved.**

## Precedence (first match wins)
New pure, exported **`resolveNemusHome({ env, home, platform, exists })`**:

1. `NEMUS_CACHE_DIR` / `WORKSPACE_MANAGER_CACHE_DIR` — explicit override.
2. An existing `~/.nemus` that already holds **state** (`config.json`/`suites.json`/`history.jsonl`) — kept on **every** platform.
3. An **absolute** `XDG_CONFIG_HOME` → `$XDG_CONFIG_HOME/nemus` (a relative value is ignored, per spec).
4. Linux, no prior install → `~/.config/nemus`.
5. Otherwise (macOS/Windows, fresh) → `~/.nemus`.

## Two design points worth calling out
- **`XDG_CONFIG_HOME`, not `XDG_CACHE_HOME`.** The dir holds real config (`config.json`), not disposable cache a cleaner may wipe. Config + state stay in one dir for now (a later change could split cache under `XDG_CACHE_HOME`) — the issue explicitly allowed keeping them together.
- **"Existing install" keys on state *files*, not the bare dir.** #88 just made `~/.nemus/shell-integration.sh` a thing, so a naive `exists('~/.nemus')` check would wrongly pin config to `~/.nemus` for anyone who installed shell integration. The check looks for actual state files, so that case correctly still gets XDG.

## Safety / migration
- The legacy `~/.workspace-manager-cache` → new-dir migration now targets whatever default was resolved (incl. the XDG dir), and is skipped under an explicit override.
- Acceptance criteria: precedence documented (README env-var + Configuration sections) ✅, existing `~/.nemus` kept ✅, tests cover the matrix ✅.

## Tests (564 total)
- Pure `resolveNemusHome` precedence matrix (override / existing-state / shell-integration-only / absolute+relative XDG / per-platform defaults).
- "Keeps an existing `~/.nemus` even on Linux (no surprise move)."
- Existing migration tests made **platform- and XDG-robust** and kept inside the temp sandbox.

**0.14.0 → 0.15.0.**
