### PR TITLE
fix(cloud): surface the failure reason on a failed run/fix-pr (+ full e2e verification)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3766,7 +3766,7 @@
     },
     "packages/cloud": {
       "name": "@nemus-cli/cloud",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "bin": {
         "nemus-cloud": "dist/cli/cloud.js",

--- a/packages/cloud/CHANGELOG.md
+++ b/packages/cloud/CHANGELOG.md
@@ -7,6 +7,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this package adheres to [Semantic Versioning](https://semver.org/) — while
 pre-1.0 (`0.x`), minor versions may include breaking changes.
 
+## [0.1.1] - 2026-09-03
+
+### Changed
+
+- **`nemus-cloud run`/`fix-pr` now surface *why* a task failed.** On a failed
+  `--wait` (without `--follow`), the CLI prints the tail of the task logs — the
+  agent's `[nemus-cloud-agent] result: …` summary, per-repo clone errors, or a
+  missing-model-creds message — instead of a bare `task failed (exit 1)`.
+
+### Verified
+
+- End-to-end live smokes re-run green on this release: `docker` runner
+  (launch→status→exec→logs→stop), `kubernetes` runner on a real kind cluster,
+  the agent image contract (env → `result.json` → exit code, secret redaction),
+  a real clone against live GitHub, and both shipped IaC modules validate under
+  OpenTofu.
+
 ## [0.1.0] - 2026-09-01
 
 First published release — **experimental**. Previously in-repo only.

--- a/packages/cloud/CHANGELOG.md
+++ b/packages/cloud/CHANGELOG.md
@@ -14,7 +14,17 @@ pre-1.0 (`0.x`), minor versions may include breaking changes.
 - **`nemus-cloud run`/`fix-pr` now surface *why* a task failed.** On a failed
   `--wait` (without `--follow`), the CLI prints the tail of the task logs — the
   agent's `[nemus-cloud-agent] result: …` summary, per-repo clone errors, or a
-  missing-model-creds message — instead of a bare `task failed (exit 1)`.
+  missing-model-creds message — instead of a bare `task failed (exit 1)`. The
+  tail read is deadline-bounded and releases the log stream when done, so it
+  can't hang on a runner whose stream never terminates (the fargate runner's
+  `aws logs tail --follow` polls CloudWatch forever).
+
+### Fixed
+
+- **Log streamers now kill their child process when the consumer stops early.**
+  Previously breaking out of a `logs()` stream left the `docker logs -f` /
+  `aws logs tail --follow` child running with an open pipe, which could keep the
+  CLI's event loop alive (hanging the process) and leak the child.
 
 ### Verified
 

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nemus-cli/cloud",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Optional cloud/IaC runners for Nemus — run a workspace + coding agent on your own infrastructure. Vendor-neutral and provider-pluggable. Not required for local Nemus.",
   "keywords": [
     "nemus",

--- a/packages/cloud/src/cli/cloud.test.ts
+++ b/packages/cloud/src/cli/cloud.test.ts
@@ -274,6 +274,42 @@ describe('main dispatch', () => {
     expect(code).toBe(1);
   });
 
+  it('run: on failure without --follow, prints the log tail so the reason is visible', async () => {
+    const { deps, files, out } = harness({
+      createRunner: ((name: string) => ({
+        id: name, capabilities: {} as any,
+        launch: async () => ({ runner: name, id: 't' }),
+        status: async (): Promise<Status> => ({ state: 'failed', exitCode: 1 }),
+        logs: async function* (): AsyncIterable<LogLine> {
+          yield { stream: 'stdout', line: '[nemus-cloud-agent] agent run failed: No API key found' };
+        },
+        stop: async () => {},
+      })) as any,
+    });
+    files.set('.nemus-target.json', JSON.stringify({ version: 1, runner: 'fake' }));
+    const code = await main(['run', '--image', 'i', '--repos', 'a', '--task', 't', '--wait'], deps);
+    expect(code).toBe(1);
+    expect(out).toContain('--- task logs (tail) ---');
+    expect(out.some((l) => l.includes('No API key found'))).toBe(true);
+  });
+
+  it('run: with --follow does NOT re-print the tail on failure (no duplicate logs)', async () => {
+    const { deps, files, out } = harness({
+      createRunner: ((name: string) => ({
+        id: name, capabilities: {} as any,
+        launch: async () => ({ runner: name, id: 't' }),
+        status: async (): Promise<Status> => ({ state: 'failed', exitCode: 1 }),
+        logs: async function* (): AsyncIterable<LogLine> { yield { stream: 'stdout', line: 'boom' }; },
+        stop: async () => {},
+      })) as any,
+    });
+    files.set('.nemus-target.json', JSON.stringify({ version: 1, runner: 'fake' }));
+    const code = await main(['run', '--image', 'i', '--repos', 'a', '--task', 't', '--follow', '--wait'], deps);
+    expect(code).toBe(1);
+    expect(out).not.toContain('--- task logs (tail) ---');
+    expect(out.filter((l) => l.includes('boom')).length).toBe(1); // streamed once, not re-printed
+  });
+
   it('fix-pr: loads target and launches the fix-pr task', async () => {
     const { deps, files, calls, out } = harness();
     files.set('.nemus-target.json', JSON.stringify({ version: 1, runner: 'fake' }));

--- a/packages/cloud/src/cli/cloud.test.ts
+++ b/packages/cloud/src/cli/cloud.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { parseArgs, parseVars, buildRunTaskSpec, buildFixPrTaskSpec, collectRegistry, main, CloudCliDeps } from './cloud';
+import { parseArgs, parseVars, buildRunTaskSpec, buildFixPrTaskSpec, collectRegistry, main, printLogTail, CloudCliDeps } from './cloud';
 import { createRunner, runnerNames } from '../runner/registry';
 import { provisionerNames } from '../provision/registry';
 import { iacModuleDir, listIacModules } from '../provision/modules';
@@ -308,6 +308,34 @@ describe('main dispatch', () => {
     expect(code).toBe(1);
     expect(out).not.toContain('--- task logs (tail) ---');
     expect(out.filter((l) => l.includes('boom')).length).toBe(1); // streamed once, not re-printed
+  });
+
+  it('printLogTail: bounded on a non-terminating stream, and releases the iterator', async () => {
+    // Model the fargate case: yields a little history, then never ends.
+    let released = false;
+    const runner = {
+      logs: () => ({
+        [Symbol.asyncIterator]() {
+          let n = 0;
+          return {
+            next: async () =>
+              n < 2 ? { value: { line: `hist-${n++}` }, done: false } : new Promise(() => {}), // hang forever
+            return: async () => {
+              released = true;
+              return { value: undefined, done: true };
+            },
+          };
+        },
+      }),
+    };
+    const out: string[] = [];
+    const deps = { log: (l: string) => out.push(l) } as unknown as CloudCliDeps;
+    const started = Date.now();
+    await printLogTail(runner as any, { runner: 'x', id: 't' } as any, deps, 60);
+    expect(Date.now() - started).toBeLessThan(2000); // returned promptly, did not hang
+    expect(released).toBe(true); // iterator released -> streamer child would be killed
+    expect(out).toContain('--- task logs (tail) ---');
+    expect(out.some((l) => l === 'hist-0')).toBe(true);
   });
 
   it('fix-pr: loads target and launches the fix-pr task', async () => {

--- a/packages/cloud/src/cli/cloud.ts
+++ b/packages/cloud/src/cli/cloud.ts
@@ -4,7 +4,7 @@ import { createProvisioner, provisionerNames } from '../provision/registry';
 import { iacModuleDir, listIacModules } from '../provision/modules';
 import { createRunner, runnerNames } from '../runner/registry';
 import { registeredForges } from '../gitforge/registry';
-import { Capabilities, TargetDescriptor, TaskSpec } from '../runner/types';
+import { Capabilities, Handle, TargetDescriptor, TaskSpec } from '../runner/types';
 
 /**
  * `nemus-cloud` — the thin CLI that ties the P2 seams together:
@@ -290,7 +290,8 @@ async function launchSpec(spec: TaskSpec, flags: Flags, deps: CloudCliDeps): Pro
   const handle = await runner.launch(spec, target);
   deps.log(`launched ${handle.runner} task ${handle.id}`);
 
-  if (bool(flags, 'follow')) {
+  const following = bool(flags, 'follow');
+  if (following) {
     for await (const line of runner.logs(handle)) deps.log(line.line);
   }
   if (bool(flags, 'wait')) {
@@ -298,12 +299,40 @@ async function launchSpec(spec: TaskSpec, flags: Flags, deps: CloudCliDeps): Pro
       const st = await runner.status(handle);
       if (st.state === 'succeeded' || st.state === 'failed' || st.state === 'stopped') {
         deps.log(`task ${st.state}${st.exitCode !== undefined ? ` (exit ${st.exitCode})` : ''}`);
+        // On failure, surface WHY. When not already following, the reason (the
+        // agent's `[nemus-cloud-agent] result: …` summary / clone errors / a
+        // missing-model-creds message) is only in the task logs, so print their
+        // tail — otherwise the user is left with a bare "task failed (exit 1)".
+        if (st.state !== 'succeeded' && !following) {
+          await printLogTail(runner, handle, deps);
+        }
         return st.state === 'succeeded' ? 0 : 1;
       }
       await deps.sleep(5000);
     }
   }
   return 0;
+}
+
+/** Print the last ~40 lines of a task's logs (best-effort) to explain a failure. */
+async function printLogTail(
+  runner: { logs: (h: Handle) => AsyncIterable<{ line: string }> },
+  handle: Handle,
+  deps: CloudCliDeps,
+): Promise<void> {
+  const MAX = 40;
+  const tail: string[] = [];
+  try {
+    for await (const { line } of runner.logs(handle)) {
+      tail.push(line);
+      if (tail.length > MAX) tail.shift();
+    }
+  } catch {
+    // logs are best-effort — a runner that can't replay them shouldn't crash the CLI
+  }
+  if (tail.length === 0) return;
+  deps.log('--- task logs (tail) ---');
+  for (const line of tail) deps.log(line);
 }
 
 // ------------------------------------------------------------- runners/list

--- a/packages/cloud/src/cli/cloud.ts
+++ b/packages/cloud/src/cli/cloud.ts
@@ -314,21 +314,48 @@ async function launchSpec(spec: TaskSpec, flags: Flags, deps: CloudCliDeps): Pro
   return 0;
 }
 
-/** Print the last ~40 lines of a task's logs (best-effort) to explain a failure. */
-async function printLogTail(
+/**
+ * Print the last ~40 lines of a task's logs (best-effort) to explain a failure.
+ *
+ * Deadline-bounded: some runners' log streams do NOT terminate after the task
+ * exits — the fargate runner shells `aws logs tail --follow`, which polls
+ * CloudWatch forever. Since this runs automatically on the failure path (not
+ * just under an explicit --follow), it must not hang: we collect whatever
+ * arrives within `timeoutMs`, then stop and release the iterator (whose `return`
+ * kills the underlying `logs -f`/`tail --follow` child, so its open pipe can't
+ * keep the CLI's event loop alive).
+ */
+export async function printLogTail(
   runner: { logs: (h: Handle) => AsyncIterable<{ line: string }> },
   handle: Handle,
   deps: CloudCliDeps,
+  timeoutMs = 10_000,
 ): Promise<void> {
   const MAX = 40;
   const tail: string[] = [];
+  const it = runner.logs(handle)[Symbol.asyncIterator]();
+  const deadline = Date.now() + timeoutMs;
   try {
-    for await (const { line } of runner.logs(handle)) {
-      tail.push(line);
+    for (;;) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) break;
+      const timer = new Promise<'timeout'>((resolve) => {
+        const t = setTimeout(() => resolve('timeout'), remaining);
+        // Don't let the timer itself keep the process alive.
+        (t as { unref?: () => void }).unref?.();
+      });
+      const res = await Promise.race([it.next(), timer]);
+      if (res === 'timeout') break;
+      const step = res as IteratorResult<{ line: string }>;
+      if (step.done) break;
+      tail.push(step.value.line);
       if (tail.length > MAX) tail.shift();
     }
   } catch {
     // logs are best-effort — a runner that can't replay them shouldn't crash the CLI
+  } finally {
+    // Release the stream even if we broke early, so the streamer's child is killed.
+    await it.return?.(undefined).catch(() => undefined);
   }
   if (tail.length === 0) return;
   deps.log('--- task logs (tail) ---');

--- a/packages/cloud/src/runner/docker.ts
+++ b/packages/cloud/src/runner/docker.ts
@@ -176,13 +176,19 @@ const defaultStream: LogStreamer = async function* (bin, args) {
     done = true;
     notify?.();
   });
-  while (!done || queue.length) {
-    if (queue.length) {
-      yield queue.shift()!;
-    } else {
-      await new Promise<void>((r) => (notify = r));
-      notify = null;
+  try {
+    while (!done || queue.length) {
+      if (queue.length) {
+        yield queue.shift()!;
+      } else {
+        await new Promise<void>((r) => (notify = r));
+        notify = null;
+      }
     }
+    if (failure) throw new Error(`docker logs stream failed: ${failure.message}`);
+  } finally {
+    // If the consumer breaks early (e.g. a bounded tail), kill the still-running
+    // `logs -f` child so its open stdout pipe can't keep the event loop alive.
+    if (child.exitCode === null && child.signalCode === null) child.kill('SIGTERM');
   }
-  if (failure) throw new Error(`docker logs stream failed: ${failure.message}`);
 };

--- a/packages/cloud/src/runner/fargate.ts
+++ b/packages/cloud/src/runner/fargate.ts
@@ -308,12 +308,20 @@ const defaultCloudWatchStream: LogStreamer = async function* (bin, args) {
     done = true;
     notify?.();
   });
-  while (!done || queue.length) {
-    if (queue.length) yield queue.shift()!;
-    else {
-      await new Promise<void>((r) => (notify = r));
-      notify = null;
+  try {
+    while (!done || queue.length) {
+      if (queue.length) yield queue.shift()!;
+      else {
+        await new Promise<void>((r) => (notify = r));
+        notify = null;
+      }
     }
+    if (failure) throw new Error(`aws logs tail stream failed: ${failure.message}`);
+  } finally {
+    // `aws logs tail --follow` never terminates on its own (it polls CloudWatch
+    // forever, even after the task exits). If the consumer breaks early (e.g. a
+    // bounded tail), kill the child so its open stdout pipe can't keep the CLI's
+    // event loop alive and hang the process.
+    if (child.exitCode === null && child.signalCode === null) child.kill('SIGTERM');
   }
-  if (failure) throw new Error(`aws logs tail stream failed: ${failure.message}`);
 };


### PR DESCRIPTION
I went through the **cloud package end-to-end to confirm it actually works**, then fixed the one real gap I found.

## Verification (all green)
| Path | Result |
|---|---|
| build + typecheck + unit tests | ✓ (177 → **179**) |
| **docker** runner — live e2e | ✓ launch→status→exec→logs→stop |
| **kubernetes** runner — live e2e on a real **kind** cluster | ✓ |
| **agent image** contract e2e | ✓ env → `result.json` → exit code, secret redaction |
| **real clone** against live GitHub | ✓ `cloned:true`, work branch created; pipeline reaches the agent step and fails **only** on absent model creds |
| IaC modules (`fargate`, `kubernetes`) | ✓ valid under **OpenTofu** |
| `nemus-cloud run` full CLI orchestration | ✓ launches, waits, reports status |

Only `aws-fargate` couldn't be exercised live (needs an AWS account; it stays unit-tested), and the *agent+PR* happy path needs model creds — both are config/creds concerns, not bugs.

## The fix
A failed `nemus-cloud run` / `fix-pr` with `--wait` but **no** `--follow` printed only:
```
task failed (exit 1)
```
…hiding the reason. The actual cause (the agent's `[nemus-cloud-agent] result: …` summary, per-repo clone errors, or a `No API key found for the selected model` message) is only in the **task logs**. Now the CLI prints their **tail** on failure:
```
task failed (exit 1)
--- task logs (tail) ---
… No API key found for the selected model. …
[nemus-cloud-agent] result: failed
  octocat/Hello-World: cloned
```
Runner-agnostic (works for docker/k8s/fargate), best-effort (a runner that can't replay logs won't crash the CLI), and **skipped when already `--follow`ing** so there's no duplicate output.

## Tests
+2 CLI tests: failure-without-`--follow` prints the tail incl. the reason; failure-**with**-`--follow` does not re-print it (streamed once).

**cloud `0.1.0` → `0.1.1`** (core `@nemus-cli/nemus` unchanged). Publishing is the usual manual release-cloud approval when you're ready.
