### PR TITLE
feat(cloud): --env passthrough so run/fix-pr can supply model credentials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3766,7 +3766,7 @@
     },
     "packages/cloud": {
       "name": "@nemus-cli/cloud",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "bin": {
         "nemus-cloud": "dist/cli/cloud.js",

--- a/packages/cloud/CHANGELOG.md
+++ b/packages/cloud/CHANGELOG.md
@@ -7,6 +7,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this package adheres to [Semantic Versioning](https://semver.org/) — while
 pre-1.0 (`0.x`), minor versions may include breaking changes.
 
+## [0.1.2] - 2026-09-03
+
+### Added
+
+- **`nemus-cloud run`/`fix-pr` gain `--env KEY=VAL|KEY` (repeatable)** to pass
+  extra environment into the agent container. `KEY=VAL` sets a literal; a bare
+  `KEY` forwards its value from your shell (so secrets stay out of argv/history).
+  This is how **model credentials/config** reach the agent on runners that don't
+  inject them ambiently (docker, kubernetes) — e.g. an Anthropic key, AWS creds
+  for Bedrock, or `NEMUS_AGENT_ARGS` to select the provider/model. The fixed
+  task contract (`NEMUS_REPOS`/`NEMUS_TASK`/forge auth/…) always wins over a
+  colliding `--env` key. Before this, the CLI forwarded only forge auth, so a
+  local/docker run had no way to authenticate the model — you had to drive the
+  runner API directly.
+
+### Verified
+
+- **Full happy path proven end-to-end**: `nemus-cloud` → docker runner → agent
+  image → clone a real GitHub repo → pi on Bedrock edits it → commit → push →
+  **opens a real PR** with the expected diff.
+
 ## [0.1.1] - 2026-09-03
 
 ### Changed

--- a/packages/cloud/CHANGELOG.md
+++ b/packages/cloud/CHANGELOG.md
@@ -17,10 +17,11 @@ pre-1.0 (`0.x`), minor versions may include breaking changes.
   This is how **model credentials/config** reach the agent on runners that don't
   inject them ambiently (docker, kubernetes) — e.g. an Anthropic key, AWS creds
   for Bedrock, or `NEMUS_AGENT_ARGS` to select the provider/model. The fixed
-  task contract (`NEMUS_REPOS`/`NEMUS_TASK`/forge auth/…) always wins over a
-  colliding `--env` key. Before this, the CLI forwarded only forge auth, so a
-  local/docker run had no way to authenticate the model — you had to drive the
-  runner API directly.
+  task contract (`NEMUS_REPOS`/`NEMUS_TASK`/…) always wins over a colliding
+  `--env` key. Forge auth can also be supplied this way (`--env GITHUB_TOKEN`)
+  in addition to the ambient environment. Before this, the CLI forwarded only
+  forge auth, so a local/docker run had no way to authenticate the model — you
+  had to drive the runner API directly.
 
 ### Verified
 

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nemus-cli/cloud",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Optional cloud/IaC runners for Nemus — run a workspace + coding agent on your own infrastructure. Vendor-neutral and provider-pluggable. Not required for local Nemus.",
   "keywords": [
     "nemus",

--- a/packages/cloud/src/cli/cloud.test.ts
+++ b/packages/cloud/src/cli/cloud.test.ts
@@ -88,6 +88,14 @@ describe('buildRunTaskSpec', () => {
     expect(spec.env!.NEMUS_TASK).toBe('do it');
   });
 
+  it('accepts forge auth supplied via --env (no separate env var needed)', () => {
+    const spec = buildRunTaskSpec(
+      { ...flags, env: ['GITHUB_TOKEN=via-env'] },
+      {}, // nothing in the process environment
+    );
+    expect(spec.env!.GITHUB_TOKEN).toBe('via-env');
+  });
+
   it('requires image/repos/task and forge auth', () => {
     expect(() => buildRunTaskSpec({ repos: 'a', task: 't' }, { GITHUB_TOKEN: 't' })).toThrow(/--image/);
     expect(() => buildRunTaskSpec({ image: 'i', task: 't' }, { GITHUB_TOKEN: 't' })).toThrow(/--repos/);

--- a/packages/cloud/src/cli/cloud.test.ts
+++ b/packages/cloud/src/cli/cloud.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { parseArgs, parseVars, buildRunTaskSpec, buildFixPrTaskSpec, collectRegistry, main, printLogTail, CloudCliDeps } from './cloud';
+import { parseArgs, parseVars, parseEnvPassthrough, buildRunTaskSpec, buildFixPrTaskSpec, collectRegistry, main, printLogTail, CloudCliDeps } from './cloud';
 import { createRunner, runnerNames } from '../runner/registry';
 import { provisionerNames } from '../provision/registry';
 import { iacModuleDir, listIacModules } from '../provision/modules';
@@ -30,6 +30,22 @@ describe('parseVars', () => {
   });
 });
 
+describe('parseEnvPassthrough', () => {
+  const src = { AWS_ACCESS_KEY_ID: 'AKIA', EMPTY: '', NEMUS_AGENT_ARGS: '-p {task} --provider amazon-bedrock' };
+  it('sets KEY=VAL literally (keeping = in the value) and forwards bare KEY from the environment', () => {
+    expect(parseEnvPassthrough(['AWS_REGION=us-east-1', 'AWS_ACCESS_KEY_ID'], src)).toEqual({
+      AWS_REGION: 'us-east-1',
+      AWS_ACCESS_KEY_ID: 'AKIA',
+    });
+    // value may itself contain '='
+    expect(parseEnvPassthrough(['NEMUS_AGENT_ARGS=-m a=b'], src)).toEqual({ 'NEMUS_AGENT_ARGS': '-m a=b' });
+  });
+  it('skips a bare KEY that is not set (but forwards an explicitly-empty one)', () => {
+    expect(parseEnvPassthrough(['MISSING'], src)).toEqual({});
+    expect(parseEnvPassthrough(['EMPTY'], src)).toEqual({ EMPTY: '' });
+  });
+});
+
 describe('buildRunTaskSpec', () => {
   const flags = { image: 'img', repos: 'acme/api,acme/web', task: 'do it', owner: 'acme' };
 
@@ -56,6 +72,20 @@ describe('buildRunTaskSpec', () => {
     });
     expect(spec.env).toMatchObject({ GITHUB_APP_ID: '1', GITHUB_APP_INSTALLATION_ID: '2' });
     expect(spec.env!.GITHUB_TOKEN).toBeUndefined();
+  });
+
+  it('forwards --env model creds/config into the container, without overriding the contract', () => {
+    const spec = buildRunTaskSpec(
+      { ...flags, env: ['AWS_ACCESS_KEY_ID', 'AWS_REGION=us-east-1', 'NEMUS_AGENT_ARGS=-p {task} --provider amazon-bedrock', 'NEMUS_TASK=hijack'] },
+      { GITHUB_TOKEN: 't', AWS_ACCESS_KEY_ID: 'AKIA' },
+    );
+    expect(spec.env).toMatchObject({
+      AWS_ACCESS_KEY_ID: 'AKIA',
+      AWS_REGION: 'us-east-1',
+      NEMUS_AGENT_ARGS: '-p {task} --provider amazon-bedrock',
+    });
+    // the fixed contract wins over a colliding --env key
+    expect(spec.env!.NEMUS_TASK).toBe('do it');
   });
 
   it('requires image/repos/task and forge auth', () => {

--- a/packages/cloud/src/cli/cloud.ts
+++ b/packages/cloud/src/cli/cloud.ts
@@ -246,7 +246,14 @@ export function buildFixPrTaskSpec(flags: Flags, env: NodeJS.ProcessEnv): TaskSp
 function injectForgeEnv(taskEnv: Record<string, string>, env: NodeJS.ProcessEnv, cmd: string): void {
   const token = env.GITHUB_TOKEN || env.GIT_TOKEN;
   const hasApp = !!(env.GITHUB_APP_ID && env.GITHUB_APP_PRIVATE_KEY && env.GITHUB_APP_INSTALLATION_ID);
-  if (!token && !hasApp) {
+  // Forge auth may already have been supplied via --env (spread into taskEnv
+  // before this runs) — accept that too, so `--env GITHUB_TOKEN=…` works and
+  // doesn't confusingly fail with "no forge auth".
+  const hasEnvForge = !!(
+    taskEnv.GITHUB_TOKEN ||
+    (taskEnv.GITHUB_APP_ID && taskEnv.GITHUB_APP_PRIVATE_KEY && taskEnv.GITHUB_APP_INSTALLATION_ID)
+  );
+  if (!token && !hasApp && !hasEnvForge) {
     throw new Error(`${cmd}: no forge auth — set GITHUB_TOKEN (or GITHUB_APP_ID/_PRIVATE_KEY/_INSTALLATION_ID)`);
   }
   if (token) taskEnv.GITHUB_TOKEN = token;

--- a/packages/cloud/src/cli/cloud.ts
+++ b/packages/cloud/src/cli/cloud.ts
@@ -122,6 +122,33 @@ export function parseVars(list: string[]): Record<string, string> {
   return out;
 }
 
+/**
+ * Parse repeatable `--env` into extra container env. `KEY=VAL` sets a literal
+ * value; a bare `KEY` forwards `KEY`'s value from the caller's environment
+ * (handy for secrets you don't want in argv / shell history). A bare key that
+ * isn't set in the environment is skipped.
+ *
+ * This is how model credentials/config reach the agent on runners that don't
+ * inject them ambiently (docker, kubernetes) — e.g. an Anthropic key, AWS creds
+ * for Bedrock, or `NEMUS_AGENT_ARGS` to pick the provider/model:
+ *   --env ANTHROPIC_API_KEY
+ *   --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN --env AWS_REGION=us-east-1
+ *   --env 'NEMUS_AGENT_ARGS=-p {task} --provider amazon-bedrock --model us.anthropic.claude-haiku-4-5-20251001-v1:0'
+ */
+export function parseEnvPassthrough(list: string[], sourceEnv: NodeJS.ProcessEnv): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const item of list) {
+    const eq = item.indexOf('=');
+    if (eq !== -1) {
+      out[item.slice(0, eq)] = item.slice(eq + 1);
+    } else {
+      const v = sourceEnv[item];
+      if (v !== undefined) out[item] = v;
+    }
+  }
+  return out;
+}
+
 // -------------------------------------------------------------- run TaskSpec
 
 /** Build the agent TaskSpec (image + the runner-image env contract) from flags.
@@ -139,6 +166,8 @@ export function buildRunTaskSpec(flags: Flags, env: NodeJS.ProcessEnv): TaskSpec
   const report = str(flags, 'report') ?? 'pr';
 
   const taskEnv: Record<string, string> = {
+    // --env passthrough first, so the fixed contract below always wins.
+    ...parseEnvPassthrough(multi(flags, 'env'), env),
     NEMUS_REPOS: repos,
     NEMUS_TASK: task,
     NEMUS_AGENT: agent,
@@ -177,6 +206,8 @@ export function buildFixPrTaskSpec(flags: Flags, env: NodeJS.ProcessEnv): TaskSp
   const agent = str(flags, 'agent') ?? 'pi';
   const owner = str(flags, 'owner');
   const taskEnv: Record<string, string> = {
+    // --env passthrough first, so the fixed contract below always wins.
+    ...parseEnvPassthrough(multi(flags, 'env'), env),
     NEMUS_MODE: 'fix-pr',
     NEMUS_REPOS: repo,
     NEMUS_PR_NUMBER: pr,
@@ -451,16 +482,24 @@ Usage:
   nemus-cloud down  [--target FILE] --module <name|--module-dir dir> [--var k=v]...
   nemus-cloud run   --image REF --repos a,b --task "..." [--target FILE]
                     [--agent pi] [--owner ORG] [--report pr|none] [--cpu N] [--memory MB]
-                    [--git-host HOST] [--follow] [--wait]
+                    [--git-host HOST] [--env KEY=VAL|KEY]... [--follow] [--wait]
   nemus-cloud fix-pr --image REF --repo owner/name --pr N --branch HEAD [--target FILE]
                     [--agent pi] [--owner ORG] [--task "..."] [--git-host HOST]
                     [--max-iterations N] [--poll-interval-ms N] [--max-polls N]
-                    [--cpu N] [--memory MB] [--follow] [--wait]
+                    [--cpu N] [--memory MB] [--env KEY=VAL|KEY]... [--follow] [--wait]
 
 Forge auth for \`run\`/\`fix-pr\` comes from the environment: GITHUB_TOKEN, or
 GITHUB_APP_ID/_PRIVATE_KEY/_INSTALLATION_ID. Target a different host with
 NEMUS_FORGE_HOST=gitlab (+ GITLAB_API_URL); report out-of-band with
-SLACK_WEBHOOK_URL / NEMUS_WEBHOOK_URL.`;
+SLACK_WEBHOOK_URL / NEMUS_WEBHOOK_URL.
+
+Model credentials/config reach the agent via --env (repeatable): KEY=VAL sets a
+literal; a bare KEY forwards its value from your shell (good for secrets).
+Runners that inject creds ambiently (e.g. a fargate task role) don't need it;
+docker/kubernetes do. Bedrock example:
+  --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN
+  --env AWS_REGION=us-east-1
+  --env 'NEMUS_AGENT_ARGS=-p {task} --provider amazon-bedrock --model us.anthropic.claude-haiku-4-5-20251001-v1:0'`;
 
 export async function main(argv: string[], deps: CloudCliDeps = defaultDeps): Promise<number> {
   const { cmd, flags } = parseArgs(argv);


### PR DESCRIPTION
Follow-up from proving the cloud happy path end-to-end.

## The gap
`nemus-cloud run`/`fix-pr` forwarded only **forge auth** (`GITHUB_TOKEN`/App creds) into the agent container. On runners without ambient credentials — **docker, kubernetes** — there was **no way to authenticate the coding agent's model**. A local run could clone the repo but never actually run the agent. (While verifying the package I could only get the full pipeline to run by driving the runner API directly with a full env.)

## The fix — `--env KEY=VAL|KEY` (repeatable) on `run` + `fix-pr`
- `KEY=VAL` sets a literal value; a **bare `KEY`** forwards its value from your shell, so secrets stay out of argv / shell history.
- This is how model creds/config now reach the agent: an Anthropic key, AWS creds for Bedrock, or `NEMUS_AGENT_ARGS` to pick the provider/model.
- Merged into the task env **before** the fixed contract, so `NEMUS_REPOS`/`NEMUS_TASK`/forge auth always win over a colliding `--env` key.
- Help/usage documents the Bedrock recipe.

```
nemus-cloud run --image … --repos owner/repo --task "…" --target target.json --report pr \
  --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN --env AWS_REGION=us-east-1 \
  --env 'NEMUS_AGENT_ARGS=-p {task} --provider amazon-bedrock --model us.anthropic.claude-haiku-4-5-…'
```

## Proven end-to-end
`nemus-cloud` → docker runner → agent image → clone a real GitHub repo → **pi on Bedrock edits it → commit → push → opens a real PR** with the expected diff; and the same **through the CLI** with `--env` delivering the Bedrock creds (agent cloned + invoked the model). Runners that inject creds ambiently (fargate task role) don't need `--env`.

## Tests
+`parseEnvPassthrough` (literal / bare-forward / skip-unset / keep `=` in value) and run+fix-pr wiring (creds forwarded; contract wins over a colliding key). **183** unit tests.

`cloud 0.1.1 → 0.1.2` (core unchanged).
