### PR TITLE
fix(activation): npx no longer hangs + cloud quickstart & BYO-model docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.1] - 2026-09-04
+
+### Fixed
+
+- **`npx @nemus-cli/nemus …` no longer hangs.** The postinstall first-run setup
+  (interactive `nemus configure`, shell-integration install) now runs **only on
+  a global install** (`npm i -g`). A transient `npx` run or a local dependency
+  install is not global — the `nemus`/`nem` bins aren't persisted on PATH, so
+  shell integration is pointless, and the interactive `configure` reached the
+  controlling terminal via `/dev/tty` and hung a non-interactive
+  `npx … --help`/`--version`. Global installs are unchanged.
+
+### Added
+
+- **Zero-install usage** documented: `npx @nemus-cli/nemus <command>` runs any
+  command without installing or touching your shell.
+
 ## [0.15.0] - 2026-09-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -140,7 +140,20 @@ npm install -g @nemus-cli/nemus
 The postinstall step sets up optional shell integration (auto-cd into new
 workspaces + a quick-navigate helper). It keeps the generated functions in
 `~/.nemus/shell-integration.sh` and adds only a guarded source line to your
-shell RC file, so upgrades don't churn your `.zshrc`/`.bashrc`.
+shell RC file, so upgrades don't churn your `.zshrc`/`.bashrc`. First-time setup
+(`nemus configure`) runs automatically **only on a global install** — a
+throwaway `npx` run or a local dependency install leaves your shell untouched.
+
+### Try it without installing
+
+```bash
+npx @nemus-cli/nemus list          # run any command via npx
+npx @nemus-cli/nemus -- "…"         # or the AI prompt
+```
+
+Zero install, nothing added to your PATH or shell RC. (Shell integration and
+auto-cd only make sense once the `nemus`/`nem` bins are on your PATH, so install
+globally when you want those.)
 
 ### From source
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nemus-cli/nemus",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nemus-cli/nemus",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "workspaces": [
     "packages/*"
   ],

--- a/packages/cloud/README.md
+++ b/packages/cloud/README.md
@@ -64,6 +64,83 @@ Standalone (no dependency on the core `@nemus-cli/nemus` CLI) and
 zero-runtime-dependency. Requires Node ≥ 22, plus whatever a given backend shells
 out to (`docker`, `kubectl`, `aws`, `tofu`/`terraform`, `git`, `gh`).
 
+## Quickstart (5 minutes)
+
+Prove the whole thing on your own machine with the **in-box `docker` runner** —
+no cloud account, no provisioning. You'll go from a task to a **real PR**:
+clone → agent edits → commit → push → open PR.
+
+**Prerequisites:** a running Docker daemon, `gh auth login` (for a token), and
+model credentials (see [Bring your own model](#bring-your-own-model) — the
+example below uses an Anthropic key).
+
+```bash
+# 1) Build the agent image (no prebuilt image is published yet — it builds from
+#    the repo so you can audit exactly what runs).
+git clone https://github.com/me-public/nemus.git && cd nemus
+npm ci && npm run build -w @nemus-cli/cloud
+docker build -f packages/cloud/image/Dockerfile -t nemus-cloud-agent .
+
+# 2) Point at the in-box docker runner (no IaC needed for local Docker).
+echo '{"version":1,"runner":"docker"}' > .nemus-target.json
+
+# 3) Hand it a task against a repo you can open a PR on. Forge auth comes from
+#    the environment; the model creds ride in via --env (bare KEY forwards the
+#    value from your shell, so it stays out of argv / history).
+export GITHUB_TOKEN=$(gh auth token)
+export ANTHROPIC_API_KEY=sk-ant-...
+
+npx nemus-cloud run \
+  --image nemus-cloud-agent \
+  --repos <you>/<repo> --owner <you> \
+  --task "Add a short 'Running tests' note to CONTRIBUTING.md" \
+  --report pr --follow --wait \
+  --env ANTHROPIC_API_KEY
+```
+
+You'll see the agent clone, edit, push, and print the PR URL:
+
+```
+[nemus-cloud-agent] result: ok
+  <you>/<repo>: PR https://github.com/<you>/<repo>/pull/1
+task succeeded (exit 0)
+```
+
+That's the full happy path on real infrastructure you control. To go bigger,
+swap the runner (`aws-fargate`, `kubernetes`) via an [IaC module](#the-provisioning-seam-iac-modules)
+and keep the exact same `run` command.
+
+## Bring your own model
+
+The agent image runs a coding-agent CLI (`pi` by default, `claude` via
+`--env NEMUS_AGENT=claude`) and hands it your task. **Model auth is the agent's
+job** — you supply it through `--env`, which forwards credentials/config into the
+container. Runners that inject credentials ambiently (e.g. a Fargate **task
+role**) don't need `--env` for them at all.
+
+`--env KEY=VAL` sets a literal; a bare `--env KEY` forwards `KEY`'s value from
+your shell (keeps secrets out of argv / shell history). Pick a provider:
+
+```bash
+# Anthropic (pi's default provider — just supply the key)
+--env ANTHROPIC_API_KEY
+
+# OpenAI
+--env OPENAI_API_KEY \
+--env 'NEMUS_AGENT_ARGS=-p {task} --provider openai --model gpt-4.1'
+
+# Amazon Bedrock (creds from your shell; select an inference-profile model)
+--env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN \
+--env AWS_REGION=us-east-1 \
+--env 'NEMUS_AGENT_ARGS=-p {task} --provider amazon-bedrock --model us.anthropic.claude-haiku-4-5-20251001-v1:0'
+```
+
+`NEMUS_AGENT_ARGS` is the escape hatch to the underlying agent: a space-split
+argument list where `{task}` is replaced with your task. Use it to pin the
+provider/model; omit it to take the agent's defaults (with `pi`, an
+`ANTHROPIC_API_KEY` in the environment is all you need). For `claude`, either an
+`ANTHROPIC_API_KEY` or `--env CLAUDE_CODE_USE_BEDROCK=1` (plus AWS creds) works.
+
 ## Why a separate package
 
 Nemus core is deliberately **local-first, vendor-neutral, zero-cloud** — and CI
@@ -173,10 +250,11 @@ kind delete cluster --name nemus-e2e
 `e2e:image` runs the **real agent image** (`nemus-cloud-agent`) through the real
 `DockerRunner` and asserts the image contract — entrypoint wiring, the env
 contract, a valid `result.json`, exit-code → runner `status`, and that the git
-token is never leaked into logs/`result.json`. The happy path (clone → agent →
-open PR) needs a live forge + model credentials and opens real PRs, so it stays
-**unit**-tested (`run.ts` / `agent.test.ts`); this covers the parts that need a
-real container on deterministic, no-network, no-secret, no-side-effect paths.
+token is never leaked into logs/`result.json`. The full happy path (clone → agent
+→ open PR) opens real PRs and needs a live forge + model credentials, so it isn't
+part of the scripted smoke tests — but it **is proven**: it's exactly the
+[Quickstart](#quickstart-5-minutes) (supply model creds via `--env`), and the
+deterministic, no-secret slices are unit-tested (`run.ts` / `agent.test.ts`).
 
 The kind test refuses to run without an explicit `NEMUS_E2E_CONTEXT` (so it can't
 touch a real cluster by accident); the docker test refuses if the daemon isn't

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -20,6 +20,16 @@ const path = require('path');
 // Skip in CI environments
 if (process.env.CI) process.exit(0);
 
+// Only run first-run setup for a real GLOBAL install (`npm i -g`). A transient
+// `npx @nemus-cli/nemus …` (npm exec) or a local dependency install is not
+// global: the `nemus`/`nem` bins aren't persisted on PATH, so shell integration
+// is pointless — and worse, the interactive `configure` below reaches the
+// controlling terminal via /dev/tty and would HANG a non-interactive
+// `npx … --help`/`--version` invocation waiting for input. npm sets
+// npm_config_global="true" only for `-g`/`--global`; npx and local installs
+// leave it false/unset.
+if (String(process.env.npm_config_global).toLowerCase() !== 'true') process.exit(0);
+
 const PKG_ROOT = path.join(__dirname, '..');
 const SHELL_SCRIPT = path.join(PKG_ROOT, 'install-shell-integration.sh');
 const CLI_BIN = path.join(PKG_ROOT, 'bin', 'workspace.js');

--- a/src/postinstall.test.ts
+++ b/src/postinstall.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const SCRIPT = join(__dirname, '..', 'scripts', 'postinstall.js');
+
+describe('postinstall.js', () => {
+  // Regression: a transient `npx @nemus-cli/nemus …` (npm exec) or a local
+  // dependency install is NOT global. Such installs must not launch the
+  // interactive `configure` (which reaches /dev/tty and would HANG a
+  // non-interactive `npx … --help`) nor mutate the user's shell RC — the bins
+  // aren't persisted on PATH for them anyway.
+  it('is a fast no-op for a non-global install: exits 0 and never touches the shell RC', () => {
+    const home = mkdtempSync(join(tmpdir(), 'nemus-postinstall-'));
+    const rc = join(home, '.zshrc');
+    writeFileSync(rc, '# user rc\n');
+    const env = { ...process.env, HOME: home, SHELL: '/bin/zsh', NEMUS_CACHE_DIR: join(home, '.nemus') };
+    // Delete CI so the global gate — not the CI early-exit — is what protects npx.
+    delete env.CI;
+    delete env.npm_config_global; // npx / local install leaves this unset
+    try {
+      // Throws on non-zero exit; throws on the 15s timeout if it ever hangs.
+      execFileSync(process.execPath, [SCRIPT], { env, stdio: 'ignore', timeout: 15_000 });
+      // RC untouched — no guarded `source` line appended.
+      expect(readFileSync(rc, 'utf8')).toBe('# user rc\n');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('treats npm_config_global="false" the same as unset (still a no-op)', () => {
+    const home = mkdtempSync(join(tmpdir(), 'nemus-postinstall-'));
+    const rc = join(home, '.bashrc');
+    writeFileSync(rc, '# user rc\n');
+    const env = {
+      ...process.env,
+      HOME: home,
+      SHELL: '/bin/bash',
+      NEMUS_CACHE_DIR: join(home, '.nemus'),
+      npm_config_global: 'false',
+    };
+    delete env.CI;
+    try {
+      execFileSync(process.execPath, [SCRIPT], { env, stdio: 'ignore', timeout: 15_000 });
+      expect(readFileSync(rc, 'utf8')).toBe('# user rc\n');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
**Track 1: activation** — close the gap between "saw the project" and "it worked for me." The code was ready; first-run friction wasn't.

## Fix — `npx @nemus-cli/nemus …` hung (the important one)
`postinstall.js` launched **interactive `nemus configure`** via `/dev/tty` on any fresh install with a controlling terminal — so a transient `npx @nemus-cli/nemus --help`/`--version` blocked waiting for input (a 120s+ hang), and a throwaway npx run also mutated the user's shell RC.

First-run setup (`configure` + shell integration) now runs **only on a real global install** (`npm i -g`). npx (npm exec) and local dependency installs aren't global — the `nemus`/`nem` bins aren't persisted on PATH, so shell integration is pointless and the interactive prompt must not fire. npm sets `npm_config_global="true"` only for `-g`. Global installs are **unchanged**.

- +2 vitest regression tests: spawn `postinstall.js` with `npm_config_global` unset / `"false"` → asserts fast exit **and** the shell RC is untouched (runs in CI, unlike the local-only bash harness).

## Docs — make the first run obvious
- **Core README**: a *Try it without installing* (`npx`) section, and a note that `configure` auto-runs only on a global install.
- **Cloud README**: a real **5-minute Quickstart** on the in-box `docker` runner (no cloud account: build the agent image → `{"version":1,"runner":"docker"}` target → `run` → a **real PR**), plus a **Bring your own model** section — Anthropic / OpenAI / Bedrock recipes via `--env` + `NEMUS_AGENT_ARGS` (now that #91 shipped `--env`). Also corrected the stale "happy path stays unit-tested" note to point at the Quickstart — it's proven end-to-end.

## Version / tests
`core 0.15.0 → 0.15.1` (postinstall is an install script; docs-only cloud changes need no cloud bump). **567** core tests green, typecheck clean.
