### PR TITLE
feat(cloud): publish prebuilt agent images to GHCR

### DIFF
--- a/.github/workflows/release-agent-image.yml
+++ b/.github/workflows/release-agent-image.yml
@@ -1,0 +1,138 @@
+name: Release agent image
+
+# Builds and publishes the Nemus cloud agent OCI image to GitHub Container
+# Registry (ghcr.io/<owner>/nemus-cloud-agent) so the cloud quickstart can pull a
+# prebuilt image instead of `docker build`-ing from source.
+#
+# Trigger: a push to main that changes packages/cloud/package.json's version
+# (same signal as the npm cloud release), OR a manual workflow_dispatch (use this
+# to cut the FIRST image without a version bump). The push runs ONLY in the
+# `release` GitHub Environment (REQUIRED REVIEWERS), so nothing reaches the
+# registry until a maintainer approves — same gate as the npm releases.
+#
+# Uses only GitHub-owned actions (checkout, setup-node) + the `docker` CLI on the
+# runner (org policy: GitHub-owned actions only — no docker/* marketplace actions).
+#
+# ONE-TIME SETUP after the first successful publish: the new GHCR package is
+# created PRIVATE. Make it public (org → Packages → nemus-cloud-agent → Package
+# settings → Change visibility → Public) so the quickstart's anonymous
+# `docker pull` works. Anonymous pulls are what the docs promise.
+
+on:
+  push:
+    branches: [main]
+    paths: ['packages/cloud/package.json']
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Why are you cutting this agent image?'
+        required: false
+        default: 'manual image release'
+
+concurrency:
+  group: release-agent-image-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  # 1) Decide whether there is a new cloud version to publish an image for.
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0 # full history so we can diff the whole push, not just HEAD~1
+      - id: check
+        run: |
+          VERSION=$(node -p "require('./packages/cloud/package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "should_release=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          # Compare against the commit BEFORE the whole push (github.event.before),
+          # not HEAD~1 — a push can carry several commits and the bump may not be
+          # last. `before` is all-zeros on a new branch -> treat as a release.
+          BEFORE='${{ github.event.before }}'
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            PREV=none
+          else
+            git show "$BEFORE:packages/cloud/package.json" > /tmp/prev.json 2>/dev/null || echo '{}' > /tmp/prev.json
+            PREV=$(node -p "JSON.parse(require('fs').readFileSync('/tmp/prev.json','utf8')).version || 'none'")
+          fi
+          echo "previous=$PREV current=$VERSION"
+          if [ "$VERSION" != "$PREV" ]; then
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # 2) Build the image (no push) as a gate before we ever ask for approval.
+  verify:
+    needs: detect
+    if: needs.detect.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run -w @nemus-cli/cloud build
+      # The Dockerfile copies packages/cloud/dist (built above); context = repo root.
+      - run: docker build -f packages/cloud/image/Dockerfile -t nemus-cloud-agent:verify .
+      # Smoke: the entrypoint resolves and reports its usage/exit contract.
+      - run: docker run --rm --entrypoint node nemus-cloud-agent:verify -e "require('/opt/nemus-cloud/dist/index.js')"
+
+  # 3) Publish — runs ONLY after a maintainer approves the `release` environment.
+  publish:
+    needs: [detect, verify]
+    if: needs.detect.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://github.com/${{ github.repository }}/pkgs/container/nemus-cloud-agent
+    permissions:
+      contents: read
+      packages: write # push to GHCR
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run -w @nemus-cli/cloud build
+
+      - name: Build + push image to GHCR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.detect.outputs.version }}
+        run: |
+          set -euo pipefail
+          # GHCR requires a lowercase image path.
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          IMG="ghcr.io/$OWNER/nemus-cloud-agent"
+
+          # Idempotent: a re-run / re-approval (workflow_dispatch always sets
+          # should_release=true) must not clobber an already-published version tag.
+          echo "${GITHUB_TOKEN}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          if docker manifest inspect "$IMG:$VERSION" >/dev/null 2>&1; then
+            echo "$IMG:$VERSION already published — skipping."
+            exit 0
+          fi
+
+          docker build -f packages/cloud/image/Dockerfile \
+            --label "org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
+            --label "org.opencontainers.image.version=$VERSION" \
+            --label "org.opencontainers.image.revision=${{ github.sha }}" \
+            -t "$IMG:$VERSION" -t "$IMG:latest" .
+
+          docker push "$IMG:$VERSION"
+          docker push "$IMG:latest"
+          echo "Published $IMG:$VERSION and $IMG:latest"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3766,7 +3766,7 @@
     },
     "packages/cloud": {
       "name": "@nemus-cli/cloud",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "bin": {
         "nemus-cloud": "dist/cli/cloud.js",

--- a/packages/cloud/CHANGELOG.md
+++ b/packages/cloud/CHANGELOG.md
@@ -7,6 +7,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this package adheres to [Semantic Versioning](https://semver.org/) — while
 pre-1.0 (`0.x`), minor versions may include breaking changes.
 
+## [0.1.3] - 2026-09-06
+
+### Added
+
+- **Prebuilt agent images on GitHub Container Registry.** The
+  `nemus-cloud-agent` OCI image is now published to
+  `ghcr.io/me-public/nemus-cloud-agent` (`:latest` + `:<version>`) on each cloud
+  release, so the Quickstart and real pipelines can pull a ready image instead of
+  `docker build`-ing from source. Building your own remains fully supported (to
+  audit, run offline, or customize). Published by a new
+  `.github/workflows/release-agent-image.yml`, gated on the same manual `release`
+  approval as the npm packages and using only the `docker` CLI (no third-party
+  actions).
+
 ## [0.1.2] - 2026-09-03
 
 ### Added

--- a/packages/cloud/README.md
+++ b/packages/cloud/README.md
@@ -75,28 +75,35 @@ model credentials (see [Bring your own model](#bring-your-own-model) — the
 example below uses an Anthropic key).
 
 ```bash
-# 1) Build the agent image (no prebuilt image is published yet — it builds from
-#    the repo so you can audit exactly what runs).
-git clone https://github.com/me-public/nemus.git && cd nemus
-npm ci && npm run build -w @nemus-cli/cloud
-docker build -f packages/cloud/image/Dockerfile -t nemus-cloud-agent .
-
-# 2) Point at the in-box docker runner (no IaC needed for local Docker).
+# 1) Point at the in-box docker runner (no IaC needed for local Docker).
 echo '{"version":1,"runner":"docker"}' > .nemus-target.json
 
-# 3) Hand it a task against a repo you can open a PR on. Forge auth comes from
-#    the environment; the model creds ride in via --env (bare KEY forwards the
-#    value from your shell, so it stays out of argv / history).
+# 2) Hand it a task against a repo you can open a PR on, using the prebuilt agent
+#    image from GHCR. Forge auth comes from the environment; the model creds ride
+#    in via --env (bare KEY forwards the value from your shell, so it stays out of
+#    argv / history).
 export GITHUB_TOKEN=$(gh auth token)
 export ANTHROPIC_API_KEY=sk-ant-...
 
 npx nemus-cloud run \
-  --image nemus-cloud-agent \
+  --image ghcr.io/me-public/nemus-cloud-agent:latest \
   --repos <you>/<repo> --owner <you> \
   --task "Add a short 'Running tests' note to CONTRIBUTING.md" \
   --report pr --follow --wait \
   --env ANTHROPIC_API_KEY
 ```
+
+<details>
+<summary>Prefer to build the image yourself (audit / offline / customize)?</summary>
+
+```bash
+git clone https://github.com/me-public/nemus.git && cd nemus
+npm ci && npm run build -w @nemus-cli/cloud
+docker build -f packages/cloud/image/Dockerfile -t nemus-cloud-agent .
+# …then pass --image nemus-cloud-agent instead of the ghcr.io reference above.
+```
+
+</details>
 
 You'll see the agent clone, edit, push, and print the PR URL:
 
@@ -140,6 +147,32 @@ argument list where `{task}` is replaced with your task. Use it to pin the
 provider/model; omit it to take the agent's defaults (with `pi`, an
 `ANTHROPIC_API_KEY` in the environment is all you need). For `claude`, either an
 `ANTHROPIC_API_KEY` or `--env CLAUDE_CODE_USE_BEDROCK=1` (plus AWS creds) works.
+
+## The agent container image
+
+The agent is a single provider-agnostic OCI image (`nemus-cloud-agent`): it takes
+only env (the [runner-image contract](#the-execution-seam-runners)) and does
+clone → run agent → open PR → write `result.json` → exit. Any runner
+(`docker`/`aws-fargate`/`kubernetes`) launches this same image.
+
+Prebuilt images are published to **GitHub Container Registry** on each cloud
+release:
+
+```
+ghcr.io/me-public/nemus-cloud-agent:latest      # newest release
+ghcr.io/me-public/nemus-cloud-agent:<version>   # pinned, e.g. :0.1.2
+```
+
+Pass one to `--image` (as in the [Quickstart](#quickstart-5-minutes)). Pin the
+`:<version>` tag for reproducibility in real pipelines; `:latest` is convenient
+for trying it out.
+
+**Build your own** instead — to audit it, run offline, or add tools/agents — from
+the repo (`docker build -f packages/cloud/image/Dockerfile -t nemus-cloud-agent .`
+after `npm ci && npm run build -w @nemus-cli/cloud`), then point `--image` at your
+tag. Nothing in the image is registry-specific, so a private registry works the
+same way. The image is published by `.github/workflows/release-agent-image.yml`,
+gated on the same manual `release` approval as the npm packages.
 
 ## Why a separate package
 

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nemus-cli/cloud",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Optional cloud/IaC runners for Nemus — run a workspace + coding agent on your own infrastructure. Vendor-neutral and provider-pluggable. Not required for local Nemus.",
   "keywords": [
     "nemus",


### PR DESCRIPTION
Follow-up on the cloud quickstart (#92): remove the `docker build`-from-source step so "prove it in 5 minutes" is really 5 minutes.

## What
Publish the `nemus-cloud-agent` OCI image to **GitHub Container Registry** so `nemus-cloud run --image …` can pull a ready image.

- **New workflow** `.github/workflows/release-agent-image.yml` — builds `packages/cloud/image/Dockerfile` (context = repo root, after `npm run build -w @nemus-cli/cloud`) and pushes `ghcr.io/<owner>/nemus-cloud-agent:<version>` + `:latest`.
  - Mirrors `release-cloud.yml`'s **detect → verify → publish** shape; triggers on a `packages/cloud/package.json` version change or `workflow_dispatch`.
  - **Gated on the same manual `release` environment approval** — nothing reaches the registry until a maintainer approves.
  - **GitHub-owned actions only** (org policy): login/build/push via the `docker` CLI, no `docker/*` marketplace actions. Idempotent — skips an already-published `:<version>`.
- **Quickstart** now leads with `--image ghcr.io/me-public/nemus-cloud-agent:latest`; build-from-source kept in a `<details>` as the audit / offline / customize path.
- **New README section** "The agent container image" — tags, pinning `:​<version>` for pipelines, and building your own (private registries work the same).
- **cloud `0.1.2 → 0.1.3`** so the image versions in lockstep with the package.

## Verified locally
`npm run build -w @nemus-cli/cloud` → `docker build -f packages/cloud/image/Dockerfile .` → entrypoint dist smoke → **184** cloud tests. Workflow YAML validated.

## Two operator notes (can't be done from a PR)
1. **First publish is manual**: either merge (bumps to 0.1.3 → triggers the workflow) or `workflow_dispatch`, then **approve** the `release` env.
2. **Make the package public once**: the first GHCR push creates a *private* package; flip it to Public (org → Packages → `nemus-cloud-agent` → visibility) so the quickstart's anonymous `docker pull` works. Documented in the workflow header. Until that's done, the build-from-source path in the quickstart still works.
